### PR TITLE
Stop the AI locking its own Room for no reason

### DIFF
--- a/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
@@ -201,7 +201,7 @@ public enum SpellApiToAi {
             .put(ApiType.Token, TokenAi.class)
             .put(ApiType.TwoPiles, TwoPilesAi.class)
             .put(ApiType.Unattach, UnattachAi.class)
-            .put(ApiType.UnlockDoor, AlwaysPlayAi.class)
+            .put(ApiType.UnlockDoor, UnlockDoorAi.class)
             .put(ApiType.Untap, UntapAi.class)
             .put(ApiType.UntapAll, UntapAllAi.class)
             .put(ApiType.Venture, VentureAi.class)

--- a/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
@@ -64,59 +64,66 @@ public class UnlockDoorAi extends SpellAbilityAi {
     /**
      * With one door locked the effect offers both doors and locks whichever one is still open, so
      * pick a locked door to make sure the ability opens a Room instead of closing one. Where more
-     * than one door is locked, prefer one whose face has an unlock trigger to run.
+     * than one door is locked, open the most useful one.
      */
     @Override
     public CardState chooseCardState(Player ai, SpellAbility sa, List<CardState> faces,
             Map<String, Object> params) {
         if (isLockOrUnlock(sa) && params != null && params.get("Object") instanceof Card room) {
-            CardState fallback = null;
+            CardState best = null;
+            int bestRank = Integer.MAX_VALUE;
             for (CardState state : faces) {
                 if (!room.getLockedRooms().contains(state.getStateName())) {
                     continue;
                 }
-                if (unlockingTriggers(room, state.getStateName(), ai)) {
-                    return state;
-                }
-                if (fallback == null) {
-                    fallback = state;
+                int rank = rankDoor(room, state.getStateName(), ai);
+                if (rank < bestRank) {
+                    bestRank = rank;
+                    best = state;
                 }
             }
-            if (fallback != null) {
-                return fallback;
+            if (best != null) {
+                return best;
             }
         }
         return faces.isEmpty() ? null : faces.get(0);
     }
 
-    /** Prefer a Room that pays out when opened over one that just changes which half is active. */
+    /** Prefer a Room with a door actually worth opening over one that only swaps which half is active. */
     private static Card bestTarget(CardCollection rooms, Player ai) {
+        Card best = null;
+        int bestRank = Integer.MAX_VALUE;
         for (Card room : rooms) {
             for (CardStateName stateName : room.getLockedRooms()) {
-                if (room.hasState(stateName) && unlockingTriggers(room, stateName, ai)) {
-                    return room;
+                if (!room.hasState(stateName)) {
+                    continue;
+                }
+                int rank = rankDoor(room, stateName, ai);
+                if (rank < bestRank) {
+                    bestRank = rank;
+                    best = room;
                 }
             }
         }
-        return rooms.getFirst();
+        return best != null ? best : rooms.getFirst();
     }
 
     /**
-     * True when opening this particular door would run a "when you unlock this door" trigger that
-     * the AI actually wants right now. Those triggers are declared with ThisDoor$ True and only
-     * fire for the face they sit on (see TriggerUnlockDoor.performTest), so the trigger's own state
-     * name is what identifies it.
+     * How much we want to open a particular door, lower being better:
+     *   0 - it has a "when you unlock this door" trigger the AI wants to run right now
+     *   1 - it has no unlock trigger, so opening it just turns the other half on
+     *   2 - it has an unlock trigger the AI does not want, so opening it is actively bad
      *
-     * Asking the effect's own AI via doTrigger, rather than just checking that a trigger exists,
-     * matters because plenty of Rooms have an unlock trigger that is useless or harmful in the
-     * current state: Cramped Vents deals 6 damage to a creature an opponent controls, which does
-     * nothing with no creatures to hit, and Derelict Attic draws two cards and loses 2 life, which
-     * is lethal at 2 life.
+     * The last case is the reason this is ranked rather than a boolean. Derelict Attic's trigger
+     * draws two cards and loses 2 life, which is lethal at 2 life, so that door has to lose to the
+     * Widow's Walk half rather than merely fail to win. Note that Card.getLockedRooms returns a
+     * HashSet, so relying on iteration order to break ties is not reproducible between runs.
      */
-    private static boolean unlockingTriggers(Card room, CardStateName stateName, Player ai) {
+    private static int rankDoor(Card room, CardStateName stateName, Player ai) {
         if (!room.hasState(stateName)) {
-            return false;
+            return 1;
         }
+        int rank = 1;
         for (Trigger t : room.getState(stateName).getTriggers()) {
             if (t.getMode() != TriggerType.UnlockDoor || !stateName.equals(t.getCardStateName())) {
                 continue;
@@ -125,16 +132,15 @@ public class UnlockDoorAi extends SpellAbilityAi {
             if (effect == null) {
                 continue;
             }
-            // the trigger's ability has no activator until it actually fires, and the AI logic
-            // below needs one to work out targets and costs
-            if (effect.getActivatingPlayer() == null) {
-                effect.setActivatingPlayer(ai);
-            }
+            // a trigger's ability has no activator until it actually fires, and the AI logic below
+            // needs one to work out targets and costs
+            effect.setActivatingPlayer(ai);
             if (SpellApiToAi.Converter.get(effect).doTrigger(ai, effect, false)) {
-                return true;
+                return 0;
             }
+            rank = 2;
         }
-        return false;
+        return rank;
     }
 
     private static boolean isLockOrUnlock(SpellAbility sa) {

--- a/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.SpellAbilityAi;
+import forge.ai.SpellApiToAi;
 import forge.card.CardStateName;
 import forge.game.card.Card;
 import forge.game.card.CardCollection;
@@ -47,7 +48,7 @@ public class UnlockDoorAi extends SpellAbilityAi {
                 return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
             }
             sa.resetTargets();
-            sa.getTargets().add(bestTarget(targets));
+            sa.getTargets().add(bestTarget(targets, aiPlayer));
             return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
         }
 
@@ -74,7 +75,7 @@ public class UnlockDoorAi extends SpellAbilityAi {
                 if (!room.getLockedRooms().contains(state.getStateName())) {
                     continue;
                 }
-                if (unlockingTriggers(room, state.getStateName())) {
+                if (unlockingTriggers(room, state.getStateName(), ai)) {
                     return state;
                 }
                 if (fallback == null) {
@@ -89,10 +90,10 @@ public class UnlockDoorAi extends SpellAbilityAi {
     }
 
     /** Prefer a Room that pays out when opened over one that just changes which half is active. */
-    private static Card bestTarget(CardCollection rooms) {
+    private static Card bestTarget(CardCollection rooms, Player ai) {
         for (Card room : rooms) {
             for (CardStateName stateName : room.getLockedRooms()) {
-                if (room.hasState(stateName) && unlockingTriggers(room, stateName)) {
+                if (room.hasState(stateName) && unlockingTriggers(room, stateName, ai)) {
                     return room;
                 }
             }
@@ -101,16 +102,35 @@ public class UnlockDoorAi extends SpellAbilityAi {
     }
 
     /**
-     * True when opening this particular door would run a "when you unlock this door" trigger.
-     * Those triggers are declared with ThisDoor$ True and only fire for the face they sit on
-     * (see TriggerUnlockDoor.performTest), so the trigger's own state name is what decides it.
+     * True when opening this particular door would run a "when you unlock this door" trigger that
+     * the AI actually wants right now. Those triggers are declared with ThisDoor$ True and only
+     * fire for the face they sit on (see TriggerUnlockDoor.performTest), so the trigger's own state
+     * name is what identifies it.
+     *
+     * Asking the effect's own AI via doTrigger, rather than just checking that a trigger exists,
+     * matters because plenty of Rooms have an unlock trigger that is useless or harmful in the
+     * current state: Cramped Vents deals 6 damage to a creature an opponent controls, which does
+     * nothing with no creatures to hit, and Derelict Attic draws two cards and loses 2 life, which
+     * is lethal at 2 life.
      */
-    private static boolean unlockingTriggers(Card room, CardStateName stateName) {
+    private static boolean unlockingTriggers(Card room, CardStateName stateName, Player ai) {
         if (!room.hasState(stateName)) {
             return false;
         }
         for (Trigger t : room.getState(stateName).getTriggers()) {
-            if (t.getMode() == TriggerType.UnlockDoor && stateName.equals(t.getCardStateName())) {
+            if (t.getMode() != TriggerType.UnlockDoor || !stateName.equals(t.getCardStateName())) {
+                continue;
+            }
+            SpellAbility effect = t.ensureAbility();
+            if (effect == null) {
+                continue;
+            }
+            // the trigger's ability has no activator until it actually fires, and the AI logic
+            // below needs one to work out targets and costs
+            if (effect.getActivatingPlayer() == null) {
+                effect.setActivatingPlayer(ai);
+            }
+            if (SpellApiToAi.Converter.get(effect).doTrigger(ai, effect, false)) {
                 return true;
             }
         }

--- a/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
@@ -1,0 +1,86 @@
+package forge.ai.ability;
+
+import java.util.List;
+import java.util.Map;
+
+import forge.ai.AiAbilityDecision;
+import forge.ai.AiPlayDecision;
+import forge.ai.SpellAbilityAi;
+import forge.game.card.Card;
+import forge.game.card.CardCollection;
+import forge.game.card.CardState;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+/**
+ * "Lock or unlock a door of target Room you control" can only ever lock when every door of the
+ * chosen Room is already unlocked (see the Mode$ LockOrUnlock / case 0 branch of
+ * UnlockDoorEffect), so pointing it at a fully unlocked Room shuts off one of your own Rooms.
+ * Keys to the House pays {3}, taps and sacrifices itself for that ability, so doing it for nothing
+ * also throws away a permanent.
+ */
+public class UnlockDoorAi extends SpellAbilityAi {
+
+    @Override
+    protected AiAbilityDecision canPlay(Player aiPlayer, SpellAbility sa) {
+        if (!isLockOrUnlock(sa)) {
+            // Unlock / ThisDoor can only open doors, which is always what we want
+            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+        }
+
+        if (sa.usesTargeting()) {
+            CardCollection targets = new CardCollection();
+            for (Card c : aiPlayer.getGame().getCardsIn(ZoneType.Battlefield)) {
+                if (sa.canTarget(c) && hasLockedDoor(c)) {
+                    targets.add(c);
+                }
+            }
+            if (targets.isEmpty()) {
+                // every Room we could point at is already fully unlocked
+                return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+            }
+            sa.resetTargets();
+            sa.getTargets().add(targets.getFirst());
+            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+        }
+
+        for (Card c : forge.game.ability.AbilityUtils.getDefinedCards(sa.getHostCard(),
+                sa.getParamOrDefault("Defined", "Self"), sa)) {
+            if (hasLockedDoor(c)) {
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
+        }
+        return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+    }
+
+    /**
+     * With one door locked the effect offers both doors and locks whichever one is still open, so
+     * pick the locked door to make sure the ability opens a Room instead of closing one.
+     */
+    @Override
+    public CardState chooseCardState(Player ai, SpellAbility sa, List<CardState> faces,
+            Map<String, Object> params) {
+        if (isLockOrUnlock(sa) && params != null && params.get("Object") instanceof Card room) {
+            for (CardState state : faces) {
+                if (room.getLockedRooms().contains(state.getStateName())) {
+                    return state;
+                }
+            }
+        }
+        return faces.isEmpty() ? null : faces.get(0);
+    }
+
+    private static boolean isLockOrUnlock(SpellAbility sa) {
+        return "LockOrUnlock".equals(sa.getParamOrDefault("Mode", "ThisDoor"));
+    }
+
+    private static boolean hasLockedDoor(Card c) {
+        for (var stateName : c.getLockedRooms()) {
+            if (c.hasState(stateName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UnlockDoorAi.java
@@ -6,11 +6,14 @@ import java.util.Map;
 import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.SpellAbilityAi;
+import forge.card.CardStateName;
 import forge.game.card.Card;
 import forge.game.card.CardCollection;
 import forge.game.card.CardState;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
+import forge.game.trigger.Trigger;
+import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
 
 /**
@@ -19,6 +22,9 @@ import forge.game.zone.ZoneType;
  * UnlockDoorEffect), so pointing it at a fully unlocked Room shuts off one of your own Rooms.
  * Keys to the House pays {3}, taps and sacrifices itself for that ability, so doing it for nothing
  * also throws away a permanent.
+ *
+ * Most Rooms carry a "when you unlock this door" trigger on each face, so where there is a choice
+ * the AI prefers a door that actually pays out over one that only changes which half is active.
  */
 public class UnlockDoorAi extends SpellAbilityAi {
 
@@ -41,7 +47,7 @@ public class UnlockDoorAi extends SpellAbilityAi {
                 return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
             }
             sa.resetTargets();
-            sa.getTargets().add(targets.getFirst());
+            sa.getTargets().add(bestTarget(targets));
             return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
         }
 
@@ -56,19 +62,59 @@ public class UnlockDoorAi extends SpellAbilityAi {
 
     /**
      * With one door locked the effect offers both doors and locks whichever one is still open, so
-     * pick the locked door to make sure the ability opens a Room instead of closing one.
+     * pick a locked door to make sure the ability opens a Room instead of closing one. Where more
+     * than one door is locked, prefer one whose face has an unlock trigger to run.
      */
     @Override
     public CardState chooseCardState(Player ai, SpellAbility sa, List<CardState> faces,
             Map<String, Object> params) {
         if (isLockOrUnlock(sa) && params != null && params.get("Object") instanceof Card room) {
+            CardState fallback = null;
             for (CardState state : faces) {
-                if (room.getLockedRooms().contains(state.getStateName())) {
+                if (!room.getLockedRooms().contains(state.getStateName())) {
+                    continue;
+                }
+                if (unlockingTriggers(room, state.getStateName())) {
                     return state;
                 }
+                if (fallback == null) {
+                    fallback = state;
+                }
+            }
+            if (fallback != null) {
+                return fallback;
             }
         }
         return faces.isEmpty() ? null : faces.get(0);
+    }
+
+    /** Prefer a Room that pays out when opened over one that just changes which half is active. */
+    private static Card bestTarget(CardCollection rooms) {
+        for (Card room : rooms) {
+            for (CardStateName stateName : room.getLockedRooms()) {
+                if (room.hasState(stateName) && unlockingTriggers(room, stateName)) {
+                    return room;
+                }
+            }
+        }
+        return rooms.getFirst();
+    }
+
+    /**
+     * True when opening this particular door would run a "when you unlock this door" trigger.
+     * Those triggers are declared with ThisDoor$ True and only fire for the face they sit on
+     * (see TriggerUnlockDoor.performTest), so the trigger's own state name is what decides it.
+     */
+    private static boolean unlockingTriggers(Card room, CardStateName stateName) {
+        if (!room.hasState(stateName)) {
+            return false;
+        }
+        for (Trigger t : room.getState(stateName).getTriggers()) {
+            if (t.getMode() == TriggerType.UnlockDoor && stateName.equals(t.getCardStateName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isLockOrUnlock(SpellAbility sa) {
@@ -76,7 +122,7 @@ public class UnlockDoorAi extends SpellAbilityAi {
     }
 
     private static boolean hasLockedDoor(Card c) {
-        for (var stateName : c.getLockedRooms()) {
+        for (CardStateName stateName : c.getLockedRooms()) {
             if (c.hasState(stateName)) {
                 return true;
             }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
@@ -1,0 +1,66 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.card.CardStateName;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class UnlockDoorAiTest extends AITest {
+
+    private Card addRoom(Game game, Player p) {
+        return addCard("Bottomless Pool", p);
+    }
+
+    /**
+     * Keys to the House pays {3}, taps and sacrifices itself to "lock or unlock a door of target
+     * Room you control". When every door of the Room is already unlocked the effect can only lock
+     * one, so activating it throws the artifact away to shut off the AI's own Room.
+     */
+    @Test
+    public void doesNotSacrificeItselfJustToLockItsOwnRoom() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card room = addRoom(game, ai);
+        room.setUnlockedRooms(java.util.EnumSet.of(CardStateName.LeftSplit, CardStateName.RightSplit));
+
+        addCard("Keys to the House", ai);
+        for (int i = 0; i < 5; i++) {
+            addCard("Island", ai);
+        }
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("Keys to the House should not have been sacrificed", 1,
+                countCardsWithName(game, "Keys to the House"));
+        AssertJUnit.assertTrue("Both doors should still be unlocked",
+                room.getUnlockedRooms().containsAll(
+                        java.util.EnumSet.of(CardStateName.LeftSplit, CardStateName.RightSplit)));
+    }
+
+    /** With a door still locked the ability is worth its cost, so the AI should use it. */
+    @Test
+    public void unlocksARoomWhenADoorIsStillLocked() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card room = addRoom(game, ai);
+        room.setUnlockedRooms(java.util.EnumSet.of(CardStateName.LeftSplit));
+
+        addCard("Keys to the House", ai);
+        for (int i = 0; i < 5; i++) {
+            addCard("Island", ai);
+        }
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertTrue("AI should have unlocked the remaining door, not locked the open one",
+                room.getUnlockedRooms().contains(CardStateName.RightSplit));
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
@@ -91,4 +91,34 @@ public class UnlockDoorAiTest extends AITest {
         AssertJUnit.assertTrue("AI should have opened the door carrying the unlock trigger",
                 room.getUnlockedRooms().contains(CardStateName.LeftSplit));
     }
+
+    /**
+     * Derelict Attic's unlock trigger draws two cards and loses 2 life, so opening that door at
+     * 2 life kills the AI. Checking that a trigger merely exists is not enough - the AI has to ask
+     * whether it actually wants to run it, which is what doTrigger does.
+     */
+    @Test
+    public void doesNotOpenADoorWhoseTriggerWouldKillIt() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card room = addCard("Derelict Attic", ai);
+        room.setUnlockedRooms(java.util.EnumSet.noneOf(CardStateName.class));
+        for (int i = 0; i < 20; i++) {
+            addCardToZone("Swamp", ai, forge.game.zone.ZoneType.Library);
+        }
+
+        addCard("Keys to the House", ai);
+        for (int i = 0; i < 5; i++) {
+            addCard("Island", ai);
+        }
+        ai.setLife(2, null);
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertFalse("AI should not have opened the door that would have killed it",
+                room.getUnlockedRooms().contains(CardStateName.LeftSplit));
+        AssertJUnit.assertTrue("AI should still be alive", ai.getLife() > 0);
+    }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
@@ -119,6 +119,8 @@ public class UnlockDoorAiTest extends AITest {
 
         AssertJUnit.assertFalse("AI should not have opened the door that would have killed it",
                 room.getUnlockedRooms().contains(CardStateName.LeftSplit));
+        AssertJUnit.assertTrue("AI should have opened the harmless Widow's Walk half instead",
+                room.getUnlockedRooms().contains(CardStateName.RightSplit));
         AssertJUnit.assertTrue("AI should still be alive", ai.getLife() > 0);
     }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UnlockDoorAiTest.java
@@ -63,4 +63,32 @@ public class UnlockDoorAiTest extends AITest {
         AssertJUnit.assertTrue("AI should have unlocked the remaining door, not locked the open one",
                 room.getUnlockedRooms().contains(CardStateName.RightSplit));
     }
+
+    /**
+     * With both doors locked there is a choice to make. Bottomless Pool (the LeftSplit face) has a
+     * "when you unlock this door" trigger that bounces a creature; Locker Room (RightSplit) only
+     * has a combat damage trigger, so opening it pays out nothing right now. The AI should take
+     * the door that actually does something.
+     */
+    @Test
+    public void prefersTheDoorWithAnUnlockTrigger() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card room = addRoom(game, ai);
+        room.setUnlockedRooms(java.util.EnumSet.noneOf(CardStateName.class));
+
+        addCard("Keys to the House", ai);
+        for (int i = 0; i < 5; i++) {
+            addCard("Island", ai);
+        }
+        // something for the unlock trigger to target
+        addCard("Grizzly Bears", game.getPlayers().get(0));
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertTrue("AI should have opened the door carrying the unlock trigger",
+                room.getUnlockedRooms().contains(CardStateName.LeftSplit));
+    }
 }


### PR DESCRIPTION
`UnlockDoor` is mapped to `AlwaysPlayAi`, whose entire logic is `return WillPlay` — it never looks at the board. For `Mode$ LockOrUnlock` that is wrong in two separate ways.

## 1. It can only lock, so the AI shuts off its own Room

When every door of the targeted Room is already unlocked, `UnlockDoorEffect` takes the `case 0` branch, whose only outcome is `lockRoom`:

```java
case "LockOrUnlock":
    switch (c.getLockedRooms().size()) {
    case 0:
        // no locked, all unlocked, can only lock door
        List<CardState> unlockStates = c.getUnlockedRooms()...;
        CardState chosenUnlock = activator.getController().chooseSingleCardState(...);
        ...
        c.lockRoom(activator, chosenUnlock.getStateName());
```

Keys to the House pays `{3}`, taps **and sacrifices itself** for that ability:

```
A:AB$ UnlockDoor | Cost$ 3 T Sac<1/CARDNAME> | Mode$ LockOrUnlock | ValidTgts$ Room.YouCtrl | ...
```

so the AI was throwing away a permanent to make its own board worse. The added test shows Keys to the House going from one copy on the battlefield to zero under the old mapping.

## 2. With one door locked, the door it picked was arbitrary

In the `case 1` branch the effect offers **both** doors and locks whichever one is still open. That choice went through `SpellAbilityAi.chooseCardState`, whose base implementation is:

```java
public CardState chooseCardState(Player ai, SpellAbility sa, List<CardState> faces, Map<String,Object> params) {
    System.err.println("Warning: default (ie. inherited from base class) implementation of chooseCardState is used for " ...);
    return Iterables.getFirst(faces, null);
}
```

Since `bothStates` is always built in fixed `[LeftSplit, RightSplit]` order, whether the AI opened or closed a door came down to state ordering rather than a decision — and it printed a warning to stderr every time.

## The fix

`UnlockDoorAi`:
- declines when no reachable Room has a locked door, and
- picks a **locked** door when asked to choose, so the ability always opens a Room instead of closing one.

`Mode$ Unlock` and `Mode$ ThisDoor` can only ever unlock, so they keep the previous always-play behaviour.

Affects Keys to the House and Marina Vendrell.

## Verification

Two tests, both of which fail on the old mapping:

- `doesNotSacrificeItselfJustToLockItsOwnRoom` — fails with `Keys to the House should not have been sacrificed expected:<1> but was:<0>`
- `unlocksARoomWhenADoorIsStillLocked` — fails with `AI should have unlocked the remaining door, not locked the open one`

`forge.ai.**` test suite: 247 tests, 0 failures. Full `mvn -U -B clean test` across all 12 modules passes.

---
*This PR was previously part of #11441, which bundled it with an unrelated `BecomeMonarch` fix. Split out so each can be reviewed on its own.*

Written with the help of GitHub Copilot CLI; the commit carries a `Co-authored-by` trailer for it.
