### PR TITLE
Restore the foretold state when a snapshot is restored

### DIFF
--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -389,8 +389,8 @@ public class GameSnapshot {
         newCard.setFaceDown(fromCard.isFaceDown());
         newCard.setManifested(fromCard.getManifestedSA());
         newCard.setSickness(fromCard.hasSickness());
-        //newCard.setForetold(fromCard.isForetold());
-        //newCard.setForetoldCostByEffect(fromCard.isForetoldCostByEffect());
+        newCard.setForetold(fromCard.isForetold());
+        newCard.setForetoldCostByEffect(fromCard.isForetoldCostByEffect());
         newCard.setState(fromCard.getCurrentStateName(), false);
     }
 


### PR DESCRIPTION
Fixes #7844.

### Problem

Cancel the cast of a foretold card and it comes back to exile without its foretold state, so it can no longer be cast with Foretell.

`setCardInCopiedGame` restores a card's tapped, face-down, manifested, sickness and state-name, but the two lines for the foretold flags are commented out:

```java
newCard.setSickness(fromCard.hasSickness());
//newCard.setForetold(fromCard.isForetold());
//newCard.setForetoldCostByEffect(fromCard.isForetoldCostByEffect());
newCard.setState(fromCard.getCurrentStateName(), false);
```

They have been comments since the method was introduced in "Trying to fix gateway dialog glitching" — never active, so this is not re-enabling something that was switched off for a reason. Nothing else restores that state, while `CardCopyService.copyCard` already carries both flags into the snapshot, so the information is there and simply not read back.

### Reproduction

Take a snapshot with a face-down foretold card in exile, turn it face up onto the stack the way casting does, restore. The card returns to exile face down, and `isForetold()` is false.

### Notes

* `isForetold()` reads the field for a card in exile and derives it from the cast ability elsewhere, so `setForetold(fromCard.isForetold())` restores the value that matters and is a no-op for cards that are not in exile.
* No test added, per the note in CONTRIBUTING about agent-added tests. I have one that fails before the change and passes after (the reproduction above); happy to include it if you want it.
* Forge's desktop suite (278 tests) passes with the change.

### AI disclosure

Written with Claude Code (Claude Opus 5), as requested in CONTRIBUTING; the agent is also recorded as co-author on the commit.
