### PR TITLE
Make the random attack-into-trade check match its documented behaviour

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -1239,10 +1239,15 @@ public class AiAttackController {
                 && ComputerUtil.countUsefulCreatures(ai) > ComputerUtil.countUsefulCreatures(defendingOpponent)
                 && ai.getLife() > defendingOpponent.getLife()
                 && !ComputerUtilCombat.lifeInDanger(ai, combat) // this isn't really doing anything unless the attacking player in combat isn't the AI (which currently isn't used like that)
-                && (ComputerUtilMana.getAvailableManaEstimate(ai) > 0) || tradeIfTappedOut
-                && (ComputerUtilMana.getAvailableManaEstimate(defendingOpponent) == 0) || MyRandom.percentTrue(extraChanceIfOppHasMana)
+                // our own mana: ATTACK_INTO_TRADE_WHEN_TAPPED_OUT lets us swing while tapped out,
+                // otherwise we want mana open so we can bluff or use a trick
+                && (ComputerUtilMana.getAvailableManaEstimate(ai) > 0 || tradeIfTappedOut)
+                // the opponent's mana: safe when they're tapped out, otherwise take the extra roll
+                // for the risk of walking into a trick
+                && (ComputerUtilMana.getAvailableManaEstimate(defendingOpponent) == 0
+                        || MyRandom.percentTrue(extraChanceIfOppHasMana))
                 && (!tradeIfLowerLifePressure || (ai.getLifeLostLastTurn() + ai.getLifeLostThisTurn() <
-                defendingOpponent.getLifeLostThisTurn() + defendingOpponent.getLifeLostThisTurn()))) {
+                defendingOpponent.getLifeLostLastTurn() + defendingOpponent.getLifeLostThisTurn()))) {
             aiAggression = 4; // random (chance-based) attack expecting to trade or damage player.
         } else if (ratioDiff >= 0 && this.attackers.size() > 1) {
             aiAggression = 3; // attack expecting to make good trades or damage player.


### PR DESCRIPTION
The "random (chance-based) attack expecting to trade" branch in `AiAttackController` mixes `&&` and `||` without parentheses, so it does not parse the way the AI profile documentation describes it. Java binds `&&` tighter than `||`, so the condition is really three independent alternatives:

1. `percentTrue(CHANCE_TO_ATTACK_INTO_TRADE)` && *all the safety checks* && AI has mana open
2. `ATTACK_INTO_TRADE_WHEN_TAPPED_OUT` && opponent is tapped out
3. `percentTrue(CHANCE_TO_ATKTRADE_WHEN_OPP_HAS_MANA)` && *life pressure check*

Only the first alternative contains the guards that make this branch safe — more useful creatures than the opponent, a higher life total, and `!lifeInDanger`. Alternatives 2 and 3 can each select "attack expecting to trade" on their own, with **none** of those guards applied.

## Why the grouping in this PR is the intended one

`res/ai/Default.ai` documents `CHANCE_TO_ATKTRADE_WHEN_OPP_HAS_MANA` as a chance that

> "is rolled separately **after** `CHANCE_TO_ATTACK_INTO_TRADE` has already succeeded"

which the current parse does not do — alternative 3 fires without the base chance succeeding at all. It also documents `ATTACK_INTO_TRADE_WHEN_TAPPED_OUT` as controlling whether the AI needs mana open ("the non-aggro AI will only attack into trades when it has mana open, thus having a chance to bluff"). Both descriptions only make sense if the three are the same mana-related condition rather than three separate ways into the branch, so this PR groups them that way: the base chance and safety checks always apply, then our own mana state, then the opponent's.

## Effect on the shipped profiles

- `Default`, `Cautious` and `Experimental` all set `CHANCE_TO_ATTACK_INTO_TRADE=0`, which reads as "never take this branch". Alternative 3 still fires it on a 30% roll for `Default` and `Experimental`.
- `Reckless` sets `CHANCE_TO_ATKTRADE_WHEN_OPP_HAS_MANA=100` **and** `RANDOMLY_ATKTRADE_ONLY_ON_LOWER_LIFE_PRESSURE=false`, which makes alternative 3 unconditionally true, so the branch is taken every time regardless of the board.

## Second fix

The life pressure comparison added the opponent's `getLifeLostThisTurn()` to itself instead of pairing it with `getLifeLostLastTurn()`, which is what the AI's own side of the comparison does.

## Measurement

I could not write a unit test that pins this. Reaching the branch needs a loaded AI profile with a non-zero `CHANCE_TO_ATKTRADE_WHEN_OPP_HAS_MANA` (the `AiProps` enum default is `0`, so `percentTrue(0)` is always false in a bare test), plus a board that falls through the earlier rungs of the aggression ladder. Rather than add a test that passes for the wrong reason, I measured with `sim` instead.

Ran the same six archetype decks, same pairings, same seeds, against a build with and without the change — `Reckless` vs `Cautious`, 40 games per pairing, 1200 games total:

| build | seat 1 (`Reckless`) | seat 2 (`Cautious`) | seat 1 win rate |
|---|---|---|---|
| before | 305 | 288 | 51.4% |
| after | 296 | 297 | 49.9% |

The confidence intervals overlap, so **this is a correctness fix rather than a strength improvement**. It is not a regression, but I make no claim that it makes the AI play better. (An earlier 150-game run showed +5.7pp for the change; that did not survive the larger sample and was noise. Reporting it for completeness.)

`forge.ai.**` test suite: 245 tests, 0 failures. Full `mvn -U -B clean test` across all 12 modules passes.

---
Written with the help of GitHub Copilot CLI; the commit carries a `Co-authored-by` trailer for it.
