### PR TITLE
Detect attack-punisher enchantments by trigger instead of by name

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -20,6 +20,7 @@ package forge.ai;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
 import forge.ai.ability.AnimateAi;
 import forge.game.GameEntity;
 import forge.game.ability.AbilityUtils;
@@ -1738,40 +1739,85 @@ public class AiAttackController {
     }
 
     private boolean doRevengeOfRavensAttackLogic(final GameEntity defender, final Queue<Card> attackersLeft, int numForcedAttackers, Integer maxAttack) {
-        // TODO: detect Revenge of Ravens by the trigger instead of by name
-        boolean revengeOfRavens = false;
-        if (defender instanceof Player player) {
-            revengeOfRavens = !CardLists.filter(player.getCardsIn(ZoneType.Battlefield),
-                    CardPredicates.nameEquals("Revenge of Ravens")).isEmpty();
-        } else if (defender instanceof Card card) {
-            revengeOfRavens = !CardLists.filter(card.getController().getCardsIn(ZoneType.Battlefield),
-                    CardPredicates.nameEquals("Revenge of Ravens")).isEmpty();
-        }
-
-        if (!revengeOfRavens) {
+        int lifeLossPerAttacker = lifeLostPerAttacker(defender);
+        if (lifeLossPerAttacker <= 0) {
             return true;
         }
 
         int life = ai.canLoseLife() && !ai.cantLoseForZeroOrLessLife() ? ai.getLife() : Integer.MAX_VALUE;
         maxAttack = Objects.requireNonNullElse(maxAttack, Integer.MAX_VALUE - 1);
-        if (Math.min(maxAttack, numForcedAttackers) >= life) {
+        if (lifeLossPerAttacker * Math.min(maxAttack, numForcedAttackers) >= life) {
             return false;
         }
 
-        // Remove all 1-power attackers since they usually only hurt the attacker
+        // Remove all attackers whose damage wouldn't outweigh the life we pay to send them
         // TODO: improve to account for possible combat effects coming from attackers like that
         CardCollection attUnsafe = new CardCollection();
         for (Card attacker : attackersLeft) {
-            if (attacker.getNetCombatDamage() <= 1) {
+            if (attacker.getNetCombatDamage() <= lifeLossPerAttacker) {
                 attUnsafe.add(attacker);
             }
         }
         attackersLeft.removeAll(attUnsafe);
-        if (Math.min(maxAttack, attackersLeft.size()) >= life) {
+        if (lifeLossPerAttacker * Math.min(maxAttack, attackersLeft.size()) >= life) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * How much life the AI loses for each creature it sends at this defender, from cards like
+     * Revenge of Ravens, Hissing Miasma, Blood Reckoning and Marchesa's Decree.
+     *
+     * Found by looking for the trigger rather than by card name: an Attacks trigger on the
+     * defending player's battlefield whose effect makes the attacking player lose life. Cards that
+     * punish the creature instead of its controller, such as Circle of Flame, deliberately do not
+     * count here, since the cost of attacking is paid by the creature and is already handled by the
+     * usual combat evaluation.
+     */
+    private static int lifeLostPerAttacker(final GameEntity defender) {
+        final Player defendingPlayer;
+        if (defender instanceof Player player) {
+            defendingPlayer = player;
+        } else if (defender instanceof Card card) {
+            defendingPlayer = card.getController();
+        } else {
+            return 0;
+        }
+
+        int total = 0;
+        for (Card c : defendingPlayer.getCardsIn(ZoneType.Battlefield)) {
+            for (Trigger t : c.getTriggers()) {
+                if (t.getMode() != TriggerType.Attacks || !t.hasParam("Attacked")) {
+                    continue;
+                }
+                if (!t.zonesCheck(c.getGame().getZoneOf(c))) {
+                    continue;
+                }
+                total += lifeLossFromTriggerEffect(t.ensureAbility());
+            }
+        }
+        return total;
+    }
+
+    /** Walks the trigger's ability chain looking for life loss aimed at the attacking player. */
+    private static int lifeLossFromTriggerEffect(SpellAbility sa) {
+        int total = 0;
+        for (SpellAbility part = sa; part != null; part = part.getSubAbility()) {
+            if (part.getApi() != ApiType.LoseLife
+                    || !"TriggeredAttackerController".equals(part.getParam("Defined"))) {
+                continue;
+            }
+            // only trust a plain number; anything computed could depend on state we can't evaluate
+            // here, and guessing it would make the AI refuse to attack for no reason
+            String amount = part.getParamOrDefault("LifeAmount", "1");
+            if (!StringUtils.isNumeric(amount)) {
+                continue;
+            }
+            total += Integer.parseInt(amount);
+        }
+        return total;
     }
 
     public final static int countExaltedBonus(Player p) {

--- a/forge-gui-desktop/src/test/java/forge/ai/attacking/AttackIntoLifeLossPunisherTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/attacking/AttackIntoLifeLossPunisherTest.java
@@ -1,0 +1,81 @@
+package forge.ai.attacking;
+
+import forge.ai.PlayerControllerAi;
+import forge.ai.simulation.SimulationTest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ * "Whenever a creature attacks you, its controller loses 1 life" punishes the attacker rather than
+ * the attacking creature, so at low life the AI has to count the attackers it sends. That was
+ * previously only recognised on Revenge of Ravens by name, which left the AI walking into the
+ * several other cards printed with the same trigger.
+ */
+public class AttackIntoLifeLossPunisherTest extends SimulationTest {
+
+    private int attackersDeclaredAgainst(String punisher, int aiLife, int attackerCount) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        ai.setLife(aiLife, null);
+        opp.setLife(40, null);
+
+        if (punisher != null) {
+            addCard(punisher, opp);
+        }
+        for (int i = 0; i < attackerCount; i++) {
+            Card attacker = addCard("Runeclaw Bear", ai);
+            attacker.setSickness(false);
+        }
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        Combat combat = ((PlayerControllerAi) ai.getController()).getAi().getPredictedCombat();
+        return combat.getAttackers().size();
+    }
+
+    /** Sanity check: with nothing punishing the attack the AI is happy to swing. */
+    @Test
+    public void attacksFreelyWithNoPunisher() {
+        AssertJUnit.assertEquals("AI should attack when nothing punishes it", 3,
+                attackersDeclaredAgainst(null, 3, 3));
+    }
+
+    /** The case the name check already covered. */
+    @Test
+    public void holdsBackAgainstRevengeOfRavens() {
+        AssertJUnit.assertEquals("AI should not attack into lethal life loss", 0,
+                attackersDeclaredAgainst("Revenge of Ravens", 3, 3));
+    }
+
+    /** Same trigger, different card - the AI used to attack straight into these. */
+    @Test
+    public void holdsBackAgainstHissingMiasma() {
+        AssertJUnit.assertEquals("AI should not attack into lethal life loss", 0,
+                attackersDeclaredAgainst("Hissing Miasma", 3, 3));
+    }
+
+    @Test
+    public void holdsBackAgainstBloodReckoning() {
+        AssertJUnit.assertEquals("AI should not attack into lethal life loss", 0,
+                attackersDeclaredAgainst("Blood Reckoning", 3, 3));
+    }
+
+    /**
+     * Circle of Flame damages the attacking creature rather than its controller, so it costs the
+     * AI no life and must not be treated as one of these.
+     */
+    @Test
+    public void stillAttacksIntoCircleOfFlame() {
+        AssertJUnit.assertTrue("Circle of Flame costs the attacker no life, so the AI should still attack",
+                attackersDeclaredAgainst("Circle of Flame", 3, 3) > 0);
+    }
+}


### PR DESCRIPTION
`AiAttackController` only recognised **Revenge of Ravens**, by name, when working out whether attacking would cost the AI life:

```java
// TODO: detect Revenge of Ravens by the trigger instead of by name
revengeOfRavens = !CardLists.filter(player.getCardsIn(ZoneType.Battlefield),
        CardPredicates.nameEquals("Revenge of Ravens")).isEmpty();
```

Several cards are printed with the same trigger, and the AI walked straight into all of them:

| card | trigger |
|---|---|
| Hissing Miasma | Whenever a creature attacks you, its controller loses 1 life |
| Blood Reckoning | same, for creatures you don't control |
| Marchesa's Decree | same, alongside the monarch ability |

This does what the TODO asks and looks for the trigger: an `Attacks` trigger on the defending player's battlefield whose effect is `LoseLife` aimed at `TriggeredAttackerController`.

With the old name check, the added test shows the AI sending all three attackers into lethal life loss:

```
holdsBackAgainstHissingMiasma  AI should not attack into lethal life loss expected:<0> but was:<3>
holdsBackAgainstBloodReckoning AI should not attack into lethal life loss expected:<0> but was:<3>
```

## What deliberately does not count

Cards that punish the attacking *creature* rather than its controller — Circle of Flame dealing 1 damage to the attacker, Raking Canopy, Palazzo Archers — are excluded. The creature pays that cost, not the player, and normal combat evaluation already accounts for it. There's a test asserting the AI still attacks into Circle of Flame, so the check can't quietly widen to cards it shouldn't cover.

## Two smaller corrections in the same logic

- The life total is compared against the actual life lost per attacker rather than assuming 1, so a card draining 2 each is handled correctly.
- The "not worth attacking" filter uses that same number instead of a hardcoded `getNetCombatDamage() <= 1`.

Amounts that aren't plain numbers are skipped rather than guessed at, since overestimating here would make the AI refuse to attack for no reason.

## Verification

5 tests: no-punisher control, Revenge of Ravens (the case the name check already covered), Hissing Miasma, Blood Reckoning, and the Circle of Flame exclusion. Two of them fail on the old code.

Full `mvn -U -B clean test`: 12 modules, 308 tests, 0 failures, run three times.

---
Written with the help of GitHub Copilot CLI; the commit carries a `Co-authored-by` trailer for it.