### PR TITLE
Fix #11375: Russian is blocked on Android/iOS and unreadable on Desktop

### DIFF
--- a/forge-core/src/main/java/forge/util/lang/LangRussian.java
+++ b/forge-core/src/main/java/forge/util/lang/LangRussian.java
@@ -37,4 +37,15 @@ public class LangRussian extends Lang {
         return "Roboto-Bold";
     }
 
+    // Desktop (GuiUtils.newFont) uses this character to test whether font1.ttf can render
+    // the active locale's script; on failure it falls back to the system's default Swing
+    // font instead of font1.ttf. Every CJK Lang subclass already overrides this (see
+    // LangChinese/LangJapanese/LangKorean) - Russian was missing it, so font1.ttf's "can
+    // display ' '" trivially passed and desktop kept rendering Cyrillic UI text with a font
+    // that has no Cyrillic glyphs at all, leaving most non-card text unreadable there.
+    @Override
+    public char canDisplayCheck() {
+        return 'Р';
+    }
+
 }

--- a/forge-core/src/main/java/forge/util/lang/LangRussian.java
+++ b/forge-core/src/main/java/forge/util/lang/LangRussian.java
@@ -37,12 +37,8 @@ public class LangRussian extends Lang {
         return "Roboto-Bold";
     }
 
-    // Desktop (GuiUtils.newFont) uses this character to test whether font1.ttf can render
-    // the active locale's script; on failure it falls back to the system's default Swing
-    // font instead of font1.ttf. Every CJK Lang subclass already overrides this (see
-    // LangChinese/LangJapanese/LangKorean) - Russian was missing it, so font1.ttf's "can
-    // display ' '" trivially passed and desktop kept rendering Cyrillic UI text with a font
-    // that has no Cyrillic glyphs at all, leaving most non-card text unreadable there.
+    // desktop's font1.ttf-can-render-script probe (GuiUtils.newFont); unset here like
+    // the CJK langs, it silently passed and left Cyrillic UI text unreadable
     @Override
     public char canDisplayCheck() {
         return 'Р';

--- a/forge-gui-mobile/src/forge/assets/FSkinFont.java
+++ b/forge-gui-mobile/src/forge/assets/FSkinFont.java
@@ -435,7 +435,7 @@ public class FSkinFont {
         //not found generate
         if (useCjkFont && !Forge.forcedEnglishonCJKMissing) {
             String ttfName = Forge.CJK_Font;
-            FileHandle ttfFile = Gdx.files.absolute(ForgeConstants.FONTS_DIR + ttfName + ".ttf");
+            FileHandle ttfFile = resolveCjkFontFile(ttfName);
             if (ttfFile != null && ttfFile.exists()) {
                 generateFont(ttfFile, fontName, fontSize);
             }
@@ -521,13 +521,29 @@ public class FSkinFont {
         final Array<String> allCJKFonts = new Array<>();
 
         allCJKFonts.add("None");
-        final FileHandle dir = Gdx.files.absolute(ForgeConstants.FONTS_DIR);
-        for (FileHandle fontFile : dir.list()) {
-            String fontName = fontFile.name();
-            if (!fontName.endsWith(".ttf")) { continue; }
-            allCJKFonts.add(fontName.replace(".ttf", ""));
+        for (String dirPath : new String[]{ForgeConstants.FONTS_DIR, ForgeConstants.COMMON_FONTS_DIR}) {
+            final FileHandle dir = Gdx.files.absolute(dirPath);
+            for (FileHandle fontFile : dir.list()) {
+                String fontName = fontFile.name();
+                if (!fontName.endsWith(".ttf")) { continue; }
+                fontName = fontName.replace(".ttf", "");
+                if (!allCJKFonts.contains(fontName, false)) {
+                    allCJKFonts.add(fontName);
+                }
+            }
         }
 
         return allCJKFonts;
+    }
+
+    // Fonts required by a Lang (see Lang#getFontFile) are normally fetched by the user via
+    // Settings -> Files -> Download CJK Fonts into FONTS_DIR (device cache). Some languages'
+    // required font is instead already bundled with the app under COMMON_FONTS_DIR (e.g.
+    // Russian's Roboto-Bold, also used directly by CardRenderer) - no download needed, so
+    // fall back to that read-only location rather than requiring it be re-downloaded/copied.
+    public static FileHandle resolveCjkFontFile(String ttfName) {
+        FileHandle ttfFile = Gdx.files.absolute(ForgeConstants.FONTS_DIR + ttfName + ".ttf");
+        if (ttfFile.exists()) { return ttfFile; }
+        return Gdx.files.absolute(ForgeConstants.COMMON_FONTS_DIR + ttfName + ".ttf");
     }
 }

--- a/forge-gui-mobile/src/forge/assets/FSkinFont.java
+++ b/forge-gui-mobile/src/forge/assets/FSkinFont.java
@@ -3,6 +3,7 @@ package forge.assets;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
@@ -521,7 +522,13 @@ public class FSkinFont {
         final Array<String> allCJKFonts = new Array<>();
 
         allCJKFonts.add("None");
-        for (String dirPath : new String[]{ForgeConstants.FONTS_DIR, ForgeConstants.COMMON_FONTS_DIR}) {
+
+        final List<String> fonts = List.of(
+                ForgeConstants.FONTS_DIR,
+                ForgeConstants.COMMON_FONTS_DIR
+        );
+
+        for (String dirPath : fonts) {
             final FileHandle dir = Gdx.files.absolute(dirPath);
             for (FileHandle fontFile : dir.list()) {
                 String fontName = fontFile.name();

--- a/forge-gui-mobile/src/forge/assets/FSkinFont.java
+++ b/forge-gui-mobile/src/forge/assets/FSkinFont.java
@@ -543,11 +543,8 @@ public class FSkinFont {
         return allCJKFonts;
     }
 
-    // Fonts required by a Lang (see Lang#getFontFile) are normally fetched by the user via
-    // Settings -> Files -> Download CJK Fonts into FONTS_DIR (device cache). Some languages'
-    // required font is instead already bundled with the app under COMMON_FONTS_DIR (e.g.
-    // Russian's Roboto-Bold, also used directly by CardRenderer) - no download needed, so
-    // fall back to that read-only location rather than requiring it be re-downloaded/copied.
+    //fall back to COMMON_FONTS_DIR for fonts bundled with the app (e.g. Roboto-Bold for Russian),
+    //vs FONTS_DIR for user-downloaded CJK fonts
     public static FileHandle resolveCjkFontFile(String ttfName) {
         FileHandle ttfFile = Gdx.files.absolute(ForgeConstants.FONTS_DIR + ttfName + ".ttf");
         if (ttfFile.exists()) { return ttfFile; }

--- a/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
@@ -71,11 +71,20 @@ public class SettingsPage extends TabPage<SettingsScreen> {
                 ForgePreferences prefs = FModel.getPreferences();
                 if (prefs.getPref(FPref.UI_CJK_FONT).isEmpty()) {
                     Lang lang = Lang.initInstance(newValue);
-                    if (lang.getFontFile() != null) {
-                        String message = "Please download CJK font (from \"Files\"), and set it before change language.";
-                        message += "\nPlease use \"" + lang.getFontFile() + "\".";
-                        FOptionPane.showMessageDialog(message, "Please set CJK Font");
-                        return;
+                    String requiredFont = lang.getFontFile();
+                    if (requiredFont != null) {
+                        // some languages' required font ships bundled with the app (see
+                        // FSkinFont#resolveCjkFontFile) and needs no user download - apply it
+                        // automatically instead of blocking the language switch
+                        if (FSkinFont.resolveCjkFontFile(requiredFont).exists()) {
+                            prefs.setPref(FPref.UI_CJK_FONT, requiredFont);
+                            prefs.save();
+                        } else {
+                            String message = "Please download CJK font (from \"Files\"), and set it before change language.";
+                            message += "\nPlease use \"" + requiredFont + "\".";
+                            FOptionPane.showMessageDialog(message, "Please set CJK Font");
+                            return;
+                        }
                     }
                 }
 

--- a/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
@@ -73,9 +73,7 @@ public class SettingsPage extends TabPage<SettingsScreen> {
                     Lang lang = Lang.initInstance(newValue);
                     String requiredFont = lang.getFontFile();
                     if (requiredFont != null) {
-                        // some languages' required font ships bundled with the app (see
-                        // FSkinFont#resolveCjkFontFile) and needs no user download - apply it
-                        // automatically instead of blocking the language switch
+                        //bundled fonts (e.g. Russian) need no download, apply directly
                         if (FSkinFont.resolveCjkFontFile(requiredFont).exists()) {
                             prefs.setPref(FPref.UI_CJK_FONT, requiredFont);
                             prefs.save();


### PR DESCRIPTION
#11375 merged Russian support, but it doesn't actually work:

- **Android/iOS**: switching to Russian is blocked by a "please download CJK font" prompt with
  nothing to download - the required font (`Roboto-Bold`) isn't in the downloadable list, even
  though it already ships with the app.
- **Desktop**: the switch succeeds, but nearly all UI text (menus/buttons/labels) renders as
  tofu - the desktop skin's base font has no Cyrillic glyphs, and Russian never wired up the
  font-fallback check that Chinese/Japanese/Korean already use for this exact situation.

Two independent commits, one per platform - see commit messages for full root-cause detail.

### Fix

- `FSkinFont` / `SettingsPage` (mobile): resolve the required font from the app's own bundled
  assets instead of only the downloaded-fonts cache, and auto-apply it instead of blocking.
- `LangRussian` (desktop): add `canDisplayCheck()` so the existing font-fallback mechanism
  (already used by zh/ja/ko) fires for Russian too.

### Test plan

- [x] Builds clean (Android + Desktop via Maven).
- [x] Android 17 (API 37), clean-room install: Russian applies immediately, no font prompt.
- [x] Windows desktop: confirmed broken before commit 2 (tofu outside card text), fixed after,
  including in a live match.
- [ ] Not verified on iOS (no device/build environment available).

---

Note: this contribution was substantially coded with the assistance of Claude Code (Anthropic).