### PR TITLE
Improve spell-choice fidelity in AI simulation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -62,6 +62,7 @@ import forge.util.collect.FCollection;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -76,7 +77,8 @@ import java.util.stream.Collectors;
  */
 public class ComputerUtil {
 
-    public static boolean handlePlayingSpellAbility(final Player ai, SpellAbility sa, Runnable chooseTargets) {
+    public static boolean handlePlayingSpellAbility(final Player ai, SpellAbility sa,
+            Consumer<SpellAbility> chooseTargets) {
         final Card source = sa.getHostCard();
         final Game game = source.getGame();
         final Card host = sa.getHostCard();
@@ -111,7 +113,7 @@ public class ComputerUtil {
             return false;
         }
         if (chooseTargets != null) {
-            chooseTargets.run();
+            chooseTargets.accept(sa);
             if (!sa.isTargetNumberValid()) {
                 return false;
             }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -77,8 +77,7 @@ import java.util.stream.Collectors;
  */
 public class ComputerUtil {
 
-    public static boolean handlePlayingSpellAbility(final Player ai, SpellAbility sa,
-            Consumer<SpellAbility> chooseTargets) {
+    public static boolean handlePlayingSpellAbility(final Player ai, SpellAbility sa, Consumer<SpellAbility> chooseTargets) {
         final Card source = sa.getHostCard();
         final Game game = source.getGame();
         final Card host = sa.getHostCard();

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -836,7 +837,7 @@ public class PlayerControllerAi extends PlayerController {
                 sa.resolve();
             }
         } else {
-            ComputerUtil.handlePlayingSpellAbility(player, sa, getDeferredTargetingPlayerRunnable(sa));
+            ComputerUtil.handlePlayingSpellAbility(player, sa, getDeferredTargetingPlayerAction(sa));
         }
         return true;
     }
@@ -846,11 +847,10 @@ public class PlayerControllerAi extends PlayerController {
      * defers the human choice from canPlayAI (worker thread with possibly low timeout)
      * to handlePlayingSpellAbility (game thread, no timeout).
      */
-    private Runnable getDeferredTargetingPlayerRunnable(SpellAbility sa) {
-        SpellAbility root = sa;
+    private Consumer<SpellAbility> getDeferredTargetingPlayerAction(SpellAbility sa) {
         while (sa != null) {
             if (sa.hasParam("TargetingPlayer") && sa.getTargetingPlayer() != null) {
-                return () -> {
+                return root -> {
                     SpellAbility cur = root;
                     while (cur != null) {
                         if (cur.hasParam("TargetingPlayer") && cur.getTargetingPlayer() != null) {
@@ -1604,6 +1604,9 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public int chooseNumberForKeywordCost(SpellAbility sa, Cost cost, KeywordInterface keyword, String prompt, int max) {
+        if (sa.hasOptionalKeywordAmount(keyword)) {
+            return Math.min(sa.getOptionalKeywordAmount(keyword), max);
+        }
         // TODO: improve the logic depending on the keyword and the playability of the cost-modified SA (enough targets present etc.)
         if (keyword.getKeyword() == Keyword.CASUALTY
                 && "true".equalsIgnoreCase(sa.getHostCard().getSVar("AINoCasualtyPayment"))) {

--- a/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
@@ -7,7 +7,6 @@ import forge.ai.PlayerControllerAi;
 import forge.ai.simulation.GameStateEvaluator.Score;
 import forge.game.Game;
 import forge.game.GameActionUtil;
-import forge.game.GameObject;
 import forge.game.card.Card;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -156,12 +155,8 @@ public class GameSimulator {
             result = saMatcher(GameActionUtil.getAlternativeCosts(cSa, aiPlayer, true), desc);
         }
 
-        // this block is for OnePlaySafetyChecker
-        if (result != null && sa.hasParam("WithoutManaCost") && !result.hasParam("WithoutManaCost")) {
-            result = result.copyWithNoManaCost(aiPlayer);
-        }
         if (result != null) {
-            result.setCastFromPlayEffect(sa.isCastFromPlayEffect());
+            result = SpellAbilityChoiceCopier.copyCastChoices(sa, result, aiPlayer);
         }
 
         return result;
@@ -209,37 +204,21 @@ public class GameSimulator {
 
             debugPrint("Found SA " + sa + " on host card " + sa.getHostCard() + " with owner:"+ sa.getHostCard().getOwner());
             sa.setActivatingPlayer(aiPlayer);
-            SpellAbility origSaOrSubSa = origSa;
-            SpellAbility saOrSubSa = sa;
-            do {
-                if (origSaOrSubSa.usesTargeting()) {
-                    final boolean divided = origSaOrSubSa.isDividedAsYouChoose();
-                    for (final GameObject o : origSaOrSubSa.getTargets()) {
-                        final GameObject target = copier.find(o);
-                        saOrSubSa.getTargets().add(target);
-                        if (divided) {
-                            saOrSubSa.addDividedAllocation(target, origSaOrSubSa.getDividedValue(o));
-                        }
-                    }
-                }
-                origSaOrSubSa = origSaOrSubSa.getSubAbility();
-                saOrSubSa = saOrSubSa.getSubAbility();
-            } while (saOrSubSa != null);
 
-            if (debugPrint && !sa.getAllTargetChoices().isEmpty()) {
-                debugPrint("Targets: ");
-                for (TargetChoices target : sa.getAllTargetChoices()) {
-                    System.out.print(target);
-                }
-                System.out.println();
-            }
-            final SpellAbility playingSa = sa;
-            // Is this right?
             simGame.copyLastState();
-            boolean success = ComputerUtil.handlePlayingSpellAbility(aiPlayer, sa, () -> {
+            boolean success = ComputerUtil.handlePlayingSpellAbility(aiPlayer, sa, playingSa -> {
                 if (interceptor != null) {
                     interceptor.announceX(playingSa);
                     interceptor.chooseTargets(playingSa, GameSimulator.this);
+                } else {
+                    SpellAbilityChoiceCopier.copyTargets(origSa, playingSa, copier::find);
+                }
+                if (debugPrint && !playingSa.getAllTargetChoices().isEmpty()) {
+                    debugPrint("Targets: ");
+                    for (TargetChoices target : playingSa.getAllTargetChoices()) {
+                        System.out.print(target);
+                    }
+                    System.out.println();
                 }
             });
             if (!success) {

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityChoiceCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityChoiceCopier.java
@@ -1,0 +1,101 @@
+package forge.ai.simulation;
+
+import forge.game.GameActionUtil;
+import forge.game.GameObject;
+import forge.game.keyword.KeywordInterface;
+import forge.game.player.Player;
+import forge.game.spellability.AbilitySub;
+import forge.game.spellability.OptionalCostValue;
+import forge.game.spellability.SpellAbility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+final class SpellAbilityChoiceCopier {
+    private SpellAbilityChoiceCopier() {
+    }
+
+    static SpellAbility copyCastChoices(SpellAbility source, SpellAbility destination, Player player) {
+        if (source.hasParam("WithoutManaCost") && !destination.hasParam("WithoutManaCost")) {
+            destination = destination.copyWithNoManaCost(player);
+        }
+
+        if (source.getOptionalCosts().iterator().hasNext()) {
+            List<OptionalCostValue> costs = GameActionUtil.getOptionalCostValues(destination);
+            costs.removeIf(cost -> !source.isOptionalCostPaid(cost.getType()));
+            destination = GameActionUtil.addOptionalCosts(destination, costs);
+        }
+
+        copyKeywordChoices(source, destination);
+        destination.setCastFromPlayEffect(source.isCastFromPlayEffect());
+        destination.setXManaCostPaid(source.getXManaCostPaid());
+        return copyChosenModes(source, destination) ? destination : null;
+    }
+
+    static void copyTargets(SpellAbility source, SpellAbility destination,
+            Function<GameObject, GameObject> gameObjectMapper) {
+        if (source == destination) {
+            return;
+        }
+        for (SpellAbility sourceAbility = source, destinationAbility = destination;
+                sourceAbility != null && destinationAbility != null;
+                sourceAbility = sourceAbility.getSubAbility(),
+                        destinationAbility = destinationAbility.getSubAbility()) {
+            if (!sourceAbility.usesTargeting()) {
+                continue;
+            }
+            for (GameObject sourceTarget : sourceAbility.getTargets()) {
+                GameObject destinationTarget = gameObjectMapper.apply(sourceTarget);
+                destinationAbility.getTargets().add(destinationTarget);
+                if (sourceAbility.isDividedAsYouChoose()) {
+                    destinationAbility.addDividedAllocation(
+                            destinationTarget, sourceAbility.getDividedValue(sourceTarget));
+                }
+            }
+        }
+    }
+
+    private static void copyKeywordChoices(SpellAbility source, SpellAbility destination) {
+        if (source.getOptionalKeywords().isEmpty()) {
+            return;
+        }
+        for (KeywordInterface sourceKeyword : source.getHostCard().getKeywords()) {
+            if (!source.hasOptionalKeywordAmount(sourceKeyword)) {
+                continue;
+            }
+            for (KeywordInterface destinationKeyword : destination.getHostCard().getKeywords()) {
+                if (sourceKeyword.getKeyword() == destinationKeyword.getKeyword()
+                        && Objects.equals(sourceKeyword.getOriginal(), destinationKeyword.getOriginal())) {
+                    destination.setOptionalKeywordAmount(
+                            destinationKeyword, source.getOptionalKeywordAmount(sourceKeyword));
+                    break;
+                }
+            }
+        }
+    }
+
+    private static boolean copyChosenModes(SpellAbility source, SpellAbility destination) {
+        if (source.getChosenList() == null) {
+            return true;
+        }
+
+        List<AbilitySub> choices = destination.getAdditionalAbilityList("Choices");
+        List<AbilitySub> chosen = new ArrayList<>();
+        for (AbilitySub sourceMode : source.getChosenList()) {
+            AbilitySub destinationMode = choices.stream()
+                    .filter(choice -> Objects.equals(
+                            choice.getParam("SpellDescription"),
+                            sourceMode.getParam("SpellDescription")))
+                    .findFirst()
+                    .orElse(null);
+            if (destinationMode == null) {
+                return false;
+            }
+            chosen.add(destinationMode);
+        }
+        destination.setChosenList(chosen);
+        return true;
+    }
+}

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityChoiceCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityChoiceCopier.java
@@ -50,8 +50,7 @@ final class SpellAbilityChoiceCopier {
                 GameObject destinationTarget = gameObjectMapper.apply(sourceTarget);
                 destinationAbility.getTargets().add(destinationTarget);
                 if (sourceAbility.isDividedAsYouChoose()) {
-                    destinationAbility.addDividedAllocation(
-                            destinationTarget, sourceAbility.getDividedValue(sourceTarget));
+                    destinationAbility.addDividedAllocation(destinationTarget, sourceAbility.getDividedValue(sourceTarget));
                 }
             }
         }
@@ -68,8 +67,7 @@ final class SpellAbilityChoiceCopier {
             for (KeywordInterface destinationKeyword : destination.getHostCard().getKeywords()) {
                 if (sourceKeyword.getKeyword() == destinationKeyword.getKeyword()
                         && Objects.equals(sourceKeyword.getOriginal(), destinationKeyword.getOriginal())) {
-                    destination.setOptionalKeywordAmount(
-                            destinationKeyword, source.getOptionalKeywordAmount(sourceKeyword));
+                    destination.setOptionalKeywordAmount(destinationKeyword, source.getOptionalKeywordAmount(sourceKeyword));
                     break;
                 }
             }
@@ -88,8 +86,7 @@ final class SpellAbilityChoiceCopier {
                     .filter(choice -> Objects.equals(
                             choice.getParam("SpellDescription"),
                             sourceMode.getParam("SpellDescription")))
-                    .findFirst()
-                    .orElse(null);
+                    .findFirst().orElse(null);
             if (destinationMode == null) {
                 return false;
             }

--- a/forge-gui-desktop/src/test/java/forge/ai/AITest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/AITest.java
@@ -188,6 +188,17 @@ public class AITest {
         return c;
     }
 
+    protected void fillLibrary(Player player, int count) {
+        for (int i = 0; i < count; i++) {
+            addCardToZone("Runeclaw Bear", player, ZoneType.Library);
+        }
+    }
+
+    protected void moveToMain2(Game game, Player player) {
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, player);
+        game.getAction().checkStateEffects(true);
+    }
+
     protected void playUntilStackClear(Game game) {
         do {
             game.getPhaseHandler().mainLoopStep();

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulatorSpellChoiceTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulatorSpellChoiceTest.java
@@ -1,0 +1,222 @@
+package forge.ai.simulation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import forge.game.Game;
+import forge.game.GameActionUtil;
+import forge.game.ability.effects.CharmEffect;
+import forge.game.card.Card;
+import forge.game.card.CounterEnumType;
+import forge.game.keyword.Keyword;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.AbilitySub;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+public class GameSimulatorSpellChoiceTest extends SimulationTest {
+    @Test
+    public void testPreservesKickerChoice() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Forest", 6, ai);
+        Card woodreaders = addCardToZone("Citanul Woodreaders", ai, ZoneType.Hand);
+        fillLibrary(ai, 2);
+
+        SpellAbility baseAbility = ability(woodreaders, ai);
+        SpellAbility kickedAbility = GameActionUtil.addOptionalCosts(
+                baseAbility, GameActionUtil.getOptionalCostValues(baseAbility));
+        kickedAbility.setActivatingPlayer(ai);
+
+        Player simulatedAi = simulatedPlayer(game, ai, kickedAbility);
+        AssertJUnit.assertEquals("The kicked ETB should draw two cards",
+                2, simulatedAi.getCardsIn(ZoneType.Hand).size());
+    }
+
+    @Test
+    public void testPreservesMultikickerCount() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Forest", 6, ai);
+        Card elemental = addCardToZone("Wolfbriar Elemental", ai, ZoneType.Hand);
+
+        SpellAbility twiceKicked = GameActionUtil.addExtraKeywordCost(ability(elemental, ai));
+        AssertJUnit.assertEquals(2,
+                twiceKicked.getOptionalKeywordAmount(Keyword.MULTIKICKER));
+        addCard("Forest", ai);
+
+        Player simulatedAi = simulatedPlayer(game, ai, twiceKicked);
+        AssertJUnit.assertEquals("The simulation must not reselect a larger multikicker count",
+                3, simulatedAi.getCreaturesInPlay().size());
+    }
+
+    @Test
+    public void testPreservesTargetsAfterAddingKeywordCosts() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Mountain", 6, ai);
+        Card pyromatics = addCardToZone("Pyromatics", ai, ZoneType.Hand);
+
+        SpellAbility twiceReplicated = GameActionUtil.addExtraKeywordCost(ability(pyromatics, ai));
+        AssertJUnit.assertEquals(2,
+                twiceReplicated.getOptionalKeywordAmount(Keyword.REPLICATE));
+        twiceReplicated.getTargets().add(opponent);
+        addCards("Mountain", 2, ai);
+
+        GameSimulator simulator = simulate(game, ai, twiceReplicated);
+        Player simulatedOpponent = (Player) simulator.getGameCopier().find(opponent);
+        AssertJUnit.assertEquals("The original spell and both copies should keep a legal target",
+                17, simulatedOpponent.getLife());
+    }
+
+    @Test
+    public void testPreservesAnnouncedX() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Forest", 5, ai);
+        Card hurricane = addCardToZone("Hurricane", ai, ZoneType.Hand);
+
+        SpellAbility ability = ability(hurricane, ai);
+        ability.setXManaCostPaid(4);
+        GameSimulator simulator = simulate(game, ai, ability);
+        Player simulatedAi = (Player) simulator.getGameCopier().find(ai);
+        Player simulatedOpponent = (Player) simulator.getGameCopier().find(opponent);
+
+        AssertJUnit.assertEquals("The copied spell must retain the announced value of X",
+                16, simulatedAi.getLife());
+        AssertJUnit.assertEquals(16, simulatedOpponent.getLife());
+    }
+
+    @Test
+    public void testPreservesChosenMode() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCard("Plains", ai);
+        addCard("Swamp", ai);
+        addCard("Forest", ai);
+        Card charm = addCardToZone("Abzan Charm", ai, ZoneType.Hand);
+        addCard("Shivan Dragon", opponent);
+        fillLibrary(ai, 2);
+
+        SpellAbility ability = ability(charm, ai);
+        chooseModes(ability, "You draw");
+
+        GameSimulator simulator = simulate(game, ai, ability);
+        Player simulatedAi = (Player) simulator.getGameCopier().find(ai);
+        Player simulatedOpponent = (Player) simulator.getGameCopier().find(opponent);
+
+        AssertJUnit.assertEquals("The copied Charm must use the selected draw mode",
+                2, simulatedAi.getCardsIn(ZoneType.Hand).size());
+        AssertJUnit.assertNotNull("The simulation must not substitute the exile mode",
+                findCardWithName(simulatedOpponent.getGame(), "Shivan Dragon"));
+    }
+
+    @Test
+    public void testPreservesMultipleChosenModes() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Island", 4, ai);
+        Card command = addCardToZone("Cryptic Command", ai, ZoneType.Hand);
+        addCards("Runeclaw Bear", 3, opponent);
+        fillLibrary(ai, 1);
+
+        SpellAbility ability = ability(command, ai);
+        chooseModes(ability, "Tap all", "Draw a card");
+
+        GameSimulator simulator = simulate(game, ai, ability);
+        Player simulatedAi = (Player) simulator.getGameCopier().find(ai);
+        Player simulatedOpponent = (Player) simulator.getGameCopier().find(opponent);
+
+        AssertJUnit.assertEquals("The draw mode should resolve",
+                1, simulatedAi.getCardsIn(ZoneType.Hand).size());
+        AssertJUnit.assertTrue("The tap mode should also resolve",
+                simulatedOpponent.getCreaturesInPlay().stream().allMatch(Card::isTapped));
+    }
+
+    @Test
+    public void testPreservesDividedModalAllocations() {
+        Game game = createGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Plains", ai);
+        addCard("Swamp", ai);
+        addCard("Forest", ai);
+        Card first = addCard("Runeclaw Bear", ai);
+        Card second = addCard("Raging Goblin", ai);
+        Card charm = addCardToZone("Abzan Charm", ai, ZoneType.Hand);
+
+        AbilitySub counters = chooseMode(ability(charm, ai), "Distribute");
+        counters.getTargets().add(first);
+        counters.getTargets().add(second);
+        counters.addDividedAllocation(first, 1);
+        counters.addDividedAllocation(second, 1);
+
+        GameSimulator simulator = simulate(game, ai, counters.getRootAbility());
+        Card simulatedFirst = (Card) simulator.getGameCopier().find(first);
+        Card simulatedSecond = (Card) simulator.getGameCopier().find(second);
+
+        AssertJUnit.assertEquals(1, simulatedFirst.getCounters(CounterEnumType.P1P1));
+        AssertJUnit.assertEquals(1, simulatedSecond.getCounters(CounterEnumType.P1P1));
+    }
+
+    private Game createGame() {
+        Game game = initAndCreateGame();
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, game.getPlayers().get(1));
+        game.getAction().checkStateEffects(true);
+        return game;
+    }
+
+    private Player simulatedPlayer(Game game, Player player, SpellAbility ability) {
+        return (Player) simulate(game, player, ability).getGameCopier().find(player);
+    }
+
+    private GameSimulator simulate(Game game, Player player, SpellAbility ability) {
+        GameSimulator simulator = createSimulator(game, player);
+        simulator.simulateSpellAbility(ability);
+        return simulator;
+    }
+
+    private SpellAbility ability(Card card, Player player) {
+        SpellAbility ability = card.getFirstSpellAbility();
+        ability.setActivatingPlayer(player);
+        return ability;
+    }
+
+    private AbilitySub chooseMode(SpellAbility ability, String descriptionPrefix) {
+        chooseModes(ability, descriptionPrefix);
+        return ability.getSubAbility();
+    }
+
+    private void chooseModes(SpellAbility ability, String... descriptionPrefixes) {
+        List<AbilitySub> options = CharmEffect.makePossibleOptions(ability);
+        List<AbilitySub> modes = new ArrayList<>();
+        for (String prefix : descriptionPrefixes) {
+            modes.add(options.stream()
+                    .filter(option -> option.getParam("SpellDescription").startsWith(prefix))
+                    .findFirst()
+                    .orElseThrow());
+        }
+        ability.setChosenList(modes);
+        CharmEffect.chainAbilities(ability, modes);
+    }
+
+    private void fillLibrary(Player player, int count) {
+        for (int i = 0; i < count; i++) {
+            addCardToZone("Runeclaw Bear", player, ZoneType.Library);
+        }
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulatorSpellChoiceTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulatorSpellChoiceTest.java
@@ -12,13 +12,13 @@ import forge.game.ability.effects.CharmEffect;
 import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
 import forge.game.keyword.Keyword;
-import forge.game.phase.PhaseType;
 import forge.game.player.Player;
 import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
 public class GameSimulatorSpellChoiceTest extends SimulationTest {
+
     @Test
     public void testPreservesKickerChoice() {
         Game game = createGame();
@@ -175,8 +175,7 @@ public class GameSimulatorSpellChoiceTest extends SimulationTest {
 
     private Game createGame() {
         Game game = initAndCreateGame();
-        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, game.getPlayers().get(1));
-        game.getAction().checkStateEffects(true);
+        moveToMain2(game, game.getPlayers().get(1));
         return game;
     }
 
@@ -214,9 +213,4 @@ public class GameSimulatorSpellChoiceTest extends SimulationTest {
         CharmEffect.chainAbilities(ability, modes);
     }
 
-    private void fillLibrary(Player player, int count) {
-        for (int i = 0; i < count; i++) {
-            addCardToZone("Runeclaw Bear", player, ZoneType.Library);
-        }
-    }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/OnePlaySafetyCheckerTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/OnePlaySafetyCheckerTest.java
@@ -10,7 +10,6 @@ import forge.ai.AiPlayDecision;
 import forge.ai.PlayerControllerAi;
 import forge.game.Game;
 import forge.game.card.Card;
-import forge.game.phase.PhaseType;
 import forge.game.player.Player;
 import forge.game.spellability.Spell;
 import forge.game.spellability.SpellAbility;
@@ -216,17 +215,6 @@ public class OnePlaySafetyCheckerTest extends SimulationTest {
 
     private AiController ai(Player player) {
         return ((PlayerControllerAi) player.getController()).getAi();
-    }
-
-    private void fillLibrary(Player player, int count) {
-        for (int i = 0; i < count; i++) {
-            addCardToZone("Runeclaw Bear", player, ZoneType.Library);
-        }
-    }
-
-    private void moveToMain2(Game game, Player player) {
-        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, player);
-        game.getAction().checkStateEffects(true);
     }
 
     private static final class Scenario {


### PR DESCRIPTION
## Summary

Improve `GameSimulator` so the ability resolved in the copied game preserves the choices already made for the original ability.

Previously, simulation could evaluate a different version of a spell by losing its optional costs, keyword-cost count, announced X value, selected modes, targets, or divided allocations.

## Changes

- Extract spell-choice translation into a focused `SpellAbilityChoiceCopier` helper.
- Preserve:
  - optional costs such as kicker
  - multikicker and replicate counts
  - announced X values
  - single and multiple selected modes
  - targets and divided allocations
  - free-cast state
- Make AI controllers respect preselected keyword-cost amounts.
- Pass the final post-cost/post-mode ability to deferred targeting.

The last point matters for abilities such as Replicate: adding the keyword cost can create a replacement ability, so targets must be applied to that final ability rather than the discarded original.

## Tests

Added focused simulation regressions for kicker, multikicker, Replicate with targets, X spells, modal spells, and divided allocations.

Thanks to Codex for help with code and tests!