### PR TITLE
Fix ConcurrentModificationException when a discard-your-hand effect resolves with exactly one card in hand

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -896,7 +896,8 @@ public abstract class SpellAbilityEffect {
         for (Map.Entry<Player, CardCollectionView> e : toDiscardMap.entrySet()) {
             discardedBefore.put(e.getKey(), Lists.newArrayList(e.getKey().getDiscardedThisTurn()));
             final CardCollection discardedByPlayer = new CardCollection();
-            for (Card card : e.getValue()) {
+            // iterate a copy: the view may be a live zone list (e.g. whole hand) that discard() mutates
+            for (Card card : Lists.newArrayList(e.getValue())) {
                 if (card == null) { continue; }
                 Card moved = e.getKey().discard(card, sa, effect, params);
                 if (moved != null) {


### PR DESCRIPTION
Fixes #11415

### Bug

`java.util.ConcurrentModificationException` crashes the match when a "discard your hand" effect (observed with Wheel of Fortune in Adventure, but the path is engine-generic) resolves while a player has exactly one card in hand:

```
java.util.ConcurrentModificationException
at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1096)
at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1050)
at forge.game.ability.SpellAbilityEffect.discard(SpellAbilityEffect.java:899)
at forge.game.ability.effects.DiscardEffect.resolve(DiscardEffect.java:287)
```

### Cause

1. `DiscardEffect` mode `"Hand"` passes `p.getCardsIn(ZoneType.Hand)` — a live view of the hand zone's backing list (`Zone.getCards()` returns `cardList` directly).
2. `GameActionUtil.orderCardsByTheirOwners` normally builds a fresh `CardCollection`, but short-circuits and returns the original list unchanged when `list.size() <= 1`.
3. `SpellAbilityEffect.discard` then iterates that live list while `Player.discard` moves each card out of the hand, invalidating the iterator.

With two or more cards in hand the ordering step makes a defensive copy, so the crash only manifests at exactly one card — which is why it appears intermittent.

### Fix

Iterate a copy (`Lists.newArrayList`) in `SpellAbilityEffect.discard`. Fixing the shared helper protects every caller that might pass a live zone view (`DiscardEffect`, `BalanceEffect`, `RecruitEffect`, `ConniveEffect`) and makes the one-card path behave identically to the multi-card path. Iterating a snapshot is safe if a card leaves the hand mid-loop (e.g. via a Discarded trigger): `Player.discard` → `Card.canBeDiscardedBy` rejects cards no longer in hand, same as today.

### Testing

- `mvn -pl forge-game -am test -DskipTests=false` passes (3 tests); checkstyle reports 0 violations.
- Root cause traced in code and the fix reviewed in multiple adversarial review rounds; the original crash is intermittent (requires exactly one card in hand at resolution) and was not re-reproduced manually.

Diagnosed and fixed with Claude Fable with guidance to keep the change as small as possible, and cross-reviewed by Codex 5.6 Sol.
