### PR TITLE
Give a stolen card back when a snapshot is restored

### DIFF
--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -14,6 +14,7 @@ import forge.game.spellability.SpellAbility;
 import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.PlayerZoneBattlefield;
+import forge.game.zone.Zone;
 import forge.game.zone.ZoneType;
 
 import java.util.Collections;
@@ -311,13 +312,15 @@ public class GameSnapshot {
                 // Storing a game uses this path...
                 newCard = createCardCopy(toGame, toPlayer, fromCard);
             } else {
-                ZoneType type = newCard.getZone().getZoneType();
-                if (type != fromType) {
-                    if (type.equals(ZoneType.Stack)) {
-                        toGame.getStackZone().remove(newCard);
-                    } else {
-                        toPlayer.getZone(type).remove(newCard);
-                    }
+                // Take it out of wherever it currently is, unless that is already the zone
+                // it is going into. Comparing zone types alone misses a move between two
+                // players' battlefields — a creature stolen after the snapshot was taken
+                // then ends up in both of them.
+                Zone currentZone = newCard.getZone();
+                Zone targetZone = fromType.equals(ZoneType.Stack)
+                        ? toGame.getStackZone() : toPlayer.getZone(fromType);
+                if (currentZone != null && currentZone != targetZone) {
+                    currentZone.remove(newCard);
                 }
             }
 
@@ -389,6 +392,13 @@ public class GameSnapshot {
         newCard.setFaceDown(fromCard.isFaceDown());
         newCard.setManifested(fromCard.getManifestedSA());
         newCard.setSickness(fromCard.hasSickness());
+        // Who controls a card is state of its own. A creature stolen after the snapshot was
+        // taken stays with the thief otherwise: its zone is corrected, but the card still
+        // names the thief as controller, so it keeps playing for them.
+        Player fromController = findBy(toGame, fromCard.getController());
+        if (fromController != null && fromController != newCard.getController()) {
+            newCard.setController(fromController, toGame.getNextTimestamp());
+        }
         //newCard.setForetold(fromCard.isForetold());
         //newCard.setForetoldCostByEffect(fromCard.isForetoldCostByEffect());
         newCard.setState(fromCard.getCurrentStateName(), false);


### PR DESCRIPTION
### Problem

Nothing in `GameSnapshot` restores who controls a card. A creature that changed hands after the snapshot was taken stays with its new controller when the state is put back.

Reported from play: cast Claim the Firstborn, then roll back. The spell returns to hand, the creature stays on the thief's side.

The zone handling misses it too:

```java
ZoneType type = newCard.getZone().getZoneType();
if (type != fromType) { ... remove ... }
```

A card already in the game is only taken out of its current zone when the zone *type* differs — and a move between two players' battlefields keeps the type. So the creature is added to the owner's battlefield while remaining in the thief's, ending up in both at once.

### Fix

Restore the controller alongside the rest of the card state, and take the card out of whatever zone it currently sits in unless that is already the zone it is going into.

### Reproduction

Snapshot with a creature under its owner's control, give control to the opponent with a zone correction, restore: before the change control stays with the opponent and the creature is in both battlefields; after it, the creature is back under its owner with a single copy on the board.

### Notes

* Touches the same method as #11419, though not the same lines. If you take both, #11419 fixes which player's zone a card is filed into and this one fixes leaving the old zone behind; they are independent but related.
* No test added, per the note in CONTRIBUTING about agent-added tests. The reproduction above exists as one (fails before, passes after) if you want it.
* Forge's desktop suite (278 tests) passes with the change.

### AI disclosure

Written with Claude Code (Claude Opus 5), as requested in CONTRIBUTING; the agent is also recorded as co-author on the commit.
