### PR TITLE
Speed up simulation AI evaluation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiDeckStatistics.java
+++ b/forge-ai/src/main/java/forge/ai/AiDeckStatistics.java
@@ -117,7 +117,11 @@ public class AiDeckStatistics {
             return fromCards(cardlist);
         }
 
-        return fromDeck(deck, player);
+        // These statistics are a pure function of the decklist, which doesn't change during a game.
+        // Simulation copies share the same Deck instance (see GameCopier.clonePlayer), so caching on
+        // it also avoids rebuilding every card of the deck for each simulated state that gets scored.
+        return AiCache.getCached("aiDeckStatistics", () -> fromDeck(deck, player),
+                List.of(AiCache::identity), deck);
     }
 
 }

--- a/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
@@ -27,6 +27,20 @@ public class GameSimulator {
     private Score origScore;
     private SpellAbilityChoicesIterator interceptor;
 
+    // Verifying that the copied game scores identically to the original costs a second full
+    // evaluation (with debug string building enabled) for every simulator that gets constructed.
+    // That's worth paying for in development and in the test suite, where a game copy bug should
+    // fail loudly, but not in a shipped game where it only slows the AI down. Assertions are
+    // enabled by Maven Surefire, so the check still runs for every test.
+    private static final boolean CHECK_GAME_COPY_SCORE = areAssertionsEnabled();
+
+    @SuppressWarnings("AssertWithSideEffects")
+    private static boolean areAssertionsEnabled() {
+        boolean enabled = false;
+        assert enabled = true;
+        return enabled;
+    }
+
     public GameSimulator(SimulationController controller, Game origGame, Player origAiPlayer, PhaseType advanceToPhase) {
         this.controller = controller;
         copier = new GameCopier(origGame);
@@ -41,7 +55,7 @@ public class GameSimulator {
         debugPrint = false;
         origScore = eval.getScoreForGameState(origGame, origAiPlayer);
 
-        if (advanceToPhase == null) {
+        if (advanceToPhase == null && CHECK_GAME_COPY_SCORE) {
             ensureGameCopyScoreMatches(origGame, origAiPlayer);
         }
 


### PR DESCRIPTION
Two changes to the cost of scoring a game state in the simulation AI. Neither
changes which move the AI picks.

**Cache `AiDeckStatistics` instead of rebuilding the deck per evaluation**

`GameStateEvaluator.getScoreForGameStateImpl` calls `AiDeckStatistics.fromPlayer`
on every scored state to feed `evalManaBase`. For a player with a registered deck
that goes through `fromDeck`, which calls `Card.fromPaperCard` for every card in
the decklist, so scoring one state rebuilt ~60-100 `Card` objects.

The statistics only depend on the decklist (CMC, colour pips, land count), which
does not change during a game. Simulation copies share the same `Deck` instance
(`GameCopier.clonePlayer` passes `p.getDeck()` straight through), so keying the
existing `AiCache` on the deck also hits for every simulated state rather than
just the root one.

Measured on a 60-card deck with a small board, averaged over 2000 calls:

| | before | after |
|---|---|---|
| `AiDeckStatistics.fromPlayer` | 0.1513 ms | 0.0030 ms |

That took it from ~10% of a `GameStateEvaluator` evaluation to ~0.2%.

The empty-deck path used by tests derives stats from the player's current cards,
which *do* change during a game, so it is deliberately left uncached. `AiCache`
is already cleared once per AI decision in `AiController.chooseSpellAbilityToPlay`.

**Only verify the game copy score when assertions are enabled**

`GameSimulator`'s constructor called `ensureGameCopyScoreMatches` on every
simulator built with no target phase. That re-scores the copied game with the
evaluator's debug mode switched on, so it costs a second full evaluation plus the
debug string building it implies, purely to assert the copy is faithful.

It is a developer self-check rather than gameplay logic, so it is now gated on
assertions being enabled. Maven Surefire enables assertions by default (verified
with a probe test), so every test still exercises the check and a game copy bug
still fails loudly in CI, while shipped builds skip the duplicated work.

Verified: forge.ai.** test suite, 245 tests, 0 failures. Full `mvn -U -B clean test`
across all 12 modules passes.

---
Written with the help of GitHub Copilot CLI; the commits carry a `Co-authored-by`
trailer for it.
