### PR TITLE
Let the AI use Venser, the Sojourner (and two other mass-unblockable cards)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -251,6 +251,32 @@ public class ComputerUtilCombat {
         return sum;
     }
 
+    /**
+     * Whether swinging with everything that can attack would kill this opponent outright if none
+     * of it could be blocked.
+     */
+    public static boolean unblockedAttackIsLethal(final Player ai, final Player opp, final Iterable<Card> candidates) {
+        if (ai.cantWin() || opp.cantLoseForZeroOrLessLife()) {
+            return false;
+        }
+        final CardCollection attackers = CardLists.filter(candidates, c -> CombatUtil.canAttack(c, opp));
+        if (attackers.isEmpty() || sumDamageIfUnblocked(attackers, opp) < opp.getLife()) {
+            return false;
+        }
+        // last, because it walks the battlefield, external zones and card memory
+        return !ComputerUtil.hasAFogEffect(opp, ai, true);
+    }
+
+    /** As above, against any one of the AI's opponents. */
+    public static boolean unblockedAttackIsLethal(final Player ai) {
+        for (final Player opp : ai.getOpponents()) {
+            if (unblockedAttackIsLethal(ai, opp, ai.getCreaturesInPlay())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // Returns the number of poison counters unblocked attackers would deal
     /**
      * <p>

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -251,6 +251,34 @@ public class ComputerUtilCombat {
         return sum;
     }
 
+    /**
+     * Whether swinging with everything that can attack would kill one of the AI's opponents
+     * outright if none of it could be blocked.
+     */
+    public static boolean unblockedAttackIsLethal(final Player ai) {
+        if (ai.cantWin()) {
+            return false;
+        }
+        for (final Player opp : ai.getOpponents()) {
+            if (unblockedAttackIsLethal(ai, opp)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean unblockedAttackIsLethal(final Player ai, final Player opp) {
+        if (opp.cantLoseForZeroOrLessLife()) {
+            return false;
+        }
+        final CardCollection attackers = CardLists.filter(ai.getCreaturesInPlay(), c -> CombatUtil.canAttack(c, opp));
+        if (attackers.isEmpty() || sumDamageIfUnblocked(attackers, opp) < opp.getLife()) {
+            return false;
+        }
+        // last, because it walks the battlefield, external zones and card memory
+        return !ComputerUtil.hasAFogEffect(opp, ai, true);
+    }
+
     // Returns the number of poison counters unblocked attackers would deal
     /**
      * <p>

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -65,6 +65,14 @@ public class EffectAi extends SpellAbilityAi {
                     }
                     randomReturn = true;
                 }
+            } else if (logic.equals("UnblockableForLethal")) {
+                // making everything unblockable is only worth a loyalty point if the swing it
+                // enables actually wins, so hold it until the attack would be lethal
+                if (!phase.isPlayerTurn(ai) || phase.getPhase().isAfter(PhaseType.MAIN1)
+                        || !unblockedAttackIsLethal(ai)) {
+                    return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                }
+                randomReturn = true;
             } else if (logic.equals("RestrictBlocking")) {
                 if (!phase.isPlayerTurn(ai) || phase.getPhase().isBefore(PhaseType.COMBAT_BEGIN)
                         || phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS)) {
@@ -835,6 +843,23 @@ public class EffectAi extends SpellAbilityAi {
             subAbility = subAbility.getSubAbility();
         }
 
+        return false;
+    }
+
+    /**
+     * Whether attacking with everything available would kill an opponent outright if none of it
+     * could be blocked - the only situation in which "creatures can't be blocked this turn" is
+     * worth spending loyalty on.
+     */
+    private static boolean unblockedAttackIsLethal(final Player ai) {
+        for (final Player opp : ai.getOpponents()) {
+            final CardCollection attackers = CardLists.filter(ai.getCreaturesInPlay(),
+                    c -> CombatUtil.canAttack(c, opp));
+            if (!opp.cantLoseForZeroOrLessLife()
+                    && ComputerUtilCombat.sumDamageIfUnblocked(attackers, opp) >= opp.getLife()) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -69,7 +69,7 @@ public class EffectAi extends SpellAbilityAi {
                 // making everything unblockable is only worth a loyalty point if the swing it
                 // enables actually wins, so hold it until the attack would be lethal
                 if (!phase.isPlayerTurn(ai) || phase.getPhase().isAfter(PhaseType.MAIN1)
-                        || !unblockedAttackIsLethal(ai)) {
+                        || !ComputerUtilCombat.unblockedAttackIsLethal(ai)) {
                     return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
                 }
                 randomReturn = true;
@@ -843,23 +843,6 @@ public class EffectAi extends SpellAbilityAi {
             subAbility = subAbility.getSubAbility();
         }
 
-        return false;
-    }
-
-    /**
-     * Whether attacking with everything available would kill an opponent outright if none of it
-     * could be blocked - the only situation in which "creatures can't be blocked this turn" is
-     * worth spending loyalty on.
-     */
-    private static boolean unblockedAttackIsLethal(final Player ai) {
-        for (final Player opp : ai.getOpponents()) {
-            final CardCollection attackers = CardLists.filter(ai.getCreaturesInPlay(),
-                    c -> CombatUtil.canAttack(c, opp));
-            if (!opp.cantLoseForZeroOrLessLife()
-                    && ComputerUtilCombat.sumDamageIfUnblocked(attackers, opp) >= opp.getLife()) {
-                return true;
-            }
-        }
         return false;
     }
 

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/VenserAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/VenserAiTest.java
@@ -24,11 +24,13 @@ public class VenserAiTest extends AITest {
 
     @Test
     public void goesUnblockableOnlyForLethal() {
-        assertTrue("18 power against 18 life should swing for the win", wouldGoUnblockable(18));
-        assertFalse("18 power against 19 life is not worth a loyalty point", wouldGoUnblockable(19));
+        assertTrue("18 power against 18 life should swing for the win", wouldGoUnblockable(18, null));
+        assertFalse("18 power against 19 life is not worth a loyalty point", wouldGoUnblockable(19, null));
+        assertFalse("a swing the opponent can Fog away is not lethal",
+                wouldGoUnblockable(18, "Kami of False Hope"));
     }
 
-    private boolean wouldGoUnblockable(int oppLife) {
+    private boolean wouldGoUnblockable(int oppLife, String oppExtra) {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
         Player opp = game.getPlayers().get(0);
@@ -37,6 +39,9 @@ public class VenserAiTest extends AITest {
         venser.setCounters(CounterEnumType.LOYALTY, 5);
         addCards("Colossal Dreadmaw", 3, ai); // 18 power
         addCards("Colossal Dreadmaw", 2, opp); // blockers, which stop mattering
+        if (oppExtra != null) {
+            addCard(oppExtra, opp);
+        }
         opp.setLife(oppLife, null);
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/VenserAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/VenserAiTest.java
@@ -1,0 +1,56 @@
+package forge.ai.ability;
+
+import org.testng.annotations.Test;
+
+import forge.ai.AITest;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.card.CounterEnumType;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Making everything unblockable is only worth the cost when the swing it enables is lethal.
+ * Exercised with Venser's -1, which never fired at all before EffectAi could ask that.
+ */
+public class VenserAiTest extends AITest {
+
+    @Test
+    public void goesUnblockableOnlyForLethal() {
+        assertTrue("18 power against 18 life should swing for the win", wouldGoUnblockable(18));
+        assertFalse("18 power against 19 life is not worth a loyalty point", wouldGoUnblockable(19));
+    }
+
+    private boolean wouldGoUnblockable(int oppLife) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card venser = addCard("Venser, the Sojourner", ai);
+        venser.setCounters(CounterEnumType.LOYALTY, 5);
+        addCards("Colossal Dreadmaw", 3, ai); // 18 power
+        addCards("Colossal Dreadmaw", 2, opp); // blockers, which stop mattering
+        opp.setLife(oppLife, null);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            c.setSickness(false);
+        }
+
+        for (SpellAbility sa : venser.getSpellAbilities()) {
+            if (sa.getApi() == ApiType.Effect && !sa.hasParam("Ultimate")) {
+                sa.setActivatingPlayer(ai);
+                return SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay();
+            }
+        }
+        throw new AssertionError("Venser has no -1 ability");
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/VenserAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/VenserAiTest.java
@@ -3,59 +3,104 @@ package forge.ai.ability;
 import org.testng.annotations.Test;
 
 import forge.ai.AITest;
-import forge.ai.SpellApiToAi;
 import forge.game.Game;
-import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
-import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
-import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
-/**
- * Making everything unblockable is only worth the cost when the swing it enables is lethal.
- * Exercised with Venser's -1, which never fired at all before EffectAi could ask that.
- */
 public class VenserAiTest extends AITest {
 
     @Test
-    public void goesUnblockableOnlyForLethal() {
-        assertTrue("18 power against 18 life should swing for the win", wouldGoUnblockable(18, null));
-        assertFalse("18 power against 19 life is not worth a loyalty point", wouldGoUnblockable(19, null));
-        assertFalse("a swing the opponent can Fog away is not lethal",
-                wouldGoUnblockable(18, "Kami of False Hope"));
+    public void goesUnblockableForALethalSwing() {
+        Game game = boardWithVenser(18, null);
+        Player opp = game.getPlayers().get(0);
+        Player ai = game.getPlayers().get(1);
+
+        gameLoopUntilNextPhase(game);
+
+        assertEquals(4, loyalty(game));
+        assertTrue(unblockableEffectIsUp(game));
+
+        // and the loyalty actually buys the game: the swing goes through unblocked
+        playUntilPhase(game, PhaseType.MAIN2);
+        assertEquals(0, opp.getLife());
+        assertTrue("the opponent is dead", opp.hasLost());
+        assertEquals("and nothing of ours traded, because nothing could block",
+                3, ourDreadmaws(ai));
     }
 
-    private boolean wouldGoUnblockable(int oppLife, String oppExtra) {
+    @Test
+    public void holdsTheAbilityWhenTheSwingIsShort() {
+        Game game = boardWithVenser(19, null);
+
+        gameLoopUntilNextPhase(game);
+
+        assertEquals(5, loyalty(game));
+    }
+
+    @Test
+    public void holdsTheAbilityAgainstAFog() {
+        Game game = boardWithVenser(18, "Kami of False Hope");
+
+        gameLoopUntilNextPhase(game);
+
+        assertEquals(5, loyalty(game));
+    }
+
+    /**
+     * 18 power against an opponent holding two 6/6 blockers, so the swing is lethal only because
+     * nothing can block it - a check that consulted blockers would answer no on this board.
+     */
+    private Game boardWithVenser(int oppLife, String oppExtra) {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
         Player opp = game.getPlayers().get(0);
 
-        Card venser = addCard("Venser, the Sojourner", ai);
-        venser.setCounters(CounterEnumType.LOYALTY, 5);
-        addCards("Colossal Dreadmaw", 3, ai); // 18 power
-        addCards("Colossal Dreadmaw", 2, opp); // blockers, which stop mattering
+        addCard("Venser, the Sojourner", ai).setCounters(CounterEnumType.LOYALTY, 5);
+        addCards("Colossal Dreadmaw", 3, ai);
+        addCards("Colossal Dreadmaw", 2, opp);
         if (oppExtra != null) {
             addCard(oppExtra, opp);
         }
         opp.setLife(oppLife, null);
+        for (Player p : game.getPlayers()) {
+            fillLibrary(p, 20);
+        }
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
         game.getAction().checkStateEffects(true);
         for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
             c.setSickness(false);
         }
+        return game;
+    }
 
-        for (SpellAbility sa : venser.getSpellAbilities()) {
-            if (sa.getApi() == ApiType.Effect && !sa.hasParam("Ultimate")) {
-                sa.setActivatingPlayer(ai);
-                return SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay();
+    private int ourDreadmaws(Player ai) {
+        int n = 0;
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            if (c.getName().equals("Colossal Dreadmaw")) {
+                n++;
             }
         }
-        throw new AssertionError("Venser has no -1 ability");
+        return n;
+    }
+
+    /** 5 to start: 4 means the -1 was activated, 7 the +2, and 5 that Venser was left alone. */
+    private int loyalty(Game game) {
+        return findCardWithName(game, "Venser, the Sojourner").getCounters(CounterEnumType.LOYALTY);
+    }
+
+    private boolean unblockableEffectIsUp(Game game) {
+        for (Card c : game.getCardsIn(ZoneType.Command)) {
+            if (c.getName().endsWith("'s Effect") && c.getName().startsWith("Venser, the Sojourner")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/forge-gui/res/cardsfolder/j/jace_arcane_strategist.txt
+++ b/forge-gui/res/cardsfolder/j/jace_arcane_strategist.txt
@@ -5,7 +5,7 @@ Loyalty:4
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 2 | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you draw your second card each turn, put a +1/+1 counter on target creature you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1
 A:AB$ Draw | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | SpellDescription$ Draw a card.
-A:AB$ Effect | Cost$ SubCounter<7/LOYALTY> | Planeswalker$ True | Ultimate$ True | StaticAbilities$ Unblockable | SpellDescription$ Creatures you control can't be blocked this turn.
+A:AB$ Effect | Cost$ SubCounter<7/LOYALTY> | Planeswalker$ True | Ultimate$ True | StaticAbilities$ Unblockable | AILogic$ UnblockableForLethal | SpellDescription$ Creatures you control can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Creature.YouCtrl | Description$ Creatures you control can't be blocked this turn.
 AI:RemoveDeck:Random
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/t/tezzerets_gatebreaker.txt
+++ b/forge-gui/res/cardsfolder/t/tezzerets_gatebreaker.txt
@@ -3,7 +3,7 @@ ManaCost:4
 Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ When CARDNAME enters, look at the top five cards of your library. You may reveal a blue or artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 SVar:TrigDig:DB$ Dig | DigNum$ 5 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Card.Blue,Card.Artifact | RestRandomOrder$ True
-A:AB$ Effect | Cost$ 5 U T Sac<1/CARDNAME> | StaticAbilities$ Unblockable | SpellDescription$ Creatures you control can't be blocked this turn.
+A:AB$ Effect | Cost$ 5 U T Sac<1/CARDNAME> | StaticAbilities$ Unblockable | AILogic$ UnblockableForLethal | SpellDescription$ Creatures you control can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Creature.YouCtrl | Description$ Creatures you control can't be blocked this turn.
 DeckHints:Color$Blue
 DeckHas:Ability$Sacrifice

--- a/forge-gui/res/cardsfolder/v/venser_the_sojourner.txt
+++ b/forge-gui/res/cardsfolder/v/venser_the_sojourner.txt
@@ -6,10 +6,9 @@ A:AB$ ChangeZone | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return exiled card to the battlefield. | SubAbility$ DBCleanup
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-A:AB$ Effect | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | StaticAbilities$ Unblockable | SpellDescription$ Creatures can't be blocked this turn.
+A:AB$ Effect | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | StaticAbilities$ Unblockable | AILogic$ UnblockableForLethal | SpellDescription$ Creatures can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Creature | Description$ Creatures can't be blocked this turn.
 A:AB$ Effect | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | Name$ Emblem — Venser, the Sojourner | Image$ emblem_venser_the_sojourner | Triggers$ TrigSpellCast | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Whenever you cast a spell, exile target permanent."
 SVar:TrigSpellCast:Mode$ SpellCast | ValidActivatingPlayer$ You | Execute$ EffSpellCast | TriggerDescription$ Whenever you cast a spell, exile target permanent.
 SVar:EffSpellCast:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent
-AI:RemoveDeck:All
 Oracle:[+2]: Exile target permanent you own. Return it to the battlefield under your control at the beginning of the next end step.\n[-1]: Creatures can't be blocked this turn.\n[-8]: You get an emblem with "Whenever you cast a spell, exile target permanent."


### PR DESCRIPTION
Venser, the Sojourner is `AI:RemoveDeck:All`. Two of his three abilities already work — the flag was covering for one dead one, and that one is not his alone.

## What was dead

The **-1** ("Creatures can't be blocked this turn") returned `CantPlayAi` on every board, including ones where it wins on the spot — `EffectAi`'s no-`AILogic` branch is a bare `return CantPlayAi`, so nothing here narrows existing behaviour.

`AILogic$ UnblockableForLethal` holds it until attacking with everything that can attack would take an opponent to zero with nothing able to block — the state the ability itself creates, so blockers are not counted.

| AI power | Opponent life | Before | After |
|---|---|---|---|
| 18 | 18 | `CantPlayAi` | activates |
| 18 | 19 | `CantPlayAi` | declines |
| 18 | 18, opponent holds a Fog | `CantPlayAi` | declines |

Same tag on the other two cards where this is an optional choice, and both argue for it harder than Venser: Jace, Arcane Strategist spends seven loyalty, Tezzeret's Gatebreaker sacrifices itself. The rest are mandatory triggers, static, or wrong for a lethal-only gate — Glaring Spotlight also grants hexproof, and Reverse the Polarity is a Charm mode CharmAi reaches another way.

## The check

It lives in `ComputerUtilCombat` beside `sumDamageIfUnblocked`, with the guards `doAssault()` already has: `ai.cantWin()`, `opp.cantLoseForZeroOrLessLife()` and `hasAFogEffect`, fog last since it walks several zones.

## Testing

368 tests, 0 failures, 6 skipped. The tests play the phase out through `AiController` rather than calling the ability AI directly, and the lethal case runs to end of combat — the opponent is dead and all three attackers survive, so it asserts the ability won the game rather than that a loyalty counter moved. Removing either half of the fix fails it.

## Not included: War Cadence

`RestrictBlocking` asks a similar question with its own loop, and an earlier revision of this PR pointed it at the same helper. Measured end to end, the AI pays `{X}{R}` at declare-attackers and then declares no attackers, so the tax buys nothing. What it would need is upstream of the ability: `AiAttackController` plans the attack in the loop commented `// presumes the Human will block`, which already carries `// TODO should be limited to how much getBlockCost the opp can pay`. Until the attacker can price blocks, that branch can only spend mana, so `RestrictBlocking` is left untouched here.

🤖 Implemented with the assistance of Claude Code (Opus 5).
