### PR TITLE
Fix NPE when restoring a snapshot taken before a card was created

### DIFF
--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -14,6 +14,7 @@ import forge.game.spellability.SpellAbility;
 import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.PlayerZoneBattlefield;
+import forge.game.zone.Zone;
 import forge.game.zone.ZoneType;
 
 import java.util.Collections;
@@ -332,6 +333,19 @@ public class GameSnapshot {
         Collections.sort(unorderedEntities);
         for(UnorderedEntities ue : unorderedEntities) {
             setCardInCopiedGame(toGame, ue.toPlayer, ue.fromCard, ue.newCard, ue.fromType, ue.zonePosition);
+        }
+
+        // Cards that exist in the game being restored but not in the snapshot: tokens,
+        // copies and effect cards created after it was taken. There is no earlier state to
+        // put them back into, so they leave the game. Without this the loop below looks
+        // them up in the snapshot and dereferences the null it gets back.
+        for (Card extraCard : toGame.getCardsInGame()) {
+            if (fromGame.findById(extraCard.getId()) == null) {
+                Zone zone = extraCard.getZone();
+                if (zone != null) {
+                    zone.remove(extraCard);
+                }
+            }
         }
 
         // This loop happens later to make sure all cards are in the correct zone first


### PR DESCRIPTION
### Problem

`GameSnapshot.copyGameState()` copies the snapshot's cards back into the running game, but it never removes cards that the running game has and the snapshot does not — tokens, copies and effect cards that were created after the snapshot was taken.

The loop that restores attachments afterwards iterates the *current* battlefield and looks every card up in the snapshot:

```java
for (Card newCard : toGame.getCardsIn(ZoneType.Battlefield)) {
    Card fromCard = fromGame.findById(newCard.getId());

    if (fromCard.isAttachedToEntity()) {   // NPE: fromCard is null for cards the snapshot never had
```

For a card the snapshot does not know, `findById` returns `null` and the next line throws.

Interestingly `assignGameState` already anticipates such cards a few lines further down — it prints `"Missing card " + c` and continues — but by then `copyGameState` has already thrown.

### When it shows up

Not in the current use of snapshots: rolling back a cancelled cast (`GameActionUtil.rollbackAbility`) creates no new objects, so every card on the battlefield is also in the snapshot. Any restore that reaches back past the creation of a token or a copy throws instead — which is what happens as soon as snapshots are used to step further back than the action in progress.

### Fix

Remove those cards from the game as part of the restore. Returning to a state in which they did not exist is exactly what a restore means, and it also gives the `"Missing card"` branch below nothing left to report.

### Notes

* Built against `master`; `forge-game` compiles clean.
* No test added, per the note in CONTRIBUTING about agent-added tests. I do have a regression test for this (it reproduces the NPE reliably by adding a card after the snapshot and restoring) and am happy to include it if you would like it.
* This came out of a personal multi-step undo experiment: https://github.com/cuinhellcat/mtg-forge-rewind — the fix is independent of that and useful on its own, so it is offered separately.

### AI disclosure

Written with Claude Code (Claude Opus 5), as requested in CONTRIBUTING; the agent is also recorded as co-author on the commit.
