### PR TITLE
Clean up the ability when a cast is rolled back via snapshot

### DIFF
--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -942,6 +942,20 @@ public final class GameActionUtil {
             // If we're able to restore the whole game state when rolling back an ability don't try to manually roll back
             System.out.println("Restored state from snapshot! Rolled back: " + ability.getHostCard().getName() + " - " + ability.getActivatingPlayer());
 
+            // The snapshot covers the cards, their zones and the mana pool, so the manual
+            // rollback below and its refund would double up on it. The ability is not part of
+            // the snapshot though, and neither is the frozen stack: without the cleanup an
+            // announced value or a chosen target survives into the next attempt to cast the
+            // card, and the stack stays frozen.
+            Card restored = game.getCardState(oldCard, null);
+            if (restored != null) {
+                restored.setCastSA(null);
+                restored.setCastFrom(null);
+            }
+            resetAnnouncedCosts(ability);
+            resetChosenTargets(ability);
+            game.getStack().clearFrozen();
+            game.getTriggerHandler().clearWaitingTriggers();
             return;
         }
 
@@ -962,18 +976,7 @@ public final class GameActionUtil {
             Integer newPosition = zonePosition >= 0 ? Math.min(zonePosition, fromZone.size()) : null;
             fromZone.add(oldCard, newPosition, null, true);
             ability.setHostCard(oldCard);
-            ability.setXManaCostPaid(null);
-            ability.setSpendPhyrexianMana(false);
-            ability.clearPipsToReduce();
-            ability.setPaidLife(0);
-            if (ability.hasParam("Announce")) {
-                for (final String aVar : ability.getParam("Announce").split(",")) {
-                    final String varName = aVar.trim();
-                    if (!varName.equals("X")) {
-                        ability.setSVar(varName, "0");
-                    }
-                }
-            }
+            resetAnnouncedCosts(ability);
             // better safe than sorry approach in case rolled back ability was copy (from addExtraKeywordCost)
             for (SpellAbility sa : oldCard.getSpells()) {
                 sa.setHostCard(oldCard);
@@ -994,6 +997,30 @@ public final class GameActionUtil {
             }
         }
 
+        resetChosenTargets(ability);
+        payment.refundPayment();
+        game.getStack().clearFrozen();
+        game.getTriggerHandler().clearWaitingTriggers();
+    }
+
+    /** Values the player announced or committed to while casting, which a snapshot does not hold. */
+    private static void resetAnnouncedCosts(SpellAbility ability) {
+        ability.setXManaCostPaid(null);
+        ability.setSpendPhyrexianMana(false);
+        ability.clearPipsToReduce();
+        ability.setPaidLife(0);
+        if (ability.hasParam("Announce")) {
+            for (final String aVar : ability.getParam("Announce").split(",")) {
+                final String varName = aVar.trim();
+                if (!varName.equals("X")) {
+                    ability.setSVar(varName, "0");
+                }
+            }
+        }
+    }
+
+    /** Modes and targets picked while casting, likewise not covered by a snapshot. */
+    private static void resetChosenTargets(SpellAbility ability) {
         if (ability.getApi() == ApiType.Charm) {
             // reset chain
             ability.setSubAbility(null);
@@ -1003,9 +1030,6 @@ public final class GameActionUtil {
         ability.clearTargets();
 
         ability.resetOnceResolved();
-        payment.refundPayment();
-        game.getStack().clearFrozen();
-        game.getTriggerHandler().clearWaitingTriggers();
     }
 
 }


### PR DESCRIPTION
Addresses #10049 and, most likely, #8762.

### Problem

`GameActionUtil.rollbackAbility` returns as soon as the snapshot has been restored:

```java
if (game.restoreGameState()) {
    // If we're able to restore the whole game state when rolling back an ability don't try to manually roll back
    System.out.println("Restored state from snapshot! ...");
    return;
}
```

That is right for the cards, their zones and the mana pool — `copyManaPool` already puts the mana back, so `payment.refundPayment()` on top of it would hand out the mana twice. It is not right for everything else the early return skips:

* `ability.setXManaCostPaid(null)`, `setSpendPhyrexianMana(false)`, `clearPipsToReduce()`, `setPaidLife(0)` and the `Announce` SVars
* `ability.clearTargets()`, the Charm mode chain, `resetOnceResolved()`
* `oldCard.setCastSA(null)` and `setCastFrom(null)`
* `game.getStack().clearFrozen()` and `getTriggerHandler().clearWaitingTriggers()`

A `SpellAbility` is not part of a snapshot, and neither is the frozen stack. So after cancelling a cast with undo restore enabled, the card keeps the announced value and targets from the attempt that was called off, still believes it is being cast, and the stack stays frozen.

That is what the two reports look like from the outside:

* **#10049** — March of the Otherworldly Light can no longer be cast after cancelling with an invalid number. Its additional cost is announced, and the announced value is exactly what survives.
* **#8762** — cancelling a cast sometimes freezes the game. A stack left frozen with waiting triggers does that, and it explains why it only happens sometimes: `Hanmac` already pointed at `GameSnapshot` in that thread, and the reporter was told to turn undo restore off.

### Fix

Do the ability-level cleanup in both paths — still no refund, still no zone handling. The values reset in the snapshot path are the same ones the manual path resets, pulled into two small helpers so the paths cannot drift apart.

### Reproduction

At engine level: enable snapshots, stash, then set `xManaCostPaid`, `castSA`, `castFrom` and freeze the stack the way a cast does, and call `rollbackAbility`. Before the change the announced X, the cast markers and the frozen stack all survive; after it they are gone. I could not drive the actual GUI cancel headlessly, so I have not confirmed the two reports end to end — the mechanism matches what they describe.

### Notes

* No test added, per the note in CONTRIBUTING about agent-added tests. The reproduction above exists as one (fails before, passes after) if you want it.
* Forge's desktop suite (278 tests) passes with the change.

### AI disclosure

Written with Claude Code (Claude Opus 5), as requested in CONTRIBUTING; the agent is also recorded as co-author on the commit.
