### PR TITLE
Let the AI use Hex Parasite

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -728,6 +728,13 @@ public class ComputerUtilMana {
                             break; // no one to finish with the gut shot
                         }
                     }
+                } else {
+                    // otherwise treat it as the life cost it is, with the floor checkLifeCost uses
+                    int remainingLife = sa.hasParam("AILifeThreshold")
+                            ? Integer.parseInt(sa.getParam("AILifeThreshold")) : 4;
+                    if (ai.getLife() - phyLifeToPay < remainingLife && !ai.cantLoseForZeroOrLessLife()) {
+                        break;
+                    }
                 }
 
                 if (toPay.isPhyrexian()) {

--- a/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
@@ -153,11 +153,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
                     Card depth = depthsList.getFirst();
                     int ice = depth.getCounters(iceType);
                     if (amount >= ice) {
-                        sa.getTargets().add(depth);
-                        if (xPay) {
-                            sa.setXManaCostPaid(ice);
-                        }
-                        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                        return takeTarget(sa, depth, xPay, amount, ice);
                     }
                 }
             }
@@ -172,11 +168,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
 
             if (!planeswalkerList.isEmpty()) {
                 Card best = ComputerUtilCard.getBestPlaneswalkerAI(planeswalkerList);
-                sa.getTargets().add(best);
-                if (xPay) {
-                    sa.setXManaCostPaid(best.getCurrentLoyalty());
-                }
-                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                return takeTarget(sa, best, xPay, amount, best.getCurrentLoyalty());
             }
 
             // do as M1M1 part

--- a/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
@@ -48,6 +48,18 @@ public class CountersRemoveAi extends SpellAbilityAi {
      * @see forge.ai.SpellAbilityAi#checkApiLogic(forge.game.player.Player,
      * forge.game.spellability.SpellAbility)
      */
+    /**
+     * For an X-cost removal, pay for the counters actually worth removing from the chosen
+     * target rather than the maximum X that {@link ComputerUtilCost#setMaxXValue} leaves set
+     * on the ability. Capped by what the AI can afford. No-op when the amount is fixed.
+     */
+    private static void payForCounters(final SpellAbility sa, final boolean xPay, final int affordable,
+            final int countersOnTarget) {
+        if (xPay) {
+            sa.setXManaCostPaid(Math.max(1, Math.min(affordable, countersOnTarget)));
+        }
+    }
+
     @Override
     protected AiAbilityDecision checkApiLogic(Player ai, SpellAbility sa) {
         final String type = sa.getParam("CounterType");
@@ -166,54 +178,65 @@ public class CountersRemoveAi extends SpellAbilityAi {
                 return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
             }
 
-            // some rules only for amount = 1
-            if (!xPay) {
-                // do as M1M1 part
-                CardCollection aiList = CardLists.filterControlledBy(list, ai);
+            // These rules used to be skipped whenever the amount was an X cost, which left a
+            // card like Hex Parasite ({X}{B/P}: remove up to X counters) able to do nothing
+            // but break its own Dark Depths or finish a planeswalker. They work for any
+            // amount; what an X cost additionally needs is to pay for just the counters the
+            // chosen target has, rather than leaving the maximum X that setMaxXValue put on
+            // the ability above and emptying the mana pool to remove one counter.
 
-                CardCollection aiM1M1List = CardLists.filter(aiList, CardPredicates.hasCounter(CounterEnumType.M1M1));
+            // do as M1M1 part
+            CardCollection aiList = CardLists.filterControlledBy(list, ai);
 
-                CardCollection aiPersistList = CardLists.getKeyword(aiM1M1List, Keyword.PERSIST);
-                if (!aiPersistList.isEmpty()) {
-                    aiM1M1List = aiPersistList;
-                }
+            CardCollection aiM1M1List = CardLists.filter(aiList, CardPredicates.hasCounter(CounterEnumType.M1M1));
 
-                if (!aiM1M1List.isEmpty()) {
-                    sa.getTargets().add(ComputerUtilCard.getBestCreatureAI(aiM1M1List));
-                    return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
-                }
+            CardCollection aiPersistList = CardLists.getKeyword(aiM1M1List, Keyword.PERSIST);
+            if (!aiPersistList.isEmpty()) {
+                aiM1M1List = aiPersistList;
+            }
 
-                // do as P1P1 part
-                CardCollection aiP1P1List = CardLists.filter(aiList, CardPredicates.hasLessCounter(CounterEnumType.P1P1, amount));
-                CardCollection aiUndyingList = CardLists.getKeyword(aiP1P1List, Keyword.UNDYING);
+            if (!aiM1M1List.isEmpty()) {
+                final Card best = ComputerUtilCard.getBestCreatureAI(aiM1M1List);
+                sa.getTargets().add(best);
+                payForCounters(sa, xPay, amount, best.getCounters(CounterEnumType.M1M1));
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
 
-                if (!aiUndyingList.isEmpty()) {
-                    sa.getTargets().add(ComputerUtilCard.getBestCreatureAI(aiUndyingList));
-                    return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
-                }
-  
-                // TODO stun counters with canRemoveCounters check
+            // do as P1P1 part
+            CardCollection aiP1P1List = CardLists.filter(aiList, CardPredicates.hasLessCounter(CounterEnumType.P1P1, amount));
+            CardCollection aiUndyingList = CardLists.getKeyword(aiP1P1List, Keyword.UNDYING);
 
-                // remove P1P1 counters from opposing creatures
-                CardCollection oppP1P1List = CardLists.filter(list,
-                        CardPredicates.CREATURES.and(CardPredicates.isControlledByAnyOf(ai.getOpponents())),
-                        CardPredicates.hasCounter(CounterEnumType.P1P1));
-                if (!oppP1P1List.isEmpty()) {
-                    sa.getTargets().add(ComputerUtilCard.getBestCreatureAI(oppP1P1List));
-                    return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
-                }
+            if (!aiUndyingList.isEmpty()) {
+                final Card best = ComputerUtilCard.getBestCreatureAI(aiUndyingList);
+                sa.getTargets().add(best);
+                payForCounters(sa, xPay, amount, best.getCounters(CounterEnumType.P1P1));
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
 
-                // fallback to remove any counter from opponent
-                CardCollection oppList = CardLists.filterControlledBy(list, ai.getOpponents());
-                oppList = CardLists.filter(oppList, CardPredicates.hasCounters());
-                if (!oppList.isEmpty()) {
-                    final Card best = ComputerUtilCard.getBestAI(oppList);
+            // TODO stun counters with canRemoveCounters check
 
-                    for (final CounterType aType : best.getCounters().elementSet()) {
-                        if (!ComputerUtil.isNegativeCounter(aType, best)) {
-                            sa.getTargets().add(best);
-                            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
-                        }
+            // remove P1P1 counters from opposing creatures
+            CardCollection oppP1P1List = CardLists.filter(list,
+                    CardPredicates.CREATURES.and(CardPredicates.isControlledByAnyOf(ai.getOpponents())),
+                    CardPredicates.hasCounter(CounterEnumType.P1P1));
+            if (!oppP1P1List.isEmpty()) {
+                final Card best = ComputerUtilCard.getBestCreatureAI(oppP1P1List);
+                sa.getTargets().add(best);
+                payForCounters(sa, xPay, amount, best.getCounters(CounterEnumType.P1P1));
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
+
+            // fallback to remove any counter from opponent
+            CardCollection oppList = CardLists.filterControlledBy(list, ai.getOpponents());
+            oppList = CardLists.filter(oppList, CardPredicates.hasCounters());
+            if (!oppList.isEmpty()) {
+                final Card best = ComputerUtilCard.getBestAI(oppList);
+
+                for (final CounterType aType : best.getCounters().elementSet()) {
+                    if (!ComputerUtil.isNegativeCounter(aType, best)) {
+                        sa.getTargets().add(best);
+                        payForCounters(sa, xPay, amount, best.getCounters(aType));
+                        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
                     }
                 }
             }

--- a/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
@@ -48,18 +48,6 @@ public class CountersRemoveAi extends SpellAbilityAi {
      * @see forge.ai.SpellAbilityAi#checkApiLogic(forge.game.player.Player,
      * forge.game.spellability.SpellAbility)
      */
-    /**
-     * For an X-cost removal, pay for the counters actually worth removing from the chosen
-     * target rather than the maximum X that {@link ComputerUtilCost#setMaxXValue} leaves set
-     * on the ability. Capped by what the AI can afford. No-op when the amount is fixed.
-     */
-    private static void payForCounters(final SpellAbility sa, final boolean xPay, final int affordable,
-            final int countersOnTarget) {
-        if (xPay) {
-            sa.setXManaCostPaid(Math.max(1, Math.min(affordable, countersOnTarget)));
-        }
-    }
-
     @Override
     protected AiAbilityDecision checkApiLogic(Player ai, SpellAbility sa) {
         final String type = sa.getParam("CounterType");
@@ -76,6 +64,19 @@ public class CountersRemoveAi extends SpellAbilityAi {
         }
 
         return super.checkApiLogic(ai, sa);
+    }
+
+    /**
+     * Take this target, and for an X cost pay for the counters on it rather than the maximum
+     * {@link ComputerUtilCost#setMaxXValue} left on the ability.
+     */
+    private static AiAbilityDecision takeTarget(final SpellAbility sa, final Card target,
+            final boolean xPay, final int affordable, final int countersOnTarget) {
+        sa.getTargets().add(target);
+        if (xPay) {
+            sa.setXManaCostPaid(Math.min(affordable, countersOnTarget));
+        }
+        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
     }
 
     private AiAbilityDecision doTgt(Player ai, SpellAbility sa, boolean mandatory) {
@@ -178,13 +179,6 @@ public class CountersRemoveAi extends SpellAbilityAi {
                 return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
             }
 
-            // These rules used to be skipped whenever the amount was an X cost, which left a
-            // card like Hex Parasite ({X}{B/P}: remove up to X counters) able to do nothing
-            // but break its own Dark Depths or finish a planeswalker. They work for any
-            // amount; what an X cost additionally needs is to pay for just the counters the
-            // chosen target has, rather than leaving the maximum X that setMaxXValue put on
-            // the ability above and emptying the mana pool to remove one counter.
-
             // do as M1M1 part
             CardCollection aiList = CardLists.filterControlledBy(list, ai);
 
@@ -197,9 +191,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
 
             if (!aiM1M1List.isEmpty()) {
                 final Card best = ComputerUtilCard.getBestCreatureAI(aiM1M1List);
-                sa.getTargets().add(best);
-                payForCounters(sa, xPay, amount, best.getCounters(CounterEnumType.M1M1));
-                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                return takeTarget(sa, best, xPay, amount, best.getCounters(CounterEnumType.M1M1));
             }
 
             // do as P1P1 part
@@ -208,9 +200,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
 
             if (!aiUndyingList.isEmpty()) {
                 final Card best = ComputerUtilCard.getBestCreatureAI(aiUndyingList);
-                sa.getTargets().add(best);
-                payForCounters(sa, xPay, amount, best.getCounters(CounterEnumType.P1P1));
-                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                return takeTarget(sa, best, xPay, amount, best.getCounters(CounterEnumType.P1P1));
             }
 
             // TODO stun counters with canRemoveCounters check
@@ -221,9 +211,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
                     CardPredicates.hasCounter(CounterEnumType.P1P1));
             if (!oppP1P1List.isEmpty()) {
                 final Card best = ComputerUtilCard.getBestCreatureAI(oppP1P1List);
-                sa.getTargets().add(best);
-                payForCounters(sa, xPay, amount, best.getCounters(CounterEnumType.P1P1));
-                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                return takeTarget(sa, best, xPay, amount, best.getCounters(CounterEnumType.P1P1));
             }
 
             // fallback to remove any counter from opponent
@@ -234,9 +222,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
 
                 for (final CounterType aType : best.getCounters().elementSet()) {
                     if (!ComputerUtil.isNegativeCounter(aType, best)) {
-                        sa.getTargets().add(best);
-                        payForCounters(sa, xPay, amount, best.getCounters(aType));
-                        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                        return takeTarget(sa, best, xPay, amount, best.getCounters(aType));
                     }
                 }
             }

--- a/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
@@ -209,7 +209,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
             // fallback to remove any counter from opponent
             CardCollection oppList = CardLists.filterControlledBy(list, ai.getOpponents());
             oppList = CardLists.filter(oppList, CardPredicates.hasCounters());
-            if (!oppList.isEmpty()) {
+            while (!oppList.isEmpty()) {
                 final Card best = ComputerUtilCard.getBestAI(oppList);
 
                 for (final CounterType aType : best.getCounters().elementSet()) {
@@ -217,6 +217,8 @@ public class CountersRemoveAi extends SpellAbilityAi {
                         return takeTarget(sa, best, xPay, amount, best.getCounters(aType));
                     }
                 }
+                // its counters are all ones we would rather leave alone, so try the next one
+                oppList.remove(best);
             }
         } else if (type.equals("M1M1")) {
             // no special amount for that one yet

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
@@ -3,35 +3,19 @@ package forge.ai.ability;
 import org.testng.annotations.Test;
 
 import forge.ai.AITest;
-import forge.ai.AiAbilityDecision;
-import forge.ai.SpellApiToAi;
 import forge.game.Game;
-import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
-import forge.game.spellability.SpellAbility;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 
 /**
- * An X-cost "remove up to X counters" - Hex Parasite - used to skip every target rule but
- * breaking its own Dark Depths and finishing a planeswalker, because those rules were gated
- * on the amount not being an X cost.
+ * Hex Parasite pays X for its counters, so every target rule below the Dark Depths and
+ * planeswalker cases was gated on the amount not being an X cost, and never ran.
  */
 public class CountersRemoveXAiTest extends AITest {
-
-    private SpellAbility removeCounterAbility(Card parasite, Player ai) {
-        for (SpellAbility sa : parasite.getSpellAbilities()) {
-            if (sa.getApi() == ApiType.RemoveCounter) {
-                sa.setActivatingPlayer(ai);
-                return sa;
-            }
-        }
-        throw new AssertionError("Hex Parasite has no RemoveCounter ability");
-    }
 
     @Test
     public void stripsCountersFromAnOpposingCreature() {
@@ -39,21 +23,14 @@ public class CountersRemoveXAiTest extends AITest {
         Player ai = game.getPlayers().get(1);
         Player opp = game.getPlayers().get(0);
 
-        Card parasite = addCard("Hex Parasite", ai);
-        addCards("Swamp", 6, ai);
-        Card bear = addCard("Centaur Courser", opp);
-        bear.setCounters(CounterEnumType.P1P1, 3);
+        Card parasite = withParasite(game, ai);
+        Card courser = addCard("Centaur Courser", opp);
+        courser.setCounters(CounterEnumType.P1P1, 3);
 
-        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
-        game.getAction().checkStateEffects(true);
+        runMain2(game, ai);
 
-        SpellAbility remove = removeCounterAbility(parasite, ai);
-        AiAbilityDecision decision = SpellApiToAi.Converter.get(remove).canPlayWithSubs(ai, remove);
-
-        assertTrue("should strip the counters", decision.willingToPlay());
-        assertEquals(bear, remove.getTargets().getFirstTargetedCard());
-        // pays for the three counters actually there, not the five it could afford
-        assertEquals(3, (long) remove.getXManaCostPaid());
+        assertEquals(0, courser.getCounters(CounterEnumType.P1P1));
+        assertEquals(4, parasite.getNetPower()); // 1/1 plus one per counter removed
     }
 
     @Test
@@ -61,38 +38,39 @@ public class CountersRemoveXAiTest extends AITest {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
 
-        Card parasite = addCard("Hex Parasite", ai);
-        addCards("Swamp", 6, ai);
+        Card parasite = withParasite(game, ai);
         Card finks = addCard("Kitchen Finks", ai);
         finks.setCounters(CounterEnumType.M1M1, 1);
 
-        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
-        game.getAction().checkStateEffects(true);
+        runMain2(game, ai);
 
-        SpellAbility remove = removeCounterAbility(parasite, ai);
-        AiAbilityDecision decision = SpellApiToAi.Converter.get(remove).canPlayWithSubs(ai, remove);
-
-        assertTrue("should clear its own -1/-1 counter", decision.willingToPlay());
-        assertEquals(finks, remove.getTargets().getFirstTargetedCard());
-        assertEquals(1, (long) remove.getXManaCostPaid());
+        assertEquals(0, finks.getCounters(CounterEnumType.M1M1));
+        assertEquals(2, parasite.getNetPower());
     }
 
     @Test
-    public void declinesWithNothingWorthRemoving() {
+    public void holdsWithNothingWorthRemoving() {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
         Player opp = game.getPlayers().get(0);
 
-        Card parasite = addCard("Hex Parasite", ai);
-        addCards("Swamp", 6, ai);
+        Card parasite = withParasite(game, ai);
         addCard("Centaur Courser", opp); // no counters anywhere
 
+        runMain2(game, ai);
+
+        assertEquals(1, parasite.getNetPower());
+    }
+
+    private Card withParasite(Game game, Player ai) {
+        Card parasite = addCard("Hex Parasite", ai);
+        addCards("Swamp", 6, ai);
+        return parasite;
+    }
+
+    private void runMain2(Game game, Player ai) {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
         game.getAction().checkStateEffects(true);
-
-        SpellAbility remove = removeCounterAbility(parasite, ai);
-        AiAbilityDecision decision = SpellApiToAi.Converter.get(remove).canPlayWithSubs(ai, remove);
-
-        assertTrue("nothing to remove, should hold", !decision.willingToPlay());
+        gameLoopUntilNextPhase(game);
     }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
@@ -1,0 +1,98 @@
+package forge.ai.ability;
+
+import org.testng.annotations.Test;
+
+import forge.ai.AITest;
+import forge.ai.AiAbilityDecision;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.card.CounterEnumType;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * An X-cost "remove up to X counters" - Hex Parasite - used to skip every target rule but
+ * breaking its own Dark Depths and finishing a planeswalker, because those rules were gated
+ * on the amount not being an X cost.
+ */
+public class CountersRemoveXAiTest extends AITest {
+
+    private SpellAbility removeCounterAbility(Card parasite, Player ai) {
+        for (SpellAbility sa : parasite.getSpellAbilities()) {
+            if (sa.getApi() == ApiType.RemoveCounter) {
+                sa.setActivatingPlayer(ai);
+                return sa;
+            }
+        }
+        throw new AssertionError("Hex Parasite has no RemoveCounter ability");
+    }
+
+    @Test
+    public void stripsCountersFromAnOpposingCreature() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card parasite = addCard("Hex Parasite", ai);
+        addCards("Swamp", 6, ai);
+        Card bear = addCard("Centaur Courser", opp);
+        bear.setCounters(CounterEnumType.P1P1, 3);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility remove = removeCounterAbility(parasite, ai);
+        AiAbilityDecision decision = SpellApiToAi.Converter.get(remove).canPlayWithSubs(ai, remove);
+
+        assertTrue("should strip the counters", decision.willingToPlay());
+        assertEquals(bear, remove.getTargets().getFirstTargetedCard());
+        // pays for the three counters actually there, not the five it could afford
+        assertEquals(3, (long) remove.getXManaCostPaid());
+    }
+
+    @Test
+    public void clearsItsOwnPersistCreature() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card parasite = addCard("Hex Parasite", ai);
+        addCards("Swamp", 6, ai);
+        Card finks = addCard("Kitchen Finks", ai);
+        finks.setCounters(CounterEnumType.M1M1, 1);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility remove = removeCounterAbility(parasite, ai);
+        AiAbilityDecision decision = SpellApiToAi.Converter.get(remove).canPlayWithSubs(ai, remove);
+
+        assertTrue("should clear its own -1/-1 counter", decision.willingToPlay());
+        assertEquals(finks, remove.getTargets().getFirstTargetedCard());
+        assertEquals(1, (long) remove.getXManaCostPaid());
+    }
+
+    @Test
+    public void declinesWithNothingWorthRemoving() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card parasite = addCard("Hex Parasite", ai);
+        addCards("Swamp", 6, ai);
+        addCard("Centaur Courser", opp); // no counters anywhere
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility remove = removeCounterAbility(parasite, ai);
+        AiAbilityDecision decision = SpellApiToAi.Converter.get(remove).canPlayWithSubs(ai, remove);
+
+        assertTrue("nothing to remove, should hold", !decision.willingToPlay());
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
@@ -9,6 +9,7 @@ import forge.game.card.CounterEnumType;
 import forge.game.card.CounterType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
+import forge.game.zone.ZoneType;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -61,6 +62,44 @@ public class CountersRemoveXAiTest extends AITest {
         runMain2(game, ai);
 
         assertEquals(1, parasite.getNetPower());
+    }
+
+    @Test
+    public void willNotSpendItsLastLifeOnTheActivation() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card parasite = addCard("Hex Parasite", ai);
+        addCards("Mountain", 3, ai); // no black source, so {B/P} would cost 2 life
+        Card courser = addCard("Centaur Courser", opp);
+        courser.setCounters(CounterEnumType.P1P1, 1);
+        ai.setLife(5, null); // paying would leave 3, under the floor the AI keeps for life costs
+
+        runMain2(game, ai);
+
+        assertEquals(5, ai.getLife());
+        assertEquals(1, courser.getCounters(CounterEnumType.P1P1));
+        assertEquals(1, parasite.getNetPower());
+    }
+
+    @Test
+    public void paysTheLifeWhenItCanAffordTo() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card parasite = addCard("Hex Parasite", ai);
+        addCards("Mountain", 3, ai); // still no black source
+        Card jace = addCard("Jace Beleren", opp);
+        jace.setCounters(CounterEnumType.LOYALTY, 3);
+        ai.setLife(20, null);
+
+        runMain2(game, ai);
+
+        assertEquals(18, ai.getLife());
+        assertEquals(0, countCardsWithName(game, "Jace Beleren", ZoneType.Battlefield));
+        assertEquals(4, parasite.getNetPower());
     }
 
     @Test

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CountersRemoveXAiTest.java
@@ -6,6 +6,7 @@ import forge.ai.AITest;
 import forge.game.Game;
 import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
+import forge.game.card.CounterType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
 
@@ -60,6 +61,26 @@ public class CountersRemoveXAiTest extends AITest {
         runMain2(game, ai);
 
         assertEquals(1, parasite.getNetPower());
+    }
+
+    @Test
+    public void looksPastAnOpponentsBestCardWhenItsCountersAreOnesWeWouldLeave() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card parasite = withParasite(game, ai);
+        // the best opposing permanent carries only a counter we would rather leave on it
+        Card dreadmaw = addCard("Colossal Dreadmaw", opp);
+        dreadmaw.setCounters(CounterEnumType.M1M1, 1);
+        Card chalice = addCard("Chalice of the Void", opp);
+        chalice.setCounters(CounterType.getType("CHARGE"), 2);
+
+        runMain2(game, ai);
+
+        assertEquals("its -1/-1 counter is left where it is", 1, dreadmaw.getCounters(CounterEnumType.M1M1));
+        assertEquals(0, chalice.getCounters(CounterType.getType("CHARGE")));
+        assertEquals(3, parasite.getNetPower());
     }
 
     private Card withParasite(Game game, Player ai) {

--- a/forge-gui/res/cardsfolder/h/hex_parasite.txt
+++ b/forge-gui/res/cardsfolder/h/hex_parasite.txt
@@ -7,5 +7,4 @@ SVar:DBPump:DB$ Pump | NumAtt$ +Y | Defined$ Self | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$xPaid
 SVar:Y:Count$RememberedSize
-AI:RemoveDeck:All
 Oracle:{X}{B/P}: Remove up to X counters from target permanent. For each counter removed this way, Hex Parasite gets +1/+0 until end of turn. ({B/P} can be paid with either {B} or 2 life.)


### PR DESCRIPTION
Hex Parasite is flagged `AI:RemoveDeck:All`. Unusable due to one gate:

## The gate

`CountersRemoveAi`'s `CounterType$ Any` branch made four targets unreachable — persist, undying, stripping opposing creatures, and "take good counter(s) off opponent" — due to the X cost amount. Hex Parasite is the only card affected: three others pair `CounterType$ Any` with an `X`, but only this one defines it as `Count$xPaid`.

Lifting the gate cannot change a fixed-amount card: the block ran exactly when `xPay` was false, so the only case added is `xPay` true. An X cost also needs to pay for the counters its target has, not the maximum `setMaxXValue` left on the ability. `takeTarget` does both, and all six branches now use it — Dark Depths and planeswalker reduce to it, each bounded by `amount`.

## Measured

`CountersRemoveAi`'s decision, six lands available, against master:

| Board | Before | After |
|---|---|---|
| Opposing creature, 3x `+1/+1` | `TargetingFailed` | `WillPlay`, X=3 |
| Own persist creature, 1x `-1/-1` | `TargetingFailed` | `WillPlay`, X=1 |
| Own Dark Depths, 3x ice | `WillPlay`, X=3 | unchanged |
| Nothing with counters | declines | declines |

Played out to the board rather than stopping at the decision: the Depths break leaves Marit Lage, and the planeswalker case takes an opponent's Jace from 3 loyalty to dead.

## Two misses the new reach exposed

**The fallback commits to one card.** It takes `getBestAI`'s single choice, then walks that card's counter types for a non-negative one; a creature carrying only a `-1/-1` counter ends the branch, with a Chalice of the Void sitting untouched beside it. It now drops that candidate and tries the next. This is the one part that reaches fixed-amount cards, and only where the branch previously did nothing at all.

**`{B/P}` is weighed against nothing.** It is paid with 2 life whenever no black source is available, and the AI would go from 3 life to 1 to strip a single counter. Phyrexian mana is a life cost, so it now takes the floor the AI already keeps for those: `remainingLife` 4, the value every `checkLifeCost` caller passes, overridable with the existing `AILifeThreshold`. Only abilities with no `AIPhyrexianPayment` param are affected, and all five cards that set it keep their behaviour. Hex Parasite declines at 5 life, pays at 20 to kill a planeswalker, and never pays while it can still make black.

## Testing

376 tests, 0 failures, 6 skipped, playing the phase out through `AiController`. Removing `CountersRemoveAi`'s change, the `AI:RemoveDeck:All` line, the fallback loop, or the life floor each fails a test.

🤖 Implemented with the assistance of Claude Code (Opus 5).
