### PR TITLE
Snapshot cards into the zone they are actually in, not the controller's

### DIFF
--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -298,7 +298,12 @@ public class GameSnapshot {
 
         for(Card fromCard : fromGame.getCardsInGame()) {
             Card newCard = toGame.findById(fromCard.getId());
-            Player toPlayer = findBy(toGame, fromCard.getController());
+            // Zones belong to a player: the controller's battlefield, but the owner's
+            // graveyard, hand and library. Going by the controller alone files a card whose
+            // control has changed under the wrong player, so a stolen creature that died
+            // reappears in the thief's graveyard when the snapshot is used.
+            Player fromZonePlayer = fromCard.getZone().getPlayer();
+            Player toPlayer = findBy(toGame, fromZonePlayer != null ? fromZonePlayer : fromCard.getController());
             ZoneType fromType = fromCard.getZone().getZoneType();
             int zonePosition = 0;
             if (ZoneType.ORDERED_ZONES.contains(fromType)) {
@@ -308,8 +313,9 @@ public class GameSnapshot {
             }
 
             if (newCard == null) {
-                // Storing a game uses this path...
-                newCard = createCardCopy(toGame, toPlayer, fromCard);
+                // Storing a game uses this path... the copy keeps the original owner, which
+                // is not the same player as the one whose zone it currently sits in.
+                newCard = createCardCopy(toGame, findBy(toGame, fromCard.getOwner()), fromCard);
             } else {
                 ZoneType type = newCard.getZone().getZoneType();
                 if (type != fromType) {


### PR DESCRIPTION
### Problem

`copyGameState` decides which player's zone a card goes into by asking the card for its controller:

```java
Player toPlayer = findBy(toGame, fromCard.getController());
```

That is only right on the battlefield. A graveyard, hand or library belongs to the card's **owner**. When control has changed — a stolen creature, or a card returned to play under someone else's control — the card is filed under the wrong player, and restoring the snapshot moves it into that player's graveyard for good. Cards silently change hands across an undo.

### Fix

Take the player from the zone the card is actually in: the controller on the battlefield, the owner everywhere else, with a fallback to the controller for the stack, which has no player. Card copies made for a stored game likewise keep their original owner rather than inheriting the controller.

### Reproduction

Put nine cards in one player's graveyard plus a tenth whose controller is the opponent, snapshot and restore: before the change the tenth ends up in the opponent's graveyard, after it stays where it belongs.

### Relationship to #9297

This came out of looking into #9297, and I want to be precise about what it does and does not do. That report's stack trace is the same mismatch seen from a different angle:

```
java.lang.IndexOutOfBoundsException: Index: 9, Size: 7
    at forge.util.collect.FCollection.insert(FCollection.java:431)
    at forge.game.zone.Zone.add(Zone.java:139)
    at forge.game.GameSnapshot.copyGameState(GameSnapshot.java:321)
```

The card kept the index it had in its owner's graveyard and was inserted at that index into the controller's shorter one. But `setCardInCopiedGame` no longer inserts by index on master, and I could not get master to throw that exception. So this PR does not claim to close #9297 — it fixes the misplacement the crash grew out of, which is a bug on its own.

If you would also like `Zone.add` to clamp an out-of-range index defensively (it already guards the empty-zone case a few lines up), that is a two-line addition and I am happy to add it.

### Notes

* No test added, per the note in CONTRIBUTING about agent-added tests; I have the reproduction above as one if you want it.
* Forge's desktop suite (278 tests) passes with the change.

### AI disclosure

Written with Claude Code (Claude Opus 5), as requested in CONTRIBUTING; the agent is also recorded as co-author on the commit.
