### PR TITLE
Let the AI use Thespian's Stage

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -810,10 +810,6 @@ public class ComputerUtilCard {
         return eval;
     }
 
-    public static int evaluateLand(final Card c) {
-        return landEvaluator.apply(c);
-    }
-
     public static int evaluatePermanentList(final CardCollectionView list) {
         int value = 0;
         for (int i = 0; i < list.size(); i++) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -810,6 +810,10 @@ public class ComputerUtilCard {
         return eval;
     }
 
+    public static int evaluateLand(final Card c) {
+        return landEvaluator.apply(c);
+    }
+
     public static int evaluatePermanentList(final CardCollectionView list) {
         int value = 0;
         for (int i = 0; i < list.size(); i++) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -784,6 +784,10 @@ public class ComputerUtilCard {
         return eval;
     }
 
+    public static int evaluateLand(final Card c) {
+        return landEvaluator.apply(c);
+    }
+
     public static int evaluatePermanentList(final CardCollectionView list) {
         int value = 0;
         for (int i = 0; i < list.size(); i++) {

--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -4,6 +4,7 @@ import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.ComputerUtilCard;
 import forge.ai.SpellAbilityAi;
+import forge.ai.simulation.GameStateEvaluator;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.*;
@@ -14,6 +15,7 @@ import forge.game.player.PlayerActionConfirmMode;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -141,6 +143,23 @@ public class CloneAi extends SpellAbilityAi {
             return true;
         }
 
+        if ("CloneBestLand".equals(sa.getParam("AILogic"))) {
+            final Card host = sa.getHostCard();
+            final Card best = targets.stream()
+                    // evaluateLand scores a land under whoever controls it now, and the copy will be
+                    // ours, so only our own lands are being judged on the board that will apply
+                    .filter(c -> c != host && c.getController() == host.getController())
+                    // copying our own legendary land just makes us sacrifice one of the two
+                    .filter(c -> !c.getType().isLegendary())
+                    .max(Comparator.comparingInt(GameStateEvaluator::evaluateLand))
+                    .orElse(null);
+            if (best == null || GameStateEvaluator.evaluateLand(best) <= GameStateEvaluator.evaluateLand(host)) {
+                return false;
+            }
+            sa.getTargets().add(best);
+            return true;
+        }
+
         // Default:
         // This is reasonable for now. Kamahl, Fist of Krosa and a sorcery or
         // two are the only things that clone a target. Those can just use
@@ -255,5 +274,16 @@ public class CloneAi extends SpellAbilityAi {
 
         // don't activate during main2 unless this effect is permanent
         return !ph.is(PhaseType.MAIN2) || !sa.hasParam("Duration");
+    }
+
+    @Override
+    protected boolean checkPhaseRestrictions(final Player ai, final SpellAbility sa, final PhaseHandler ph,
+            final String logic) {
+        if ("CloneBestLand".equals(logic)) {
+            // the upgrade is permanent and the cost taps, so wait until the end of the turn before
+            // ours: the mana stays open as a threat until then, and it unlocks in our untap step
+            return super.checkPhaseRestrictions(ai, sa, ph, "AtOppEOT");
+        }
+        return super.checkPhaseRestrictions(ai, sa, ph, logic);
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -4,6 +4,7 @@ import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.ComputerUtilCard;
 import forge.ai.SpellAbilityAi;
+import forge.ai.simulation.GameStateEvaluator;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.*;
@@ -14,6 +15,7 @@ import forge.game.player.PlayerActionConfirmMode;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -136,6 +138,23 @@ public class CloneAi extends SpellAbilityAi {
             return true;
         }
 
+        if ("CloneBestLand".equals(sa.getParam("AILogic"))) {
+            final Card host = sa.getHostCard();
+            final Card best = targets.stream()
+                    // evaluateLand scores a land under whoever controls it now, and the copy will be
+                    // ours, so only our own lands are being judged on the board that will apply
+                    .filter(c -> c != host && c.getController() == host.getController())
+                    // copying our own legendary land just makes us sacrifice one of the two
+                    .filter(c -> !c.getType().isLegendary())
+                    .max(Comparator.comparingInt(GameStateEvaluator::evaluateLand))
+                    .orElse(null);
+            if (best == null || GameStateEvaluator.evaluateLand(best) <= GameStateEvaluator.evaluateLand(host)) {
+                return false;
+            }
+            sa.getTargets().add(best);
+            return true;
+        }
+
         // Default:
         // This is reasonable for now. Kamahl, Fist of Krosa and a sorcery or
         // two are the only things that clone a target. Those can just use
@@ -250,5 +269,16 @@ public class CloneAi extends SpellAbilityAi {
 
         // don't activate during main2 unless this effect is permanent
         return !ph.is(PhaseType.MAIN2) || !sa.hasParam("Duration");
+    }
+
+    @Override
+    protected boolean checkPhaseRestrictions(final Player ai, final SpellAbility sa, final PhaseHandler ph,
+            final String logic) {
+        if ("CloneBestLand".equals(logic)) {
+            // the upgrade is permanent and the cost taps, so wait until the end of the turn before
+            // ours: the mana stays open as a threat until then, and it unlocks in our untap step
+            return super.checkPhaseRestrictions(ai, sa, ph, "AtOppEOT");
+        }
+        return super.checkPhaseRestrictions(ai, sa, ph, logic);
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -4,7 +4,6 @@ import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.ComputerUtilCard;
 import forge.ai.SpellAbilityAi;
-import forge.ai.simulation.GameStateEvaluator;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.*;
@@ -15,7 +14,6 @@ import forge.game.player.PlayerActionConfirmMode;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -140,15 +138,12 @@ public class CloneAi extends SpellAbilityAi {
 
         if ("CloneBestLand".equals(sa.getParam("AILogic"))) {
             final Card host = sa.getHostCard();
-            final Card best = targets.stream()
-                    // evaluateLand scores a land under whoever controls it now, and the copy will be
-                    // ours, so only our own lands are being judged on the board that will apply
-                    .filter(c -> c != host && c.getController() == host.getController())
-                    // copying our own legendary land just makes us sacrifice one of the two
-                    .filter(c -> !c.getType().isLegendary())
-                    .max(Comparator.comparingInt(GameStateEvaluator::evaluateLand))
-                    .orElse(null);
-            if (best == null || GameStateEvaluator.evaluateLand(best) <= GameStateEvaluator.evaluateLand(host)) {
+            // a land is scored under whoever controls it now and the copy arrives under ours, so
+            // only our own lands are judged on the board that will apply; copying our own
+            // legendary land just makes us sacrifice one of the two
+            final Card best = ComputerUtilCard.getBestLandToPlayAI(CardLists.filter(targets,
+                    c -> c != host && c.getController() == host.getController() && !c.getType().isLegendary()));
+            if (best == null || ComputerUtilCard.evaluateLand(best) <= ComputerUtilCard.evaluateLand(host)) {
                 return false;
             }
             sa.getTargets().add(best);

--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -1,8 +1,11 @@
 package forge.ai.ability;
 
+import com.google.common.collect.Sets;
+
 import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.ComputerUtilCard;
+import forge.ai.simulation.GameStateEvaluator;
 import forge.ai.SpellAbilityAi;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
@@ -143,12 +146,13 @@ public class CloneAi extends SpellAbilityAi {
 
         if ("CloneBestLand".equals(sa.getParam("AILogic"))) {
             final Card host = sa.getHostCard();
-            // a land is scored under whoever controls it now and the copy arrives under ours, so
-            // only our own lands are judged on the board that will apply; copying our own
-            // legendary land just makes us sacrifice one of the two
-            final Card best = ComputerUtilCard.getBestLandToPlayAI(CardLists.filter(targets,
-                    c -> c != host && c.getController() == host.getController() && !c.getType().isLegendary()));
-            if (best == null || ComputerUtilCard.evaluateLand(best) <= ComputerUtilCard.evaluateLand(host)) {
+            final Player self = host.getController();
+            // every land is scored as ours, because that is where the copy arrives: Cabal Coffers
+            // counts our Swamps, not theirs. Skip a legendary we already control, since copying
+            // that just means sacrificing one of the two
+            final Card best = bestLandToBecome(CardLists.filter(targets,
+                    t -> t != host && !(t.getType().isLegendary() && self.isCardInPlay(t.getName()))), host, self);
+            if (best == null) {
                 return false;
             }
             sa.getTargets().add(best);
@@ -161,6 +165,36 @@ public class CloneAi extends SpellAbilityAi {
         // AI:RemoveDeck:All until this can do a reasonably good job of picking
         // a good target
         return false;
+    }
+
+    /**
+     * The land the host is best off becoming, or null if none of them beats what it already is.
+     * A land is scored under whoever controls it now, so an opponent's is judged on a copy moved
+     * to our side: Cabal Coffers counts our Swamps, Gaea's Cradle our creatures.
+     */
+    private static Card bestLandToBecome(final Iterable<Card> candidates, final Card host, final Player self) {
+        final Game game = self.getGame();
+        Card best = null;
+        int bestScore = GameStateEvaluator.evaluateLand(host);
+        boolean copied = false;
+        for (final Card land : candidates) {
+            Card judged = land;
+            if (!self.equals(land.getController())) {
+                judged = CardCopyService.getLKICopy(land);
+                judged.setController(self, game.getNextTimestamp());
+                game.getAction().checkStaticAbilities(false, Sets.newHashSet(judged), new CardCollection(judged));
+                copied = true;
+            }
+            final int score = GameStateEvaluator.evaluateLand(judged);
+            if (score > bestScore) {
+                best = land;
+                bestScore = score;
+            }
+        }
+        if (copied) {
+            game.getAction().checkStaticAbilities(false);
+        }
+        return best;
     }
 
     /* (non-Javadoc)

--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -4,7 +4,6 @@ import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.ComputerUtilCard;
 import forge.ai.SpellAbilityAi;
-import forge.ai.simulation.GameStateEvaluator;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.*;
@@ -15,7 +14,6 @@ import forge.game.player.PlayerActionConfirmMode;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -145,15 +143,12 @@ public class CloneAi extends SpellAbilityAi {
 
         if ("CloneBestLand".equals(sa.getParam("AILogic"))) {
             final Card host = sa.getHostCard();
-            final Card best = targets.stream()
-                    // evaluateLand scores a land under whoever controls it now, and the copy will be
-                    // ours, so only our own lands are being judged on the board that will apply
-                    .filter(c -> c != host && c.getController() == host.getController())
-                    // copying our own legendary land just makes us sacrifice one of the two
-                    .filter(c -> !c.getType().isLegendary())
-                    .max(Comparator.comparingInt(GameStateEvaluator::evaluateLand))
-                    .orElse(null);
-            if (best == null || GameStateEvaluator.evaluateLand(best) <= GameStateEvaluator.evaluateLand(host)) {
+            // a land is scored under whoever controls it now and the copy arrives under ours, so
+            // only our own lands are judged on the board that will apply; copying our own
+            // legendary land just makes us sacrifice one of the two
+            final Card best = ComputerUtilCard.getBestLandToPlayAI(CardLists.filter(targets,
+                    c -> c != host && c.getController() == host.getController() && !c.getType().isLegendary()));
+            if (best == null || ComputerUtilCard.evaluateLand(best) <= ComputerUtilCard.evaluateLand(host)) {
                 return false;
             }
             sa.getTargets().add(best);

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
@@ -23,6 +23,10 @@ public class CloneBestLandAiTest extends AITest {
         Card stage = addCard("Thespian's Stage", ai);
         addCard("Ancient Tomb", ai);
         addCards("Swamp", 4, ai);
+        // scores higher than the Tomb once creatures are out, but copying it would just make us
+        // sacrifice one of the two
+        addCard("Gaea's Cradle", ai);
+        addCards("Grizzly Bears", 3, ai);
 
         // end of the opponent's turn, so ours is next
         game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
@@ -56,6 +60,9 @@ public class CloneBestLandAiTest extends AITest {
 
         Card stage = addCard("Thespian's Stage", ai);
         addCards("Swamp", 4, ai);
+        // the only upgrade on the board is theirs, and it would be scored under them rather than
+        // under us, so it is not one to read
+        addCard("Ancient Tomb", opp);
 
         game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
         game.getAction().checkStateEffects(true);

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
@@ -14,6 +14,13 @@ import forge.game.player.Player;
  */
 public class CloneBestLandAiTest extends AITest {
 
+    /** The Stage is taken at the end of the turn before ours, so run the game from there. */
+    private void runAtOppEndStep(Game game, Player opp) {
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+    }
+
     @Test
     public void copiesTheBetterLandItControls() {
         Game game = initAndCreateGame();
@@ -28,12 +35,41 @@ public class CloneBestLandAiTest extends AITest {
         addCard("Gaea's Cradle", ai);
         addCards("Grizzly Bears", 3, ai);
 
-        // end of the opponent's turn, so ours is next
-        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
-        game.getAction().checkStateEffects(true);
-        gameLoopUntilNextPhase(game);
+        runAtOppEndStep(game, opp);
 
         AssertJUnit.assertEquals("Ancient Tomb", stage.getName());
+    }
+
+    @Test
+    public void copiesAnOpponentsLandToo() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCards("Swamp", 4, ai);
+        addCard("Ancient Tomb", opp);
+
+        runAtOppEndStep(game, opp);
+
+        AssertJUnit.assertEquals("Ancient Tomb", stage.getName());
+    }
+
+    @Test
+    public void ignoresALandThatOnlyScoresOnTheirBoard() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCards("Swamp", 4, ai);
+        // huge for them, worthless for us: the creatures it counts are on their side
+        addCard("Gaea's Cradle", opp);
+        addCards("Grizzly Bears", 3, opp);
+
+        runAtOppEndStep(game, opp);
+
+        AssertJUnit.assertEquals("Thespian's Stage", stage.getName());
     }
 
     @Test
@@ -46,25 +82,6 @@ public class CloneBestLandAiTest extends AITest {
         addCards("Swamp", 4, ai);
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
-        game.getAction().checkStateEffects(true);
-        gameLoopUntilNextPhase(game);
-
-        AssertJUnit.assertEquals("Thespian's Stage", stage.getName());
-    }
-
-    @Test
-    public void leavesItAloneWithNothingBetterAround() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-        Player opp = game.getPlayers().get(0);
-
-        Card stage = addCard("Thespian's Stage", ai);
-        addCards("Swamp", 4, ai);
-        // the only upgrade on the board is theirs, and it would be scored under them rather than
-        // under us, so it is not one to read
-        addCard("Ancient Tomb", opp);
-
-        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
         game.getAction().checkStateEffects(true);
         gameLoopUntilNextPhase(game);
 

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
@@ -1,0 +1,66 @@
+package forge.ai.ability;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+
+/**
+ * Thespian's Stage was AI:RemoveDeck:All because CloneAi had no way to pick a land to copy.
+ */
+public class CloneBestLandAiTest extends AITest {
+
+    @Test
+    public void copiesTheBetterLandItControls() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCard("Ancient Tomb", ai);
+        addCards("Swamp", 4, ai);
+
+        // end of the opponent's turn, so ours is next
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertEquals("Ancient Tomb", stage.getName());
+    }
+
+    @Test
+    public void waitsForTheTurnBeforeOurs() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCard("Ancient Tomb", ai);
+        addCards("Swamp", 4, ai);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertEquals("Thespian's Stage", stage.getName());
+    }
+
+    @Test
+    public void leavesItAloneWithNothingBetterAround() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCards("Swamp", 4, ai);
+
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertEquals("Thespian's Stage", stage.getName());
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
@@ -1,0 +1,67 @@
+package forge.ai.ability;
+
+import org.testng.annotations.Test;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Thespian's Stage was AI:RemoveDeck:All because CloneAi had no way to pick a land to copy.
+ */
+public class CloneBestLandAiTest extends AITest {
+
+    @Test
+    public void copiesTheBetterLandItControls() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCard("Ancient Tomb", ai);
+        addCards("Swamp", 4, ai);
+
+        // end of the opponent's turn, so ours is next
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        assertEquals("Ancient Tomb", stage.getName());
+    }
+
+    @Test
+    public void waitsForTheTurnBeforeOurs() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCard("Ancient Tomb", ai);
+        addCards("Swamp", 4, ai);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        assertEquals("Thespian's Stage", stage.getName());
+    }
+
+    @Test
+    public void leavesItAloneWithNothingBetterAround() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card stage = addCard("Thespian's Stage", ai);
+        addCards("Swamp", 4, ai);
+
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        assertEquals("Thespian's Stage", stage.getName());
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CloneBestLandAiTest.java
@@ -24,6 +24,10 @@ public class CloneBestLandAiTest extends AITest {
         Card stage = addCard("Thespian's Stage", ai);
         addCard("Ancient Tomb", ai);
         addCards("Swamp", 4, ai);
+        // scores higher than the Tomb once creatures are out, but copying it would just make us
+        // sacrifice one of the two
+        addCard("Gaea's Cradle", ai);
+        addCards("Grizzly Bears", 3, ai);
 
         // end of the opponent's turn, so ours is next
         game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
@@ -57,6 +61,9 @@ public class CloneBestLandAiTest extends AITest {
 
         Card stage = addCard("Thespian's Stage", ai);
         addCards("Swamp", 4, ai);
+        // the only upgrade on the board is theirs, and it would be scored under them rather than
+        // under us, so it is not one to read
+        addCard("Ancient Tomb", opp);
 
         game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
         game.getAction().checkStateEffects(true);

--- a/forge-gui/res/cardsfolder/t/thespians_stage.txt
+++ b/forge-gui/res/cardsfolder/t/thespians_stage.txt
@@ -2,6 +2,5 @@ Name:Thespian's Stage
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Clone | Cost$ 2 T | ValidTgts$ Land | TgtPrompt$ Select target land to copy. | GainThisAbility$ True | SpellDescription$ CARDNAME becomes a copy of target land, except it has this ability.
-AI:RemoveDeck:All
+A:AB$ Clone | Cost$ 2 T | ValidTgts$ Land | TgtPrompt$ Select target land to copy. | GainThisAbility$ True | AILogic$ CloneBestLand | SpellDescription$ CARDNAME becomes a copy of target land, except it has this ability.
 Oracle:{T}: Add {C}.\n{2}, {T}: Thespian's Stage becomes a copy of target land, except it has this ability.


### PR DESCRIPTION
Thespian's Stage (`{2}, {T}`: becomes a copy of target land, keeping this ability) is `AI:RemoveDeck:All`, and `CloneAi` says why — its default target branch is `return false` under *"Those can just use AI:RemoveDeck:All until this can do a reasonably good job of picking a good target."*

## Picking a land

New `AILogic$ CloneBestLand` takes the highest `evaluateLand` score that beats what the Stage already is (156).

A land is scored under whoever controls it *now*, while the copy always arrives under ours, so reading an opponent's board raw misjudges in both directions: Cabal Coffers is 6 for them and 306 for us, and Gaea's Cradle behind their creatures is 706 for them and 6 for us. So an opponent's land is judged on an LKI copy moved to our side, the same shape `ComputerUtilCard.filterOutFatalCopies` now uses for the creature case. Copying their land is much of why this card is good.

That replaces the `getBestLandToPlayAI` ranking from the previous push, which scores each land under its current controller.

The only land skipped is a legendary we already control, since copying that just means sacrificing one of the two.

The bar is deliberately conservative: the copy keeps the clone ability, so a target only has to beat a plain land. It passes on marginal upgrades like Wasteland (116) rather than risk a bad one.

The copy gets a statics pass so our own effects reach it: under our Prismatic Omen an opponent's Swamp is worth 118 rather than 106. It does not strip *their* statics from the copy, which is a gap this shares with the pattern it follows.

Timing is `AtOppEOT`, unchanged, for the reasons in the comment above. Removing the flag also lets a colourless-only land into AI deckbuilding, a fair trade.

## Testing

`mvn -pl forge-gui-desktop -am test`: 364 tests, 0 failures.

Four tests, each pinned by a mutation only it catches — the phase gate by `waitsForTheTurnBeforeOurs`, the legendary skip by `copiesTheBetterLandItControls`, the score bar and the re-control by `ignoresALandThatOnlyScoresOnTheirBoard`, and including opponents' lands at all by `copiesAnOpponentsLandToo`.

🤖 Implemented with the assistance of Claude Code (Opus 5).
