### PR TITLE
Some Card Updates/Fixes

### DIFF
--- a/forge-gui/res/cardsfolder/a/a_i_m_bot.txt
+++ b/forge-gui/res/cardsfolder/a/a_i_m_bot.txt
@@ -1,6 +1,6 @@
 Name:A.I.M. Bot
 ManaCost:2 U
 Types:Artifact Creature Robot Villain
-PT:3/3
+PT:2/3
 K:Flying
 Oracle:Flying (This creature can't be blocked except by creatures with flying or reach.)

--- a/forge-gui/res/cardsfolder/b/bebop_warthog_warrior.txt
+++ b/forge-gui/res/cardsfolder/b/bebop_warthog_warrior.txt
@@ -1,5 +1,5 @@
 Name:Bebop, Warthog Warrior
-ManaCost:4 U4 B
+ManaCost:4 B
 Types:Legendary Creature Boar Mutant Warrior
 PT:5/4
 K:Menace

--- a/forge-gui/res/cardsfolder/b/big_boa_constrictor.txt
+++ b/forge-gui/res/cardsfolder/b/big_boa_constrictor.txt
@@ -1,7 +1,7 @@
 Name:Big Boa Constrictor
 ManaCost:3 B
 Types:Host Creature Snake
-PT:3/3
+PT:1/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigRoll | Host$ True | TriggerDescription$ When this creature enters, roll a six-sided die. Target opponent loses life equal to the result.
 SVar:TrigRoll:DB$ RollDice | ResultSVar$ Result | SubAbility$ DBLife
 SVar:DBLife:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ Result

--- a/forge-gui/res/cardsfolder/b/bolshack_dragon.txt
+++ b/forge-gui/res/cardsfolder/b/bolshack_dragon.txt
@@ -1,6 +1,6 @@
 Name:Bolshack Dragon
 ManaCost:5 R
-Types:Creature Dragon
+Types:Creature Armored Dragon
 PT:6/6
 # Note: For convenience, it was determined that "Armored" wasn't striked through on the type line of this card due to an editing lapse. The striked-through parts of the card text were excised from the script for lack of a consistent way to display them in-game. These may be added back on at some point once the game engine deals well with them.
 K:Double Strike

--- a/forge-gui/res/cardsfolder/c/captain_americas_shield.txt
+++ b/forge-gui/res/cardsfolder/c/captain_americas_shield.txt
@@ -1,6 +1,6 @@
 Name:Captain America's Shield
 ManaCost:2
-Types:Artifact Equipment
+Types:Legendary Artifact Equipment
 K:Indestructible
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddToughness$ 8 | AddKeyword$ Vigilance | Description$ Equipped creature gets +0/+8 and has vigilance.
 T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ TrigTap | TriggerDescription$ Whenever equipped creature attacks, tap target creature defending player controls.

--- a/forge-gui/res/cardsfolder/c/cogwork_tracker.txt
+++ b/forge-gui/res/cardsfolder/c/cogwork_tracker.txt
@@ -1,9 +1,9 @@
 Name:Cogwork Tracker
 ManaCost:4
-Types:Artifact Creature Hound Construct
+Types:Artifact Creature Dog Construct
 PT:4/4
 Draft:Reveal CARDNAME as you draft it.
 Draft:Note the player who passed CARDNAME to you.
-S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ CARDNAME attacks each combat if able.
-S:Mode$ MustAttack | ValidPlayer$ Opponent.NotedDefender | ValidCreature$ Card.Self | Description$ CARDNAME attacks a player you noted for cards named Cogwork Tracker each combat if able.
-Oracle:Reveal Cogwork Tracker as you draft it and note the player who passed it to you.\nCogwork Tracker attacks each combat if able.\nCogwork Tracker attacks a player you noted for cards named Cogwork Tracker each combat if able.
+S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ This creature attacks each combat if able.
+S:Mode$ MustAttack | ValidPlayer$ Opponent.NotedDefender | ValidCreature$ Card.Self | Description$ This creature attacks a player you noted for cards named Cogwork Tracker each combat if able.
+Oracle:Reveal this card as you draft it and note the player who passed it to you.\nThis creature attacks each combat if able.\nThis creature attacks a player you noted for cards named Cogwork Tracker each combat if able.

--- a/forge-gui/res/cardsfolder/c/cyclonus_the_saboteur_cyclonus_cybertronian_fighter.txt
+++ b/forge-gui/res/cardsfolder/c/cyclonus_the_saboteur_cyclonus_cybertronian_fighter.txt
@@ -16,7 +16,7 @@ ALTERNATE
 
 Name:Cyclonus, Cybertronian Fighter
 ManaCost:no cost
-Colors:black
+Colors:black,blue
 Types:Legendary Artifact Vehicle
 PT:5/5
 K:Living metal

--- a/forge-gui/res/cardsfolder/d/death_rattle_oni.txt
+++ b/forge-gui/res/cardsfolder/d/death_rattle_oni.txt
@@ -5,6 +5,6 @@ PT:5/4
 K:Flash
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {2} less to cast for each creature that died this turn.
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature/Times.2
-T:Mode$ ChangesZone | TriggerZones$ Battlefield | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBDestroyAll | TriggerDescription$ When CARDNAME enters, destroy all other creatures that were dealt damage this turn.
+T:Mode$ ChangesZone | TriggerZones$ Battlefield | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBDestroyAll | TriggerDescription$ When this creature enters, destroy all other creatures that were dealt damage this turn.
 SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Creature.wasDealtDamageThisTurn+StrictlyOther
-Oracle:This spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters, destroy all other creatures that were dealt damage this turn.
+Oracle:Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen this creature enters, destroy all other creatures that were dealt damage this turn.

--- a/forge-gui/res/cardsfolder/d/deep_dish_pizza.txt
+++ b/forge-gui/res/cardsfolder/d/deep_dish_pizza.txt
@@ -2,8 +2,8 @@ Name:Deep Dish Pizza
 ManaCost:no cost
 Types:Artifact Food
 K:Suspend:2:2
-A:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME> | LifeAmount$ 3 | SubAbility$ DBDraw | SpellDescription$ Gain 3 life, draw three cards, and CARDNAME deals 3 damage to each opponent.
+A:AB$ GainLife | Cost$ 2 Sac<1/CARDNAME> | LifeAmount$ 3 | SubAbility$ DBDraw | SpellDescription$ Gain 3 life, draw three cards, and CARDNAME deals 3 damage to each opponent.
 SVar:DBDraw:DB$ Draw | NumCards$ 3 | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ 3
 DeckHas:Ability$LifeGain|Sacrifice
-Oracle:Suspend 2—{2} (Deep Dish Pizza has no mana cost and must be suspended.)\n{2}, {T}, Sacrifice Deep Dish Pizza: Gain 3 life, draw three cards, and Deep Dish Pizza deals 3 damage to each opponent.
+Oracle:Suspend 2—{2} (Deep Dish Pizza has no mana cost and must be suspended.)\n{2}, Sacrifice Deep Dish Pizza: Gain 3 life, draw three cards, and Deep Dish Pizza deals 3 damage to each opponent.

--- a/forge-gui/res/cardsfolder/d/domesticated_mammoth.txt
+++ b/forge-gui/res/cardsfolder/d/domesticated_mammoth.txt
@@ -1,7 +1,7 @@
 Name:Domesticated Mammoth
 ManaCost:1 G
 Types:Snow Creature Mammoth
-PT:4/5
+PT:5/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | Static$ True | TriggerDescription$ CARDNAME enters with a token copy of Pacifism attached to it.
 SVar:TrigToken:DB$ CopyPermanent | DefinedName$ Pacifism | AttachedTo$ Self
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/n/necrodominance.txt
+++ b/forge-gui/res/cardsfolder/n/necrodominance.txt
@@ -6,7 +6,7 @@ T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefiel
 SVar:TrigDraw:AB$ Draw | Cost$ PayLife<X> | NumCards$ X
 SVar:X:Count$xPaid
 S:Mode$ Continuous | Affected$ You | SetMaxHandSize$ 5 | Description$ Your maximum hand size is five.
-R:Event$ Moved | ActiveZones$ Battlefield | Destination$ Graveyard | ValidCard$ Card.YouCtrl,Card.token+YouCtrl | ReplaceWith$ Exile | Description$ If a card or token would be put into your graveyard from anywhere, exile it instead.
+R:Event$ Moved | ActiveZones$ Battlefield | Destination$ Graveyard | ValidCard$ Card.YouOwn | ReplaceWith$ Exile | Description$ If a card or token would be put into your graveyard from anywhere, exile it instead.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
 AI:RemoveDeck:All
 Oracle:Skip your draw step.\nAt the beginning of your end step, you may pay any amount of life. If you do, draw that many cards.\nYour maximum hand size is five.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/r/relic_axe.txt
+++ b/forge-gui/res/cardsfolder/r/relic_axe.txt
@@ -5,7 +5,6 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigAttach:DB$ Attach | ValidTgts$ Creature.YouCtrl | AITgts$ Warrior | TgtPrompt$ Select target creature you control
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddPower$ X | AddToughness$ 1 | Description$ Equipped creature gets +1/+1. If it's a Warrior, it gets +2/+1 instead.
 SVar:X:Count$Compare Y GE1.2.1
-SVar:Y:Targeted$Valid Warrior
 SVar:Y:Count$Valid Warrior.AttachedBy
 K:Equip:2
 SVar:NeedsToPlay:Creature.YouCtrl

--- a/forge-gui/res/editions/Mystery Booster 2.txt
+++ b/forge-gui/res/editions/Mystery Booster 2.txt
@@ -394,6 +394,8 @@ F619 R Temur Elevator @Marika Lord
 F620 R Under-Construction Skyscraper @Kevin Dubell
 F621 R Value Town @Hélio Frazão
 
+[CreatureTypes]
+Armored:Armored
 [LandTypes]
 Omenpath:Omenpaths
 [WalkerTypes]


### PR DESCRIPTION
Added changes/fixes for the following cards:
---

- **A.I.M. Bot:** 3/3 > **2/3**
- **Bebop, Warthog Warrior:** _**Remove the U4**_  on the card's mana cost.
- **Big Boa Constrictor:** 3/3 > **1/2**
- **Bolshack Dragon:** _**Added  Armored**_  to its creature type (based on the mtg.wiki of the card's origin). Myster Booster 2 edition file updated to reflect the change 
- **Captain America's Shield:** _**Added  Legendary**_  to the card's type.
- **Cogwork Tracker:** Hound > **Dog**
- **Cyclonus, Cybertronian Fighter:** _**Added blue**_  to the card's color.
- **Death-Rattle Oni:** Updated Oracle text to reflect the current Oracle text which includes the missing _**Flash**_  keyword.
- **Deep Dish Pizza:** _**Remove the tap cost**_ from its Oracle text and script.
- **Domesticated Mammoth:** 4/5 > **5/4**
- **Necrodominance:** Changed the cards being exiled to _**ValidCard$ Card.YouOwn**_ to reflect its actual Oracle text effect.
- **Relic Axe:** Removed _**SVar:Y:Targeted$Valid Warrior**_ since it doesn't do anything and the other **SVar:Y** actually implements the proper condition (this is more of a cleanup than a card fix).