### PR TITLE
Stop the AI seeking a card its library cannot supply

### DIFF
--- a/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
@@ -182,7 +182,7 @@ public enum SpellApiToAi {
             .put(ApiType.Sacrifice, SacrificeAi.class)
             .put(ApiType.SacrificeAll, SacrificeAllAi.class)
             .put(ApiType.Scry, ScryAi.class)
-            .put(ApiType.Seek, AlwaysPlayAi.class)
+            .put(ApiType.Seek, SeekAi.class)
             .put(ApiType.SetInMotion, AlwaysPlayAi.class)
             .put(ApiType.SetLife, LifeSetAi.class)
             .put(ApiType.SetState, SetStateAi.class)

--- a/forge-ai/src/main/java/forge/ai/ability/SeekAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SeekAi.java
@@ -1,0 +1,91 @@
+package forge.ai.ability;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import forge.ai.AiAbilityDecision;
+import forge.ai.AiPlayDecision;
+import forge.ai.SpellAbilityAi;
+import forge.game.ability.AbilityUtils;
+import forge.game.card.Card;
+import forge.game.card.CardCollection;
+import forge.game.card.CardLists;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+/**
+ * Seek picks at random from the cards in the library that match its type, and SeekEffect skips a
+ * type whose pool is empty after the cost has already been paid. Runecarved Obelisk taps and
+ * sacrifices itself to seek, so seeking a type the library cannot supply throws the artifact away
+ * for nothing.
+ */
+public class SeekAi extends SpellAbilityAi {
+
+    @Override
+    protected AiAbilityDecision canPlay(Player aiPlayer, SpellAbility sa) {
+        for (Player seeker : getSeekers(aiPlayer, sa)) {
+            for (String seekType : getSeekTypes(sa)) {
+                if (canFindSomething(seeker, seekType, sa)) {
+                    return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+                }
+            }
+        }
+        return new AiAbilityDecision(0, AiPlayDecision.DoesntImpactGame);
+    }
+
+    private static List<Player> getSeekers(Player aiPlayer, SpellAbility sa) {
+        if (sa.usesTargeting()) {
+            // targets aren't chosen yet at this point, so assume we can aim at ourselves
+            return Lists.newArrayList(aiPlayer);
+        }
+        List<Player> defined = Lists.newArrayList();
+        for (String def : sa.getParamOrDefault("Defined", "You").split(" & ")) {
+            defined.addAll(AbilityUtils.getDefinedPlayers(sa.getHostCard(), def, sa));
+        }
+        return defined.isEmpty() ? Lists.newArrayList(aiPlayer) : defined;
+    }
+
+    private static List<String> getSeekTypes(SpellAbility sa) {
+        if (sa.hasParam("Types")) {
+            return Arrays.asList(sa.getParam("Types").split(","));
+        }
+        return Lists.newArrayList(sa.getParamOrDefault("Type", "Card"));
+    }
+
+    /**
+     * Mirrors how SeekEffect builds its pool. Types that depend on what the cost sacrifices (such
+     * as Spawning Pod's Creature.cmcEQX, where X comes from the sacrificed creature) cannot be
+     * resolved before the cost is paid, so those are assumed findable rather than guessed at.
+     */
+    private static boolean canFindSomething(Player seeker, String seekType, SpellAbility sa) {
+        final Card source = sa.getHostCard();
+        CardCollection pool;
+        if (sa.hasParam("DefinedCards")) {
+            pool = AbilityUtils.getDefinedCards(source, sa.getParam("DefinedCards"), sa);
+        } else {
+            pool = new CardCollection(seeker.getCardsIn(ZoneType.Library));
+        }
+        if (pool.isEmpty()) {
+            return false;
+        }
+        if (seekType.equals("Card")) {
+            return true;
+        }
+        if (dependsOnCostPayment(seekType, sa)) {
+            return true;
+        }
+        return !CardLists.getValidCards(pool, seekType, source.getController(), source, sa).isEmpty();
+    }
+
+    private static boolean dependsOnCostPayment(String seekType, SpellAbility sa) {
+        for (String svar : new String[] { "X", "Y", "Z" }) {
+            if (seekType.contains(svar) && sa.getSVar(svar).startsWith("Sacrificed$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/SeekAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/SeekAiTest.java
@@ -1,0 +1,60 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.card.CounterEnumType;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class SeekAiTest extends AITest {
+
+    /**
+     * Runecarved Obelisk taps and sacrifices itself to seek a card whose mana value is at most the
+     * number of charge counters on it. With no charge counters nothing in the library can match, and
+     * SeekEffect skips an empty pool after the cost has already been paid, so activating it throws
+     * the artifact away for nothing.
+     */
+    @Test
+    public void doesNotSacrificeItselfSeekingAnEmptyPool() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Runecarved Obelisk", ai);
+        // no charge counters, and nothing in the library is free
+        for (int i = 0; i < 10; i++) {
+            addCardToZone("Hill Giant", ai, ZoneType.Library);
+        }
+        game.getAction().checkStateEffects(true);
+
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("Runecarved Obelisk should not have been sacrificed", 1,
+                countCardsWithName(game, "Runecarved Obelisk"));
+    }
+
+    /** With enough charge counters the library can answer, so the ability is worth its cost. */
+    @Test
+    public void seeksWhenTheLibraryCanAnswer() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card obelisk = addCard("Runecarved Obelisk", ai);
+        obelisk.setCounters(CounterEnumType.CHARGE, 6);
+        for (int i = 0; i < 10; i++) {
+            addCardToZone("Hill Giant", ai, ZoneType.Library);
+        }
+        game.getAction().checkStateEffects(true);
+
+        int handBefore = ai.getCardsIn(ZoneType.Hand).size();
+        playUntilStackClear(game);
+
+        AssertJUnit.assertEquals("Runecarved Obelisk should have been sacrificed to seek", 0,
+                countCardsWithName(game, "Runecarved Obelisk"));
+        AssertJUnit.assertEquals("the sought card should be in hand", handBefore + 1,
+                ai.getCardsIn(ZoneType.Hand).size());
+    }
+}


### PR DESCRIPTION
`Seek` is mapped to `AlwaysPlayAi`, whose entire logic is `return WillPlay` — it never looks at the board.

`SeekEffect` builds a pool from the library filtered by the seek type, and when that pool is empty it simply skips the type:

```java
if (pool.isEmpty()) {
    if (notify.length() != 0) notify.append("\r\n");
    notify.append(Localizer.getInstance().getMessage("lblSeekFailed", seekType));
    continue; // can't find if nothing to seek
}
```

The cost has already been paid by that point. Runecarved Obelisk pays it with the card itself:

```
A:AB$ Seek | Cost$ T Sac<1/CARDNAME> | Type$ Card.cmcEQY | ...
SVar:Y:Count$ValidLibrary Card.YouOwn+cmcLEX$GreatestCardManaCost
SVar:X:Count$CardCounters.CHARGE
```

With no charge counters nothing in the library can match, so the AI sacrificed the artifact for nothing. The added test shows it going from one copy on the battlefield to zero under the old mapping.

## The fix

`SeekAi` mirrors how `SeekEffect` builds its pool (including the `DefinedCards` variant) and declines when no seek type can find anything.

## Cost-dependent types are deliberately left alone

Spawning Pod seeks `Creature.cmcEQX` where `SVar:X:Sacrificed$CardManaCost/Plus.1` — the filter depends on **which creature the cost sacrifices**, so it cannot be resolved before the cost is paid. Guessing there would make the AI stop using the card entirely, which would be a worse bug than the one being fixed.

So any type whose `X`/`Y`/`Z` resolves to a `Sacrificed$` SVar is treated as findable, preserving the old behaviour. I verified this by running Spawning Pod activations with and without the change and getting identical results.

## Verification

- `doesNotSacrificeItselfSeekingAnEmptyPool` — the regression; fails with `Runecarved Obelisk should not have been sacrificed expected:<1> but was:<0>` without the fix
- `seeksWhenTheLibraryCanAnswer` — with 6 charge counters it still sacrifices and draws, so the guard does not over-decline

`forge.ai.**` test suite: 247 tests, 0 failures. Full `mvn -U -B clean test` across all 12 modules passes.

---
Written with the help of GitHub Copilot CLI; the commit carries a `Co-authored-by` trailer for it.