### PR TITLE
Stop the AI paying real costs for abilities that do nothing

### DIFF
--- a/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
@@ -34,7 +34,7 @@ public enum SpellApiToAi {
             .put(ApiType.AssembleContraption, AssembleContraptionAi.class)
             .put(ApiType.AssignGroup, AssignGroupAi.class)
             .put(ApiType.Balance, BalanceAi.class)
-            .put(ApiType.BecomeMonarch, AlwaysPlayAi.class)
+            .put(ApiType.BecomeMonarch, BecomeMonarchAi.class)
             .put(ApiType.BecomesBlocked, BecomesBlockedAi.class)
             .put(ApiType.BidLife, BidLifeAi.class)
             .put(ApiType.BlankLine, AlwaysPlayAi.class)

--- a/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
@@ -201,7 +201,7 @@ public enum SpellApiToAi {
             .put(ApiType.Token, TokenAi.class)
             .put(ApiType.TwoPiles, TwoPilesAi.class)
             .put(ApiType.Unattach, UnattachAi.class)
-            .put(ApiType.UnlockDoor, AlwaysPlayAi.class)
+            .put(ApiType.UnlockDoor, UnlockDoorAi.class)
             .put(ApiType.Untap, UntapAi.class)
             .put(ApiType.UntapAll, UntapAllAi.class)
             .put(ApiType.Venture, VentureAi.class)

--- a/forge-ai/src/main/java/forge/ai/ability/BecomeMonarchAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BecomeMonarchAi.java
@@ -1,0 +1,60 @@
+package forge.ai.ability;
+
+import java.util.Map;
+
+import forge.ai.AiAbilityDecision;
+import forge.ai.AiPlayDecision;
+import forge.ai.SpellAbilityAi;
+import forge.game.ability.AbilityUtils;
+import forge.game.player.Player;
+import forge.game.player.PlayerActionConfirmMode;
+import forge.game.spellability.SpellAbility;
+
+/**
+ * GameAction.becomeMonarch returns immediately when the chosen player is already the monarch, so
+ * an ability that would only crown the current monarch again does nothing at all. Cards such as
+ * Throne of the High City and King Solomon's Frogs sacrifice or exile themselves as part of the
+ * cost, so activating one redundantly throws a permanent away for no effect.
+ */
+public class BecomeMonarchAi extends SpellAbilityAi {
+
+    @Override
+    protected AiAbilityDecision canPlay(Player aiPlayer, SpellAbility sa) {
+        if (changesNothing(aiPlayer, sa)) {
+            return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+        }
+        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+    }
+
+    @Override
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message,
+            Map<String, Object> params) {
+        return !changesNothing(player, sa);
+    }
+
+    /**
+     * True only when every player the ability would crown is already the monarch. Targeted
+     * abilities are left alone, since some of them deliberately hand the crown to an opponent to
+     * enable another effect on the same card.
+     */
+    private static boolean changesNothing(Player aiPlayer, SpellAbility sa) {
+        if (sa.usesTargeting()) {
+            return false;
+        }
+        final Player monarch = aiPlayer.getGame().getMonarch();
+        if (monarch == null) {
+            return false;
+        }
+        boolean anyAffected = false;
+        // mirrors how SpellAbilityEffect resolves "Defined" for this effect
+        for (String def : sa.getParamOrDefault("Defined", "You").split(" & ")) {
+            for (Player p : AbilityUtils.getDefinedPlayers(sa.getHostCard(), def, sa)) {
+                anyAffected = true;
+                if (!monarch.equals(p)) {
+                    return false;
+                }
+            }
+        }
+        return anyAffected;
+    }
+}

--- a/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
@@ -1,0 +1,86 @@
+package forge.ai.ability;
+
+import java.util.List;
+import java.util.Map;
+
+import forge.ai.AiAbilityDecision;
+import forge.ai.AiPlayDecision;
+import forge.ai.SpellAbilityAi;
+import forge.game.card.Card;
+import forge.game.card.CardCollection;
+import forge.game.card.CardState;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+/**
+ * "Lock or unlock a door of target Room you control" can only ever lock when every door of the
+ * chosen Room is already unlocked (see the Mode$ LockOrUnlock / case 0 branch of
+ * UnlockDoorEffect), so pointing it at a fully unlocked Room shuts off one of your own Rooms.
+ * Keys to the House pays {3}, taps and sacrifices itself for that ability, so doing it for nothing
+ * also throws away a permanent.
+ */
+public class UnlockDoorAi extends SpellAbilityAi {
+
+    @Override
+    protected AiAbilityDecision canPlay(Player aiPlayer, SpellAbility sa) {
+        if (!isLockOrUnlock(sa)) {
+            // Unlock / ThisDoor can only open doors, which is always what we want
+            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+        }
+
+        if (sa.usesTargeting()) {
+            CardCollection targets = new CardCollection();
+            for (Card c : aiPlayer.getGame().getCardsIn(ZoneType.Battlefield)) {
+                if (sa.canTarget(c) && hasLockedDoor(c)) {
+                    targets.add(c);
+                }
+            }
+            if (targets.isEmpty()) {
+                // every Room we could point at is already fully unlocked
+                return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+            }
+            sa.resetTargets();
+            sa.getTargets().add(targets.getFirst());
+            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+        }
+
+        for (Card c : forge.game.ability.AbilityUtils.getDefinedCards(sa.getHostCard(),
+                sa.getParamOrDefault("Defined", "Self"), sa)) {
+            if (hasLockedDoor(c)) {
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
+        }
+        return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+    }
+
+    /**
+     * With one door locked the effect offers both doors and locks whichever one is still open, so
+     * pick the locked door to make sure the ability opens a Room instead of closing one.
+     */
+    @Override
+    public CardState chooseCardState(Player ai, SpellAbility sa, List<CardState> faces,
+            Map<String, Object> params) {
+        if (isLockOrUnlock(sa) && params != null && params.get("Object") instanceof Card room) {
+            for (CardState state : faces) {
+                if (room.getLockedRooms().contains(state.getStateName())) {
+                    return state;
+                }
+            }
+        }
+        return faces.isEmpty() ? null : faces.get(0);
+    }
+
+    private static boolean isLockOrUnlock(SpellAbility sa) {
+        return "LockOrUnlock".equals(sa.getParamOrDefault("Mode", "ThisDoor"));
+    }
+
+    private static boolean hasLockedDoor(Card c) {
+        for (var stateName : c.getLockedRooms()) {
+            if (c.hasState(stateName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/BecomeMonarchAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/BecomeMonarchAiTest.java
@@ -1,0 +1,71 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.player.Player;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class BecomeMonarchAiTest extends AITest {
+
+    /**
+     * Throne of the High City sacrifices itself to make you the monarch. Becoming the monarch while
+     * already the monarch does nothing (GameAction.becomeMonarch returns early), so the AI must not
+     * throw the land away for no effect.
+     */
+    @Test
+    public void doesNotCrownItselfTwice() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Throne of the High City", ai);
+        for (int i = 0; i < 4; i++) {
+            addCard("Swamp", ai);
+        }
+        game.getAction().becomeMonarch(ai, null);
+        AssertJUnit.assertEquals(ai, game.getMonarch());
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("AI should still be the monarch", ai, game.getMonarch());
+        AssertJUnit.assertEquals("Throne of the High City should not have been sacrificed", 1,
+                countCardsWithName(game, "Throne of the High City"));
+    }
+
+    /** When somebody else holds the crown the ability is worth activating. */
+    @Test
+    public void takesTheCrownFromAnOpponent() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCard("Throne of the High City", ai);
+        for (int i = 0; i < 4; i++) {
+            addCard("Swamp", ai);
+        }
+        game.getAction().becomeMonarch(opponent, null);
+        AssertJUnit.assertEquals(opponent, game.getMonarch());
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("AI should have taken the crown", ai, game.getMonarch());
+    }
+
+    /** With no monarch at all the ability is still worth activating. */
+    @Test
+    public void claimsAnUnclaimedCrown() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Throne of the High City", ai);
+        for (int i = 0; i < 4; i++) {
+            addCard("Swamp", ai);
+        }
+        AssertJUnit.assertNull(game.getMonarch());
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("AI should have become the monarch", ai, game.getMonarch());
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
@@ -1,0 +1,66 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.card.CardStateName;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class UnlockDoorAiTest extends AITest {
+
+    private Card addRoom(Game game, Player p) {
+        return addCard("Bottomless Pool", p);
+    }
+
+    /**
+     * Keys to the House pays {3}, taps and sacrifices itself to "lock or unlock a door of target
+     * Room you control". When every door of the Room is already unlocked the effect can only lock
+     * one, so activating it throws the artifact away to shut off the AI's own Room.
+     */
+    @Test
+    public void doesNotSacrificeItselfJustToLockItsOwnRoom() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card room = addRoom(game, ai);
+        room.setUnlockedRooms(java.util.EnumSet.of(CardStateName.LeftSplit, CardStateName.RightSplit));
+
+        addCard("Keys to the House", ai);
+        for (int i = 0; i < 5; i++) {
+            addCard("Island", ai);
+        }
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("Keys to the House should not have been sacrificed", 1,
+                countCardsWithName(game, "Keys to the House"));
+        AssertJUnit.assertTrue("Both doors should still be unlocked",
+                room.getUnlockedRooms().containsAll(
+                        java.util.EnumSet.of(CardStateName.LeftSplit, CardStateName.RightSplit)));
+    }
+
+    /** With a door still locked the ability is worth its cost, so the AI should use it. */
+    @Test
+    public void unlocksARoomWhenADoorIsStillLocked() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card room = addRoom(game, ai);
+        room.setUnlockedRooms(java.util.EnumSet.of(CardStateName.LeftSplit));
+
+        addCard("Keys to the House", ai);
+        for (int i = 0; i < 5; i++) {
+            addCard("Island", ai);
+        }
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertTrue("AI should have unlocked the remaining door, not locked the open one",
+                room.getUnlockedRooms().contains(CardStateName.RightSplit));
+    }
+}


### PR DESCRIPTION
Two abilities were mapped to `AlwaysPlayAi`, whose entire logic is
`return WillPlay` with no look at the board. In both cases the engine can resolve
the ability to a no-op (or worse), while the activation cost sacrifices a permanent.

**Monarch**

`GameAction.becomeMonarch` returns immediately when the chosen player is already
the monarch, so activating one of these abilities while holding the crown does
nothing. Throne of the High City taps and sacrifices itself for {4}, King
Solomon's Frogs exiles itself, and Tchaka, Venerable King exiles itself from the
graveyard, so the AI was throwing a permanent away for no effect. With the old
mapping the added test shows Throne of the High City going from one copy on the
battlefield to zero.

`BecomeMonarchAi` declines only when every player the ability would crown is
already the monarch. Targeted versions are deliberately left alone: cards like
Jared Carthalion, True Heir and Garland, Royal Kidnapper hand the crown to an
opponent on purpose to turn on another ability.

Initiative is intentionally not changed - `GameAction.takeInitiative` documents
that "You can take the initiative even if you already have it" and still runs the
trigger, so always-play is correct there.

**Rooms**

`UnlockDoor` with `Mode$ LockOrUnlock` is wrong in two ways. When every door of
the targeted Room is already unlocked, `UnlockDoorEffect`'s `case 0` branch can
only call `lockRoom`, so the ability shuts off one of the AI's own Rooms. Keys to
the House pays {3}, taps and sacrifices itself for that ability.

When exactly one door is locked, the effect offers both doors and locks the one
that is still open. That choice went through `SpellAbilityAi.chooseCardState`,
whose base implementation prints a "default implementation is used" warning and
returns the first element, so which door the AI got was down to state ordering.

`UnlockDoorAi` declines when no reachable Room has a locked door, and picks a
locked door when asked to choose. `Mode$ Unlock` and `Mode$ ThisDoor` can only
ever unlock, so they keep the previous behaviour. Affects Keys to the House and
Marina Vendrell.

Each fix comes with a test that fails on the old mapping.

Verified: forge.ai.** test suite, 251 tests, 0 failures. Full `mvn -U -B clean test`
across all 12 modules passes.

---
Written with the help of GitHub Copilot CLI; the commits carry a `Co-authored-by`
trailer for it.
