### PR TITLE
Keep melded permanents intact across a snapshot

### DIFF
--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -346,6 +346,10 @@ public class GameSnapshot {
                     newAttachedTo.addAttachedCard(newCard);
                 }
             }
+            // Melded or not, the front half has to point at what the snapshot had — the two
+            // halves are one permanent, and a stale link outlives the meld otherwise.
+            newCard.setMeldedWith(fromCard.getMeldedWith() == null ? null
+                    : toGame.findById(fromCard.getMeldedWith().getId()));
             if (fromCard.getCloneOrigin() != null) {
                 newCard.setCloneOrigin(toGame.findById(fromCard.getCloneOrigin().getId()));
             }
@@ -377,7 +381,20 @@ public class GameSnapshot {
         if (fromType.equals(ZoneType.Stack)) {
             toGame.getStackZone().add(newCard);
             newCard.setZone(toGame.getStackZone());
+        } else if (isMelded(fromCard)) {
+            // The back half of a meld lives in the battlefield zone but in its own
+            // collection rather than the card list. Putting it in the list instead would
+            // leave it on the battlefield as a permanent of its own.
+            PlayerZoneBattlefield battlefield = (PlayerZoneBattlefield) toPlayer.getZone(ZoneType.Battlefield);
+            if (newCard.getZone() == null) {
+                newCard.setZone(battlefield);
+            }
+            battlefield.addToMelded(newCard);
         } else {
+            // It may have been melded in the state we are leaving behind.
+            if (toPlayer.getZone(ZoneType.Battlefield) instanceof PlayerZoneBattlefield battlefield) {
+                battlefield.removeFromMelded(newCard);
+            }
             toPlayer.getZone(fromType).add(newCard);
             newCard.setZone(toPlayer.getZone(fromType));
         }
@@ -391,7 +408,14 @@ public class GameSnapshot {
         newCard.setSickness(fromCard.hasSickness());
         //newCard.setForetold(fromCard.isForetold());
         //newCard.setForetoldCostByEffect(fromCard.isForetoldCostByEffect());
+        newCard.setBackSide(fromCard.isBackSide());
         newCard.setState(fromCard.getCurrentStateName(), false);
+    }
+
+    /** The back half of a meld: on the battlefield, but held apart from its card list. */
+    private static boolean isMelded(Card c) {
+        return c.getZone() instanceof PlayerZoneBattlefield battlefield
+                && battlefield.getMeldedCards().contains(c);
     }
 
     private static SpellAbility findSAInCard(SpellAbility sa, Card c) {


### PR DESCRIPTION
Follow-up to a review question on #11416 ("Does this break things like meld?"). It does not — but checking turned up that snapshots break meld already, in both directions, on master and independently of that PR.

### Problem

A melded permanent is two cards. The front half sits on the battlefield in its `Meld` state; the back half is held in `PlayerZoneBattlefield.meldedCards`, not in the zone's card list. `forEachCardInGame` walks that collection, so both halves reach `copyGameState` — which places every card by zone type alone and drops both into the card list.

That breaks a meld whichever way the restore goes:

* **Snapshot taken while melded** — the back half comes back loose on the battlefield. One permanent becomes two.
* **Snapshot taken before the meld** — the back half is added to the card list but never taken out of `meldedCards`, so it is both melded and on the battlefield, with the front half still pointing at it through `meldedWith`.

### Fix

Put a card the snapshot holds as melded back into the melded collection, take it out of there when the snapshot does not hold it that way, and carry `meldedWith` and the back-side flag across with the rest of the card state.

### Reproduction

Bruna, the Fading Light and Gisela, the Broken Blade, melded the way `MeldEffect` does:

* snapshot → meld → restore: before the change the back half stays in `getMeldedCards()` and the front half keeps its `meldedWith`; after it, both halves are loose again and the link is cleared.
* meld → snapshot → restore: before the change the battlefield holds two permanents; after it, one, with the back half still melded.

### Notes

* Independent of #11416 — this reproduces on unmodified master, and the two changes do not touch the same lines.
* No test added, per the note in CONTRIBUTING about agent-added tests. Both directions above exist as tests that fail before the change and pass after; say the word and I will add them, since meld has few other guards.
* Forge's desktop suite (279 tests) passes with the change.

### AI disclosure

Written with Claude Code (Claude Opus 5), as requested in CONTRIBUTING; the agent is also recorded as co-author on the commit.
