### PR TITLE
Allow sim mode to give each player a different AI profile

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
+++ b/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.time.StopWatch;
 
 import forge.LobbyPlayer;
+import forge.ai.AiProfileUtil;
 import forge.deck.Deck;
 import forge.deck.DeckGroup;
 import forge.deck.io.DeckSerializer;
@@ -111,6 +112,20 @@ public class SimulateMatch {
 
         int i = 1;
 
+        // Optional AI profile per player, in the same order as the decks. Lets a run pit one set of
+        // AI settings against another, which is the only way to tell from the results whether an AI
+        // change actually helped.
+        List<String> aiProfiles = params.get("a");
+        if (aiProfiles != null) {
+            for (String profile : aiProfiles) {
+                if (!AiProfileUtil.getProfilesDisplayList().contains(profile)) {
+                    System.out.println(TextUtil.concatNoSpace("Unknown AI profile - ", profile,
+                            ". Available profiles: ", String.join(", ", AiProfileUtil.getProfilesDisplayList())));
+                    return;
+                }
+            }
+        }
+
         if (params.containsKey("d")) {
             for (String deck : params.get("d")) {
                 Deck d = deckFromCommandLineParameter(deck, type);
@@ -121,8 +136,12 @@ public class SimulateMatch {
                 if (i > 1) {
                     sb.append(" vs ");
                 }
+                String profile = aiProfiles != null && aiProfiles.size() >= i ? aiProfiles.get(i - 1) : "";
                 String name = TextUtil.concatNoSpace("Ai(", String.valueOf(i), ")-", d.getName());
                 sb.append(name);
+                if (!profile.isEmpty()) {
+                    sb.append(" [").append(profile).append("]");
+                }
 
                 RegisteredPlayer rp;
 
@@ -131,7 +150,7 @@ public class SimulateMatch {
                 } else {
                     rp = new RegisteredPlayer(d);
                 }
-                rp.setPlayer(GamePlayerUtil.createAiPlayer(name, i - 1));
+                rp.setPlayer(GamePlayerUtil.createAiPlayer(name, i - 1, profile));
                 pp.add(rp);
                 i++;
             }
@@ -167,7 +186,7 @@ public class SimulateMatch {
     }
 
     private static void argumentHelp() {
-        System.out.println("Syntax: forge.exe sim -d <deck1[.dck]> ... <deckX[.dck]> -D [D] -n [N] -m [M] -t [T] -p [P] -f [F] -s [S] -q");
+        System.out.println("Syntax: forge.exe sim -d <deck1[.dck]> ... <deckX[.dck]> -D [D] -n [N] -m [M] -t [T] -p [P] -f [F] -s [S] -a [A] -q");
         System.out.println("\tsim - stands for simulation mode");
         System.out.println("\tdeck1 (or deck2,...,X) - constructed deck name or filename (has to be quoted when contains multiple words)");
         System.out.println("\tdeck is treated as file if it ends with a dot followed by three numbers or letters");
@@ -178,6 +197,7 @@ public class SimulateMatch {
         System.out.println("\tP - Amount of players per match (used only with Tournaments, defaults to 2)");
         System.out.println("\tF - format of games, defaults to constructed");
         System.out.println("\tS - RNG seed for simulation");
+        System.out.println("\tA - AI profile per player, in the same order as the decks (e.g. -a Default Experimental)");
         System.out.println("\tc - Clock flag. Set the maximum time in seconds before calling the match a draw, defaults to 120.");
         System.out.println("\tq - Quiet flag. Output just the game result, not the entire game log.");
     }

--- a/forge-gui/src/main/java/forge/player/GamePlayerUtil.java
+++ b/forge-gui/src/main/java/forge/player/GamePlayerUtil.java
@@ -57,8 +57,11 @@ public final class GamePlayerUtil {
         return createAiPlayer(name, avatarCount == 0 ? 0 : MyRandom.getRandom().nextInt(avatarCount), sleeveCount == 0 ? 0 : MyRandom.getRandom().nextInt(sleeveCount), null, profileOverride);
     }
     public static LobbyPlayer createAiPlayer(final String name, final int avatarIndex) {
+        return createAiPlayer(name, avatarIndex, "");
+    }
+    public static LobbyPlayer createAiPlayer(final String name, final int avatarIndex, final String profileOverride) {
         final int sleeveCount = GuiBase.getInterface().getSleevesCount();
-        return createAiPlayer(name, avatarIndex, sleeveCount == 0 ? 0 : MyRandom.getRandom().nextInt(sleeveCount), null, "");
+        return createAiPlayer(name, avatarIndex, sleeveCount == 0 ? 0 : MyRandom.getRandom().nextInt(sleeveCount), null, profileOverride);
     }
     public static LobbyPlayer createAiPlayer(final String name, final int avatarIndex, final int sleeveIndex) {
         return createAiPlayer(name, avatarIndex, sleeveIndex, null, "");


### PR DESCRIPTION
Both seats in a simulated match were built with
`GamePlayerUtil.createAiPlayer(name, avatarIndex)`, which always resolves to the
AI profile stored in preferences. That makes it impossible to tell from a `sim`
run whether an AI change helped, because every result is one build playing
itself and any win rate just measures the decks.

This adds `-a`, taking one profile name per player in the same order as the decks:

```
forge.jar sim -d deckA.dck deckB.dck -n 200 -a Cautious Reckless -q
```

Unknown names are rejected up front with the list of available profiles rather
than silently falling back to the preferences profile. The match banner shows the
profile per seat.

`GamePlayerUtil` gains a `createAiPlayer(name, avatarIndex, profileOverride)`
overload and the existing two-argument version delegates to it with an empty
override, so it consumes the random sleeve index exactly as before. Runs without
`-a` are unchanged: re-running seed 12345 across four games produced identical
winners before and after.

This makes it possible to A/B an AI change by gating the new behaviour behind an
AI profile property in `res/ai/*.ai` and running the two profiles against each
other over the same decks and seeds.

Verified: forge.ai.** test suite, 245 tests, 0 failures. Full `mvn -U -B clean test`
across all 12 modules passes.

---
Written with the help of GitHub Copilot CLI; the commits carry a `Co-authored-by`
trailer for it.
