### PR TITLE
Some Card Fixes

### DIFF
--- a/forge-gui/res/cardsfolder/i/incite.txt
+++ b/forge-gui/res/cardsfolder/i/incite.txt
@@ -1,7 +1,7 @@
 Name:Incite
 ManaCost:R
 Types:Instant
-A:SP$ Animate | ValidTgts$ Creature | Colors$ Red | OverwriteColors$ True | SpellDescription$ Target creature becomes red until end of turn and attacks this turn if able.
+A:SP$ Animate | ValidTgts$ Creature | Colors$ Red | OverwriteColors$ True | SubAbility$ DBEffect | SpellDescription$ Target creature becomes red until end of turn and attacks this turn if able.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ MustAttack | ExileOnMoved$ Battlefield | RememberObjects$ Targeted
 SVar:MustAttack:Mode$ MustAttack | ValidCreature$ Creature.IsRemembered | Description$ This creature attacks this turn if able.
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/p/phantasmal_extraction.txt
+++ b/forge-gui/res/cardsfolder/p/phantasmal_extraction.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast if you weren't the starting player.
 SVar:X:Count$StartingPlayer.0.1
 A:SP$ Reveal | ValidTgts$ Opponent | RevealAllValid$ Card.nonLand+TargetedPlayerOwn+cmcLE4 | SubAbility$ DBPumpAll | RememberRevealed$ True | SpellDescription$ Target opponent reveals each nonland card in their hand with mana value 4 or less.
-SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Card.TargetedPlayerOwn | RememberAllPumped$ True | PumpZone$ Graveyard | SubAbility$ DBChoose
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Card.TargetedPlayerOwn | RememberPumped$ True | PumpZone$ Graveyard | SubAbility$ DBChoose
 SVar:DBChoose:DB$ ChooseCard | ChoiceZone$ Hand,Graveyard | Choices$ Card.IsRemembered | SubAbility$ DBChangeZone | ChoiceTitle$ Choose a card revealed this way or a card in their graveyard | SpellDescription$ Choose a card revealed this way or a card in their graveyard.
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ ChosenCard | Origin$ Hand,Graveyard | Destination$ Exile | SubAbility$ DBCleanup | Hidden$ True | SpellDescription$ Exile that card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True

--- a/forge-gui/res/cardsfolder/r/reparations.txt
+++ b/forge-gui/res/cardsfolder/r/reparations.txt
@@ -1,6 +1,6 @@
 Name:Reparations
 ManaCost:1 W U
 Types:Enchantment
-T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidCard$ Card | ValidActivatingPlayer$ Opponent | TargetsValid$ You,Creature.YouCtrl+inZoneBattlefield | Execute$ TrigDraw | TriggerDescription$ Whenever an opponent casts a spell that targets you or a creature you control, you may draw a card.
+T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidCard$ Card | ValidActivatingPlayer$ Opponent | TargetsValid$ You,Creature.YouCtrl+inZoneBattlefield | OptionalDecider$ You | Execute$ TrigDraw | TriggerDescription$ Whenever an opponent casts a spell that targets you or a creature you control, you may draw a card.
 SVar:TrigDraw:DB$ Draw
 Oracle:Whenever an opponent casts a spell that targets you or a creature you control, you may draw a card.

--- a/forge-gui/res/cardsfolder/v/vault_13_dwellers_journey.txt
+++ b/forge-gui/res/cardsfolder/v/vault_13_dwellers_journey.txt
@@ -6,7 +6,7 @@ SVar:DBExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTg
 SVar:OneEach:PlayerCountPlayers$Amount
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | SubAbility$ DBScry | SpellDescription$ You gain 2 life and scry 2.
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-SVar:DBReturn:DB$ ChangeZone | ChangeType$ Card.ExiledWithSource | Origin$ Exile | Destination$ Battlefield | Hidden$ True | ChangeNum$ 2 | Mandatory$ True | RememberChanged$ True | SpellDescription$ Return two cards exiled with NICKNAME to the battlefield under their owners' control and put the rest on the bottom of their owners' libraries.
+SVar:DBReturn:DB$ ChangeZone | ChangeType$ Card.ExiledWithSource | Origin$ Exile | Destination$ Battlefield | Hidden$ True | ChangeNum$ 2 | Mandatory$ True | RememberChanged$ True | SubAbility$ DBChangeZoneAll | SpellDescription$ Return two cards exiled with NICKNAME to the battlefield under their owners' control and put the rest on the bottom of their owners' libraries.
 SVar:DBChangeZoneAll:DB$ ChangeZoneAll | ChangeType$ Card.ExiledWithSource+!IsRemembered | Origin$ Exile | Destination$ Library | LibraryPosition$ -1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$LifeGain


### PR DESCRIPTION
Added fixes for the following cards:
---

- **Incite:** Attach the _**SubAbility$ DBEffect**_ that was not included in the script.
- **Phantasmal Extraction:** Changed the _**RememberAllPumped$**_ to _**RememberPumped$**_ since the former doesn't exist based on Claude's analysis.
- **Reparations:** Included the _**OptionalDecider$ You**_ to the script to make drawing from the card's effect optional.
- **Vault 13: Dweller's Journey:** Attach the _**SubAbility$ DBChangeZoneAll**_ that was not included on the script.