### PR TITLE
fix: restore RGBA8888 card textures on non-iOS platforms

### DIFF
--- a/forge-gui-mobile/src/forge/assets/Assets.java
+++ b/forge-gui-mobile/src/forge/assets/Assets.java
@@ -310,10 +310,13 @@ public class Assets implements Disposable {
         return textureParameter;
     }
 
-    // Card images are opaque, so load the bundled (AssetManager) card path as RGB565 (half the RGBA8888
-    // footprint) with no mipmaps (cards are drawn ~1:1). Separate from getTextureFilter() so UI textures that
-    // need alpha/mipmaps are unaffected. Mirrors the RGB565 downscale already applied to the downloaded path.
+    // Card images are opaque. iOS is native-memory constrained, so there it loads the card path as RGB565
+    // (half the RGBA8888 footprint) with no mipmaps (cards are drawn ~1:1) — mirroring the RGB565 downscale on
+    // the downloaded path. Every other platform keeps the full-quality RGBA8888 + mipmap path (getTextureFilter),
+    // so card textures are not downgraded off iOS. Kept separate so UI textures are unaffected either way.
     public TextureParameter getCardTextureFilter() {
+        if (!GuiBase.isIOS())
+            return getTextureFilter();
         if (cardTextureParameter == null) {
             cardTextureParameter = new TextureParameter();
             cardTextureParameter.format = Pixmap.Format.RGB565;

--- a/forge-gui-mobile/src/forge/assets/ImageCache.java
+++ b/forge-gui-mobile/src/forge/assets/ImageCache.java
@@ -564,8 +564,8 @@ public class ImageCache {
 
         // Only use AssetManager for bundled assets (not downloaded images)
         if (!isDownloadedImage) {
-            //load to assetmanager - card images are opaque, so use the RGB565 card parameter (half the RGBA8888
-            //footprint) to bound the bundled-texture memory that grows over a long game (cardsLoaded climb)
+            //load to assetmanager with the card texture parameter (RGB565 on iOS to bound native memory,
+            //full-quality RGBA8888 elsewhere - see Assets.getCardTextureFilter())
             try {
                 if (Forge.getAssets().manager().get(fileName, Texture.class, false) == null) {
                     Forge.getAssets().manager().load(fileName, Texture.class, Forge.getAssets().getCardTextureFilter());


### PR DESCRIPTION
## Summary

PR #11190 inadvertently applied the RGB565 texture format globally in `getCardTextureFilter()`, downgrading card texture quality on desktop and Android. The RGB565 path was intended only for iOS, where native-memory constraints make it worthwhile (half the RGBA8888 footprint). Desktop and Android have no such constraint and should use the full-quality RGBA8888 + mipmap path.

- Add `if (!GuiBase.isIOS()) return getTextureFilter();` so non-iOS platforms route through the existing full-quality path
- iOS continues to use RGB565 (no change to iOS behaviour)
- Update comments in `Assets.java` and `ImageCache.java` to clarify the iOS-only scope

## Test plan

- [x] Android emulator (Pixel Tablet, 2560×1600): card art renders at full RGBA8888 quality — verified zoomed card view shows crisp gradients with no colour banding
- [x] iOS simulator (iPad Air 13" M3): cards still render correctly via the RGB565 path — Jungle Hollow zoom confirmed clean artwork, no regression

Fixes the texture regression reported by Eradev in #11190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)