### PR TITLE
Guard against a null AI player when pruning hidden info in game copies

### DIFF
--- a/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
@@ -302,7 +302,7 @@ public class GameCopier {
         }
         if (USE_FROM_PAPER_CARD && !c.isImmutable() && c.getPaperCard() != null) {
             Card newCard;
-            if (PRUNE_HIDDEN_INFO && !c.getView().canBeShownTo(aiPlayer.getView())) {
+            if (PRUNE_HIDDEN_INFO && aiPlayer != null && !c.getView().canBeShownTo(aiPlayer.getView())) {
                 // TODO also check REVEALED_CARDS memory
                 newCard = new Card(c.getId(), hidden_info_card, newGame);
                 newCard.setOwner(newOwner);


### PR DESCRIPTION
`GameCopier.createCardCopy` dereferences `aiPlayer` to decide whether a card should be replaced by a placeholder:

```java
if (PRUNE_HIDDEN_INFO && !c.getView().canBeShownTo(aiPlayer.getView())) {
```

but `aiPlayer` is nullable on that path. `GameCopier.makeCopy()` passes `null` for it, and both `GameStateEvaluator.simulateUpcomingCombatThisTurn` and `GameSimulator`'s copy-score self-check reach the copier that way. So turning `PRUNE_HIDDEN_INFO` on throws `NullPointerException` out of a dozen simulation tests before the feature can be evaluated at all.

This skips pruning when there is no AI player to prune for — without one there is no perspective from which to decide what is hidden.

## This does not enable the flag

`PRUNE_HIDDEN_INFO` stays `false`. This only makes it *possible to evaluate*, which it currently isn't.

For reference, since the numbers seem worth recording somewhere: flipping it locally on a 126-card board (100 of them in libraries, `N=300` copies) takes `GameCopier.makeCopy` from **3.13 ms to 1.99 ms**, about **36%**. That is because `CardView.canBeShownTo` treats `Library` as hidden to everyone, so library cards stop being re-parsed from their paper card. It also stops the simulation AI from seeing hidden zones, which is a fairness improvement in its own right.

With this guard in place, 12 simulation tests still fail when the flag is on — all of them from that behaviour change (the AI can no longer see its own library when choosing plays), not from crashes. So actually enabling it is a separate decision with its own measurement, and I have not tried to make it here.

`forge.ai.**` test suite: 245 tests, 0 failures. Full `mvn -U -B clean test` across all 12 modules passes.

---
Written with the help of GitHub Copilot CLI; the commit carries a `Co-authored-by` trailer for it.