### PR TITLE
Stop the AI crowning itself when it is already the monarch

### DIFF
--- a/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
@@ -34,7 +34,7 @@ public enum SpellApiToAi {
             .put(ApiType.AssembleContraption, AssembleContraptionAi.class)
             .put(ApiType.AssignGroup, AssignGroupAi.class)
             .put(ApiType.Balance, BalanceAi.class)
-            .put(ApiType.BecomeMonarch, AlwaysPlayAi.class)
+            .put(ApiType.BecomeMonarch, BecomeMonarchAi.class)
             .put(ApiType.BecomesBlocked, BecomesBlockedAi.class)
             .put(ApiType.BidLife, BidLifeAi.class)
             .put(ApiType.BlankLine, AlwaysPlayAi.class)

--- a/forge-ai/src/main/java/forge/ai/ability/BecomeMonarchAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BecomeMonarchAi.java
@@ -1,0 +1,60 @@
+package forge.ai.ability;
+
+import java.util.Map;
+
+import forge.ai.AiAbilityDecision;
+import forge.ai.AiPlayDecision;
+import forge.ai.SpellAbilityAi;
+import forge.game.ability.AbilityUtils;
+import forge.game.player.Player;
+import forge.game.player.PlayerActionConfirmMode;
+import forge.game.spellability.SpellAbility;
+
+/**
+ * GameAction.becomeMonarch returns immediately when the chosen player is already the monarch, so
+ * an ability that would only crown the current monarch again does nothing at all. Cards such as
+ * Throne of the High City and King Solomon's Frogs sacrifice or exile themselves as part of the
+ * cost, so activating one redundantly throws a permanent away for no effect.
+ */
+public class BecomeMonarchAi extends SpellAbilityAi {
+
+    @Override
+    protected AiAbilityDecision canPlay(Player aiPlayer, SpellAbility sa) {
+        if (changesNothing(aiPlayer, sa)) {
+            return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+        }
+        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+    }
+
+    @Override
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message,
+            Map<String, Object> params) {
+        return !changesNothing(player, sa);
+    }
+
+    /**
+     * True only when every player the ability would crown is already the monarch. Targeted
+     * abilities are left alone, since some of them deliberately hand the crown to an opponent to
+     * enable another effect on the same card.
+     */
+    private static boolean changesNothing(Player aiPlayer, SpellAbility sa) {
+        if (sa.usesTargeting()) {
+            return false;
+        }
+        final Player monarch = aiPlayer.getGame().getMonarch();
+        if (monarch == null) {
+            return false;
+        }
+        boolean anyAffected = false;
+        // mirrors how SpellAbilityEffect resolves "Defined" for this effect
+        for (String def : sa.getParamOrDefault("Defined", "You").split(" & ")) {
+            for (Player p : AbilityUtils.getDefinedPlayers(sa.getHostCard(), def, sa)) {
+                anyAffected = true;
+                if (!monarch.equals(p)) {
+                    return false;
+                }
+            }
+        }
+        return anyAffected;
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/BecomeMonarchAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/BecomeMonarchAiTest.java
@@ -1,0 +1,71 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.player.Player;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class BecomeMonarchAiTest extends AITest {
+
+    /**
+     * Throne of the High City sacrifices itself to make you the monarch. Becoming the monarch while
+     * already the monarch does nothing (GameAction.becomeMonarch returns early), so the AI must not
+     * throw the land away for no effect.
+     */
+    @Test
+    public void doesNotCrownItselfTwice() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Throne of the High City", ai);
+        for (int i = 0; i < 4; i++) {
+            addCard("Swamp", ai);
+        }
+        game.getAction().becomeMonarch(ai, null);
+        AssertJUnit.assertEquals(ai, game.getMonarch());
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("AI should still be the monarch", ai, game.getMonarch());
+        AssertJUnit.assertEquals("Throne of the High City should not have been sacrificed", 1,
+                countCardsWithName(game, "Throne of the High City"));
+    }
+
+    /** When somebody else holds the crown the ability is worth activating. */
+    @Test
+    public void takesTheCrownFromAnOpponent() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCard("Throne of the High City", ai);
+        for (int i = 0; i < 4; i++) {
+            addCard("Swamp", ai);
+        }
+        game.getAction().becomeMonarch(opponent, null);
+        AssertJUnit.assertEquals(opponent, game.getMonarch());
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("AI should have taken the crown", ai, game.getMonarch());
+    }
+
+    /** With no monarch at all the ability is still worth activating. */
+    @Test
+    public void claimsAnUnclaimedCrown() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Throne of the High City", ai);
+        for (int i = 0; i < 4; i++) {
+            addCard("Swamp", ai);
+        }
+        AssertJUnit.assertNull(game.getMonarch());
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("AI should have become the monarch", ai, game.getMonarch());
+    }
+}


### PR DESCRIPTION
`BecomeMonarch` is mapped to `AlwaysPlayAi`, whose entire logic is `return WillPlay` — it never looks at the board.

`GameAction.becomeMonarch` returns immediately when the chosen player is already the monarch:

```java
public void becomeMonarch(final Player p, final String set) {
    final Player previous = game.getMonarch();
    if (p == null || p.equals(previous)) {
        return;
    }
    ...
```

So activating one of these abilities while already holding the crown does nothing at all.

That is not merely a wasted activation, because several of these abilities cost a permanent:

| card | cost |
|---|---|
| Throne of the High City | `{4}, {T}, Sacrifice` |
| King Solomon's Frogs | `{3}, {T}, Exile` |
| Tchaka, Venerable King | `{3}, Exile from graveyard` |

The AI was throwing a permanent away for no effect. The added test shows Throne of the High City going from one copy on the battlefield to zero under the old mapping.

## The fix

`BecomeMonarchAi` declines only when **every** player the ability would crown is already the monarch.

Targeted versions are deliberately left alone. Cards like Jared Carthalion, True Heir and Garland, Royal Kidnapper hand the crown to an *opponent* on purpose in order to turn on another ability, so always-play is still right for them.

## Initiative is intentionally not changed

The initiative mechanic looks identical but is not. `GameAction.takeInitiative` explicitly documents:

```java
// You can take the initiative even if you already have it
```

and still runs the `TakesInitiative` trigger in that case, so `AlwaysPlayAi` remains correct for `TakeInitiative`.

## Verification

Three tests, each of which fails on the old mapping or covers a case that must keep working:

- `doesNotCrownItselfTwice` — the regression; fails with `expected:<1> but was:<0>` without the fix
- `takesTheCrownFromAnOpponent` — still activates when an opponent holds the crown
- `claimsAnUnclaimedCrown` — still activates when nobody is the monarch

`forge.ai.**` test suite: 248 tests, 0 failures. Full `mvn -U -B clean test` across all 12 modules passes.

---
*This PR was previously part of #11441, which bundled it with an unrelated `UnlockDoor` fix. Split out so each can be reviewed on its own.*

Written with the help of GitHub Copilot CLI; the commit carries a `Co-authored-by` trailer for it.
