### PR TITLE
Improve multiplayer and phasing evaluation in AI simulation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -105,7 +105,7 @@ public class AiController {
         player = computerPlayer;
         game = game0;
         memory = new AiCardMemory();
-        simPicker = new SpellAbilityPicker(game, player);
+        simPicker = new SpellAbilityPicker(player);
     }
 
     public boolean usesHybridSimulation() {

--- a/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
@@ -251,7 +251,7 @@ public class GameSimulator {
         controller.possiblyCacheResult(score, origSa);
         if (controller.shouldRecurse() && !simGame.isGameOver()) {
             controller.push(sa, score, this);
-            SpellAbilityPicker sim = new SpellAbilityPicker(simGame, aiPlayer);
+            SpellAbilityPicker sim = new SpellAbilityPicker(aiPlayer);
             SpellAbility nextSa = sim.chooseSpellAbilityToPlay(controller);
             if (nextSa != null) {
                 score = sim.getScoreForChosenAbility();

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -119,7 +119,7 @@ public class GameStateEvaluator {
 
     private Score getScoreForGameStateImpl(Game game, Player aiPlayer) {
         // TODO: try and reuse evaluateBoardPosition
-        int handScore = 0;
+        int score = 0;
         int aiCards = 0;
         int teammateCards = 0;
         int opponentCards = 0;
@@ -131,14 +131,14 @@ public class GameStateEvaluator {
         for (Player player : game.getPlayers()) {
             int cards = player.getCardsIn(ZoneType.Hand).size();
             if (player.isOpponentOf(aiPlayer)) {
-                handScore -= 4 * cards;
+                score -= 4 * cards;
                 opponentCards += cards;
                 opponentLife += player.getLife();
                 debugPrint("  Opponent " + (++opponents) + " life: -" + player.getLife());
             } else {
                 int fullValueCards = player.isUnlimitedHandSize()
                         ? cards : min(cards, player.getMaxHandSize());
-                handScore += cards + 4 * fullValueCards;
+                score += cards + 4 * fullValueCards;
                 teamLife += player.getLife();
                 teamPlayers++;
                 if (player == aiPlayer) {
@@ -156,18 +156,17 @@ public class GameStateEvaluator {
         }
         debugPrint("Their cards in hand: " + opponentCards);
         // TODO weight cards in hand more if opponent has discard or if we have looting or can bluff a trick
-        int score = handScore + 2 * teamLife / teamPlayers;
+        score += 2 * teamLife / teamPlayers;
         if (opponents > 0) {
             score -= 2 * opponentLife / opponents;
         }
 
         // evaluate mana base quality
         AiDeckStatistics statistics = AiDeckStatistics.fromPlayer(aiPlayer);
-        int availableManaScore = evalManaBase(game, aiPlayer, statistics);
+        int availableManaScore = evalManaBase(aiPlayer, statistics, false);
         int strategicManaScore = aiPlayer.getCardsIn(ZoneType.Battlefield, false).stream()
-                .anyMatch(c -> c.isPhasedOut() && phasesInNormally(c)
-                        && !c.getManaAbilities().isEmpty())
-                ? evalManaBase(game, aiPlayer, statistics, true) : availableManaScore;
+                .anyMatch(c -> c.isPhasedOut() && phasesInNormally(c) && !c.getManaAbilities().isEmpty())
+                ? evalManaBase(aiPlayer, statistics, true) : availableManaScore;
         int availableScore = score + availableManaScore;
         score += strategicManaScore;
         // TODO deal with opponents. Do we want to use perfect information to evaluate their manabase?
@@ -186,10 +185,10 @@ public class GameStateEvaluator {
                 continue;
             }
             int value = evalCard(game, aiPlayer, c);
-            int availableValue = phasedOut ? 0 : value;
+            int availableValue = value;
             // To make the AI hold-off on playing creatures before MAIN2 if they give no other benefits,
             // keep track of the score while treating summon sick creatures as having a value of 0.
-            if (gamePhase.isBefore(PhaseType.MAIN2) && c.isSick() && c.getController() == aiPlayer) {
+            if (phasedOut || (gamePhase.isBefore(PhaseType.MAIN2) && c.isSick() && c.getController() == aiPlayer)) {
                 availableValue = 0;
             }
             String str = cardToString(c);
@@ -207,11 +206,7 @@ public class GameStateEvaluator {
         return new Score(score, availableScore);
     }
 
-    public int evalManaBase(Game game, Player player, AiDeckStatistics statistics) {
-        return evalManaBase(game, player, statistics, false);
-    }
-
-    private int evalManaBase(Game game, Player player, AiDeckStatistics statistics, boolean includeNormalPhasing) {
+    private int evalManaBase(Player player, AiDeckStatistics statistics, boolean includeNormalPhasing) {
         // TODO should these be fixed quantities or should they be linear out of like 1000/(desired - total)?
         int value = 0;
         // get the colors of mana we can produce and the maximum number of pips
@@ -221,8 +216,7 @@ public class GameStateEvaluator {
 
         // Strategic evaluation includes lands guaranteed to phase in normally; availability does not.
         for (Card c : player.getCardsIn(ZoneType.Battlefield, false)) {
-            if (c.isPhasedOut()
-                    && (!includeNormalPhasing || !phasesInNormally(c))) {
+            if (c.isPhasedOut() && (!includeNormalPhasing || !phasesInNormally(c))) {
                 continue;
             }
             int max_produced = 0;

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -88,39 +88,29 @@ public class GameStateEvaluator {
         return score > Integer.MAX_VALUE - (long) MAX_DISCOUNTED_TURNS * GAME_OVER_TURN_PENALTY;
     }
 
-    private Score getTerminalScore(Game game, boolean won) {
+    private Score getTerminalScore(Game game, Player ai) {
         // a game long enough to overflow the discount is not one we can reason about anyway
-        int turn = Math.min(Math.max(game.getPhaseHandler().getTurn(), 0), MAX_DISCOUNTED_TURNS);
-        if (won) {
+        int turn = Math.min(game.getPhaseHandler().getTurn(), MAX_DISCOUNTED_TURNS);
+        if (ai.hasWon()) {
             // prefer winning sooner
             // TODO should consider recursion depth for the less complex combos more likely to succeed
             return new Score(Integer.MAX_VALUE - turn * GAME_OVER_TURN_PENALTY);
         }
 
-        // prefer losing later, staying clear of MIN_VALUE so a loss is never mistaken for a
-        // failed simulation
+        // prefer losing later, staying clear of MIN_VALUE so a loss is never mistaken for a failed simulation
         return new Score(Integer.MIN_VALUE + 1 + turn * GAME_OVER_TURN_PENALTY);
     }
 
-    private Score getScoreForGameOver(Game game, Player aiPlayer) {
-        boolean won = game.getOutcome().getWinningTeam() == aiPlayer.getTeam()
-                || game.getOutcome().isWinner(aiPlayer.getRegisteredPlayer());
-        return getTerminalScore(game, won);
-    }
-
     public Score getScoreForGameState(Game game, Player aiPlayer) {
-        if (game.isGameOver()) {
-            return getScoreForGameOver(game, aiPlayer);
-        }
         if (!aiPlayer.isInGame()) {
-            return getTerminalScore(game, aiPlayer.hasWon());
+            return getTerminalScore(game, aiPlayer);
         }
 
         CombatSimResult result = simulateUpcomingCombatThisTurn(game, aiPlayer);
         if (result != null) {
             Player aiPlayerCopy = (Player) result.copier.find(aiPlayer);
-            if (result.gameCopy.isGameOver()) {
-                return getScoreForGameOver(result.gameCopy, aiPlayerCopy);
+            if (!aiPlayerCopy.isInGame()) {
+                return getTerminalScore(result.gameCopy, aiPlayerCopy);
             }
             return getScoreForGameStateImpl(result.gameCopy, aiPlayerCopy);
         }

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -78,6 +78,9 @@ public class GameStateEvaluator {
     }
 
     public Score getScoreForGameState(Game game, Player aiPlayer) {
+        if (aiPlayer.hasLost()) {
+            return new Score(Integer.MIN_VALUE);
+        }
         if (game.isGameOver()) {
             return getScoreForGameOver(game, aiPlayer);
         }
@@ -94,37 +97,33 @@ public class GameStateEvaluator {
     }
 
     private Score getScoreForGameStateImpl(Game game, Player aiPlayer) {
-        int score = 0;
-        // TODO: more than 2 players
         // TODO: try and reuse evaluateBoardPosition
-        int myCards = 0;
-        int theirCards = 0;
-        for (Card c : game.getCardsIn(ZoneType.Hand)) {
-            if (c.getController() == aiPlayer) {
-                myCards++;
+        int handScore = 0;
+        int alliedLife = 0;
+        int alliedPlayers = 0;
+        int opponentLife = 0;
+        int opponents = 0;
+        for (Player player : game.getPlayers()) {
+            int cards = player.getCardsIn(ZoneType.Hand).size();
+            if (player.isOpponentOf(aiPlayer)) {
+                handScore -= 4 * cards;
+                opponentLife += player.getLife();
+                debugPrint("  Opponent " + (++opponents) + ": " + cards
+                        + " cards, " + player.getLife() + " life");
             } else {
-                theirCards++;
+                int fullValueCards = player.isUnlimitedHandSize()
+                        ? cards : min(cards, player.getMaxHandSize());
+                handScore += cards + 4 * fullValueCards;
+                alliedLife += player.getLife();
+                debugPrint("  Ally " + (++alliedPlayers) + ": " + cards
+                        + " cards, " + player.getLife() + " life");
             }
         }
-        debugPrint("My cards in hand: " + myCards);
-        debugPrint("Their cards in hand: " + theirCards);
-        if (!aiPlayer.isUnlimitedHandSize() && myCards > aiPlayer.getMaxHandSize()) {
-            // Count excess cards for less.
-            score += myCards - aiPlayer.getMaxHandSize();
-            myCards = aiPlayer.getMaxHandSize();
-        }
         // TODO weight cards in hand more if opponent has discard or if we have looting or can bluff a trick
-        score += 5 * myCards - 4 * theirCards;
-        debugPrint("  My life: " + aiPlayer.getLife());
-        score += 2 * aiPlayer.getLife();
-        int opponentIndex = 1;
-        int opponentLife = 0;
-        for (Player opponent : aiPlayer.getOpponents()) {
-            debugPrint("  Opponent " + opponentIndex + " life: -" + opponent.getLife());
-            opponentLife += opponent.getLife();
-            opponentIndex++;
+        int score = handScore + 2 * alliedLife / alliedPlayers;
+        if (opponents > 0) {
+            score -= 2 * opponentLife / opponents;
         }
-        score -= 2* opponentLife / (game.getPlayers().size() - 1);
 
         // evaluate mana base quality
         score += evalManaBase(game, aiPlayer, AiDeckStatistics.fromPlayer(aiPlayer));
@@ -139,7 +138,7 @@ public class GameStateEvaluator {
 
         int summonSickScore = score;
         PhaseType gamePhase = game.getPhaseHandler().getPhase();
-        for (Card c : game.getCardsIn(ZoneType.Battlefield)) {
+        for (Card c : game.getCardsIncludePhasingIn(ZoneType.Battlefield)) {
             int value = evalCard(game, aiPlayer, c);
             int summonSickValue = value;
             // To make the AI hold-off on playing creatures before MAIN2 if they give no other benefits,
@@ -148,7 +147,7 @@ public class GameStateEvaluator {
                 summonSickValue = 0;
             }
             String str = cardToString(c);
-            if (c.getController() == aiPlayer) {
+            if (!c.getController().isOpponentOf(aiPlayer)) {
                 debugPrint("  Battlefield: " + str + " = " + value);
                 score += value;
                 summonSickScore += summonSickValue;
@@ -175,7 +174,8 @@ public class GameStateEvaluator {
         // this logic taken from ManaCost.getColorShardCounts()
         int[] counts = new int[6]; // in WUBRGC order
 
-        for (Card c : player.getCardsIn(ZoneType.Battlefield)) {
+        // Mana-base quality is long-term, so include lands that will phase back in.
+        for (Card c : player.getCardsIn(ZoneType.Battlefield, false)) {
             int max_produced = 0;
             for (SpellAbility m: c.getManaAbilities()) {
                 m.setActivatingPlayer(c.getController());

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -35,7 +35,6 @@ public class GameStateEvaluator {
 
     private static class CombatSimResult {
         public GameCopier copier;
-        public Game gameCopy;
     }
     private CombatSimResult simulateUpcomingCombatThisTurn(final Game evalGame, final Player aiPlayer) {
         PhaseType phase = evalGame.getPhaseHandler().getPhase();
@@ -56,7 +55,6 @@ public class GameStateEvaluator {
         gameCopy.getPhaseHandler().devAdvanceToPhase(PhaseType.COMBAT_DAMAGE, () -> GameSimulator.resolveStack(gameCopy, aiPlayer.getWeakestOpponent()));
         CombatSimResult result = new CombatSimResult();
         result.copier = copier;
-        result.gameCopy = gameCopy;
         return result;
     }
 
@@ -110,9 +108,9 @@ public class GameStateEvaluator {
         if (result != null) {
             Player aiPlayerCopy = (Player) result.copier.find(aiPlayer);
             if (!aiPlayerCopy.isInGame()) {
-                return getTerminalScore(result.gameCopy, aiPlayerCopy);
+                return getTerminalScore(result.copier.getCopiedGame(), aiPlayerCopy);
             }
-            return getScoreForGameStateImpl(result.gameCopy, aiPlayerCopy);
+            return getScoreForGameStateImpl(result.copier.getCopiedGame(), aiPlayerCopy);
         }
         return getScoreForGameStateImpl(game, aiPlayer);
     }

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -73,8 +73,7 @@ public class GameStateEvaluator {
             return false;
         }
         Card attachedTo = card.getAttachedTo();
-        return card.isDirectlyPhasedOut()
-                || attachedTo != null && phasesInNormally(attachedTo);
+        return card.isDirectlyPhasedOut() || attachedTo != null && phasesInNormally(attachedTo);
     }
 
     // Winning and losing are still the extremes of the range, but a win twenty turns from now is
@@ -200,14 +199,12 @@ public class GameStateEvaluator {
             int availableValue = phasedOut ? 0 : value;
             // To make the AI hold-off on playing creatures before MAIN2 if they give no other benefits,
             // keep track of the score while treating summon sick creatures as having a value of 0.
-            if (gamePhase.isBefore(PhaseType.MAIN2) && c.isSick()
-                    && c.getController() == aiPlayer) {
+            if (gamePhase.isBefore(PhaseType.MAIN2) && c.isSick() && c.getController() == aiPlayer) {
                 availableValue = 0;
             }
             String str = cardToString(c);
             int multiplier = c.getController().isOpponentOf(aiPlayer) ? -1 : 1;
-            debugPrint("  Battlefield: " + str + " = "
-                    + (multiplier < 0 ? "-" : "") + value);
+            debugPrint("  Battlefield: " + str + " = " + (multiplier < 0 ? "-" : "") + value);
             score += multiplier * value;
             availableScore += multiplier * availableValue;
             String nonAbilityText = c.getNonAbilityText();
@@ -224,8 +221,7 @@ public class GameStateEvaluator {
         return evalManaBase(game, player, statistics, false);
     }
 
-    private int evalManaBase(Game game, Player player, AiDeckStatistics statistics,
-            boolean includeNormalPhasing) {
+    private int evalManaBase(Game game, Player player, AiDeckStatistics statistics, boolean includeNormalPhasing) {
         // TODO should these be fixed quantities or should they be linear out of like 1000/(desired - total)?
         int value = 0;
         // get the colors of mana we can produce and the maximum number of pips

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -68,6 +68,15 @@ public class GameStateEvaluator {
         return str;
     }
 
+    private static boolean phasesInNormally(Card card) {
+        if (card.isWontPhaseInNormal()) {
+            return false;
+        }
+        Card attachedTo = card.getAttachedTo();
+        return card.isDirectlyPhasedOut()
+                || attachedTo != null && phasesInNormally(attachedTo);
+    }
+
     // Winning and losing are still the extremes of the range, but a win twenty turns from now is
     // worth less than a win this turn, and a loss we can put off is better than one we cannot.
     // GameSimulator returns Integer.MIN_VALUE to mean "this line could not be simulated", so the
@@ -80,11 +89,10 @@ public class GameStateEvaluator {
         return score > Integer.MAX_VALUE - (long) MAX_DISCOUNTED_TURNS * GAME_OVER_TURN_PENALTY;
     }
 
-    private Score getScoreForGameOver(Game game, Player aiPlayer) {
+    private Score getTerminalScore(Game game, boolean won) {
         // a game long enough to overflow the discount is not one we can reason about anyway
         int turn = Math.min(Math.max(game.getPhaseHandler().getTurn(), 0), MAX_DISCOUNTED_TURNS);
-        if (game.getOutcome().getWinningTeam() == aiPlayer.getTeam() ||
-                game.getOutcome().isWinner(aiPlayer.getRegisteredPlayer())) {
+        if (won) {
             // prefer winning sooner
             // TODO should consider recursion depth for the less complex combos more likely to succeed
             return new Score(Integer.MAX_VALUE - turn * GAME_OVER_TURN_PENALTY);
@@ -95,12 +103,18 @@ public class GameStateEvaluator {
         return new Score(Integer.MIN_VALUE + 1 + turn * GAME_OVER_TURN_PENALTY);
     }
 
+    private Score getScoreForGameOver(Game game, Player aiPlayer) {
+        boolean won = game.getOutcome().getWinningTeam() == aiPlayer.getTeam()
+                || game.getOutcome().isWinner(aiPlayer.getRegisteredPlayer());
+        return getTerminalScore(game, won);
+    }
+
     public Score getScoreForGameState(Game game, Player aiPlayer) {
-        if (aiPlayer.hasLost()) {
-            return new Score(Integer.MIN_VALUE);
-        }
         if (game.isGameOver()) {
             return getScoreForGameOver(game, aiPlayer);
+        }
+        if (!aiPlayer.isInGame()) {
+            return getTerminalScore(game, aiPlayer.hasWon());
         }
 
         CombatSimResult result = simulateUpcomingCombatThisTurn(game, aiPlayer);
@@ -117,12 +131,12 @@ public class GameStateEvaluator {
     private Score getScoreForGameStateImpl(Game game, Player aiPlayer) {
         // TODO: try and reuse evaluateBoardPosition
         int handScore = 0;
-        int myCards = 0;
-        int alliedCards = 0;
+        int aiCards = 0;
+        int teammateCards = 0;
         int opponentCards = 0;
-        int alliedLife = 0;
-        int alliedPlayers = 0;
-        int allies = 0;
+        int teamLife = 0;
+        int teamPlayers = 0;
+        int teammates = 0;
         int opponentLife = 0;
         int opponents = 0;
         for (Player player : game.getPlayers()) {
@@ -136,30 +150,37 @@ public class GameStateEvaluator {
                 int fullValueCards = player.isUnlimitedHandSize()
                         ? cards : min(cards, player.getMaxHandSize());
                 handScore += cards + 4 * fullValueCards;
-                alliedLife += player.getLife();
-                alliedPlayers++;
+                teamLife += player.getLife();
+                teamPlayers++;
                 if (player == aiPlayer) {
-                    myCards = cards;
+                    aiCards = cards;
                     debugPrint("  My life: " + player.getLife());
                 } else {
-                    alliedCards += cards;
-                    debugPrint("  Ally " + (++allies) + " life: " + player.getLife());
+                    teammateCards += cards;
+                    debugPrint("  Ally " + (++teammates) + " life: " + player.getLife());
                 }
             }
         }
-        debugPrint("My cards in hand: " + myCards);
-        if (allies > 0) {
-            debugPrint("Allied cards in hand: " + alliedCards);
+        debugPrint("My cards in hand: " + aiCards);
+        if (teammates > 0) {
+            debugPrint("Allied cards in hand: " + teammateCards);
         }
         debugPrint("Their cards in hand: " + opponentCards);
         // TODO weight cards in hand more if opponent has discard or if we have looting or can bluff a trick
-        int score = handScore + 2 * alliedLife / alliedPlayers;
+        int score = handScore + 2 * teamLife / teamPlayers;
         if (opponents > 0) {
             score -= 2 * opponentLife / opponents;
         }
 
         // evaluate mana base quality
-        score += evalManaBase(game, aiPlayer, AiDeckStatistics.fromPlayer(aiPlayer));
+        AiDeckStatistics statistics = AiDeckStatistics.fromPlayer(aiPlayer);
+        int availableManaScore = evalManaBase(game, aiPlayer, statistics);
+        int strategicManaScore = aiPlayer.getCardsIn(ZoneType.Battlefield, false).stream()
+                .anyMatch(c -> c.isPhasedOut() && phasesInNormally(c)
+                        && !c.getManaAbilities().isEmpty())
+                ? evalManaBase(game, aiPlayer, statistics, true) : availableManaScore;
+        int availableScore = score + availableManaScore;
+        score += strategicManaScore;
         // TODO deal with opponents. Do we want to use perfect information to evaluate their manabase?
         //int opponentManaScore = 0;
         //for (Player opponent : aiPlayer.getOpponents()) {
@@ -169,26 +190,26 @@ public class GameStateEvaluator {
 
         // TODO evaluate holding mana open for counterspells
 
-        int summonSickScore = score;
         PhaseType gamePhase = game.getPhaseHandler().getPhase();
         for (Card c : game.getCardsIncludePhasingIn(ZoneType.Battlefield)) {
+            boolean phasedOut = c.isPhasedOut();
+            if (phasedOut && !phasesInNormally(c)) {
+                continue;
+            }
             int value = evalCard(game, aiPlayer, c);
-            int summonSickValue = value;
+            int availableValue = phasedOut ? 0 : value;
             // To make the AI hold-off on playing creatures before MAIN2 if they give no other benefits,
             // keep track of the score while treating summon sick creatures as having a value of 0.
-            if (gamePhase.isBefore(PhaseType.MAIN2) && c.isSick() && c.getController() == aiPlayer) {
-                summonSickValue = 0;
+            if (gamePhase.isBefore(PhaseType.MAIN2) && c.isSick()
+                    && c.getController() == aiPlayer) {
+                availableValue = 0;
             }
             String str = cardToString(c);
-            if (!c.getController().isOpponentOf(aiPlayer)) {
-                debugPrint("  Battlefield: " + str + " = " + value);
-                score += value;
-                summonSickScore += summonSickValue;
-            } else {
-                debugPrint("  Battlefield: " + str + " = -" + value);
-                score -= value;
-                summonSickScore -= summonSickValue;
-            }
+            int multiplier = c.getController().isOpponentOf(aiPlayer) ? -1 : 1;
+            debugPrint("  Battlefield: " + str + " = "
+                    + (multiplier < 0 ? "-" : "") + value);
+            score += multiplier * value;
+            availableScore += multiplier * availableValue;
             String nonAbilityText = c.getNonAbilityText();
             if (!nonAbilityText.isEmpty()) {
                 debugPrint("    "+nonAbilityText.replaceAll("CARDNAME", c.getName()));
@@ -196,10 +217,15 @@ public class GameStateEvaluator {
         }
 
         debugPrint("Score = " + score);
-        return new Score(score, summonSickScore);
+        return new Score(score, availableScore);
     }
 
     public int evalManaBase(Game game, Player player, AiDeckStatistics statistics) {
+        return evalManaBase(game, player, statistics, false);
+    }
+
+    private int evalManaBase(Game game, Player player, AiDeckStatistics statistics,
+            boolean includeNormalPhasing) {
         // TODO should these be fixed quantities or should they be linear out of like 1000/(desired - total)?
         int value = 0;
         // get the colors of mana we can produce and the maximum number of pips
@@ -207,8 +233,12 @@ public class GameStateEvaluator {
         // this logic taken from ManaCost.getColorShardCounts()
         int[] counts = new int[6]; // in WUBRGC order
 
-        // Mana-base quality is long-term, so include lands that will phase back in.
+        // Strategic evaluation includes lands guaranteed to phase in normally; availability does not.
         for (Card c : player.getCardsIn(ZoneType.Battlefield, false)) {
+            if (c.isPhasedOut()
+                    && (!includeNormalPhasing || !phasesInNormally(c))) {
+                continue;
+            }
             int max_produced = 0;
             for (SpellAbility m: c.getManaAbilities()) {
                 m.setActivatingPlayer(c.getController());
@@ -322,27 +352,29 @@ public class GameStateEvaluator {
     }
 
     public static class Score {
+        /** Long-term value, including permanents guaranteed to phase in normally. */
         public final int value;
-        public final int summonSickValue;
+        /** Value currently available for mana, abilities, and the next combat. */
+        public final int availableValue;
         
         public Score(int value) {
             this.value = value;
-            this.summonSickValue = value;
+            this.availableValue = value;
         }
 
-        public Score(int value, int summonSickValue) {
+        public Score(int value, int availableValue) {
             this.value = value;
-            this.summonSickValue = summonSickValue;
+            this.availableValue = availableValue;
         }
 
         public boolean equals(Score other) {
             if (other == null)
                 return false;
-            return value == other.value && summonSickValue == other.summonSickValue;
+            return value == other.value && availableValue == other.availableValue;
         }
 
         public String toString() {
-            return value + (summonSickValue != value ? " (ss " + summonSickValue + ")" :"");
+            return value + (availableValue != value ? " (available " + availableValue + ")" : "");
         }
     }
 }

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -117,26 +117,41 @@ public class GameStateEvaluator {
     private Score getScoreForGameStateImpl(Game game, Player aiPlayer) {
         // TODO: try and reuse evaluateBoardPosition
         int handScore = 0;
+        int myCards = 0;
+        int alliedCards = 0;
+        int opponentCards = 0;
         int alliedLife = 0;
         int alliedPlayers = 0;
+        int allies = 0;
         int opponentLife = 0;
         int opponents = 0;
         for (Player player : game.getPlayers()) {
             int cards = player.getCardsIn(ZoneType.Hand).size();
             if (player.isOpponentOf(aiPlayer)) {
                 handScore -= 4 * cards;
+                opponentCards += cards;
                 opponentLife += player.getLife();
-                debugPrint("  Opponent " + (++opponents) + ": " + cards
-                        + " cards, " + player.getLife() + " life");
+                debugPrint("  Opponent " + (++opponents) + " life: -" + player.getLife());
             } else {
                 int fullValueCards = player.isUnlimitedHandSize()
                         ? cards : min(cards, player.getMaxHandSize());
                 handScore += cards + 4 * fullValueCards;
                 alliedLife += player.getLife();
-                debugPrint("  Ally " + (++alliedPlayers) + ": " + cards
-                        + " cards, " + player.getLife() + " life");
+                alliedPlayers++;
+                if (player == aiPlayer) {
+                    myCards = cards;
+                    debugPrint("  My life: " + player.getLife());
+                } else {
+                    alliedCards += cards;
+                    debugPrint("  Ally " + (++allies) + " life: " + player.getLife());
+                }
             }
         }
+        debugPrint("My cards in hand: " + myCards);
+        if (allies > 0) {
+            debugPrint("Allied cards in hand: " + alliedCards);
+        }
+        debugPrint("Their cards in hand: " + opponentCards);
         // TODO weight cards in hand more if opponent has discard or if we have looting or can bluff a trick
         int score = handScore + 2 * alliedLife / alliedPlayers;
         if (opponents > 0) {

--- a/forge-ai/src/main/java/forge/ai/simulation/SimulationController.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SimulationController.java
@@ -30,8 +30,7 @@ public class SimulationController {
         final int targetScore;
         final int scoreDelta;
 
-        public CachedEffect(GameObject hostCard, SpellAbility sa, GameObject target,
-                int targetScore, int scoreDelta) {
+        public CachedEffect(GameObject hostCard, SpellAbility sa, GameObject target, int targetScore, int scoreDelta) {
             this.hostCard = hostCard;
             this.sa = sa.toString();
             this.target = target;
@@ -235,8 +234,7 @@ public class SimulationController {
                     int cardScore = evaluator.evalCard(player.getGame(), player, (Card) hostAndTarget[2]);
                     if (cardScore == effect.targetScore) {
                         Score currentScore = getCurrentScore();
-                        return new Score(currentScore.value + effect.scoreDelta,
-                                currentScore.availableValue + effect.scoreDelta);
+                        return new Score(currentScore.value + effect.scoreDelta, currentScore.availableValue + effect.scoreDelta);
                     }
                 }
             }
@@ -251,21 +249,18 @@ public class SimulationController {
         if (!currentStack.isEmpty()) {
             Plan.Decision d = currentStack.get(currentStack.size() - 1);
             int scoreDelta = score.value - d.initialScore.value;
-            int availableScoreDelta =
-                    score.availableValue - d.initialScore.availableValue;
+            int availableScoreDelta = score.availableValue - d.initialScore.availableValue;
             // Needed to make sure below is only executed when target decisions are ended.
             // Also, only cache negative effects - so that in those cases we don't need to
             // recurse.
-            if (scoreDelta <= 0 && scoreDelta == availableScoreDelta
-                    && d.targets != null) {
+            if (scoreDelta <= 0 && scoreDelta == availableScoreDelta && d.targets != null) {
                 // FIXME: Support more than one target in this logic.
                 GameObject[] hostAndTarget = currentHostAndTarget;
                 if (currentHostAndTarget != null) {
                     GameStateEvaluator evaluator = new GameStateEvaluator();
                     Player player = sa.getActivatingPlayer();
                     int cardScore = evaluator.evalCard(player.getGame(), player, (Card) hostAndTarget[2]);
-                    effectCache.add(new CachedEffect(hostAndTarget[0], sa, hostAndTarget[1],
-                            cardScore, scoreDelta));
+                    effectCache.add(new CachedEffect(hostAndTarget[0], sa, hostAndTarget[1], cardScore, scoreDelta));
                     cached = " (added to cache)";
                 }
             }

--- a/forge-ai/src/main/java/forge/ai/simulation/SimulationController.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SimulationController.java
@@ -30,7 +30,8 @@ public class SimulationController {
         final int targetScore;
         final int scoreDelta;
 
-        public CachedEffect(GameObject hostCard, SpellAbility sa, GameObject target, int targetScore, int scoreDelta) {
+        public CachedEffect(GameObject hostCard, SpellAbility sa, GameObject target,
+                int targetScore, int scoreDelta) {
             this.hostCard = hostCard;
             this.sa = sa.toString();
             this.target = target;
@@ -234,8 +235,8 @@ public class SimulationController {
                     int cardScore = evaluator.evalCard(player.getGame(), player, (Card) hostAndTarget[2]);
                     if (cardScore == effect.targetScore) {
                         Score currentScore = getCurrentScore();
-                        // TODO: summonSick score?
-                        return new Score(currentScore.value + effect.scoreDelta, currentScore.summonSickValue);
+                        return new Score(currentScore.value + effect.scoreDelta,
+                                currentScore.availableValue + effect.scoreDelta);
                     }
                 }
             }
@@ -250,17 +251,21 @@ public class SimulationController {
         if (!currentStack.isEmpty()) {
             Plan.Decision d = currentStack.get(currentStack.size() - 1);
             int scoreDelta = score.value - d.initialScore.value;
+            int availableScoreDelta =
+                    score.availableValue - d.initialScore.availableValue;
             // Needed to make sure below is only executed when target decisions are ended.
             // Also, only cache negative effects - so that in those cases we don't need to
             // recurse.
-            if (scoreDelta <= 0 && d.targets != null) {
+            if (scoreDelta <= 0 && scoreDelta == availableScoreDelta
+                    && d.targets != null) {
                 // FIXME: Support more than one target in this logic.
                 GameObject[] hostAndTarget = currentHostAndTarget;
                 if (currentHostAndTarget != null) {
                     GameStateEvaluator evaluator = new GameStateEvaluator();
                     Player player = sa.getActivatingPlayer();
                     int cardScore = evaluator.evalCard(player.getGame(), player, (Card) hostAndTarget[2]);
-                    effectCache.add(new CachedEffect(hostAndTarget[0], sa, hostAndTarget[1], cardScore, scoreDelta));
+                    effectCache.add(new CachedEffect(hostAndTarget[0], sa, hostAndTarget[1],
+                            cardScore, scoreDelta));
                     cached = " (added to cache)";
                 }
             }

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
@@ -31,8 +31,8 @@ public class SpellAbilityPicker {
     private Plan plan;
     private int numSimulations;
 
-    public SpellAbilityPicker(Game game, Player player) {
-        this.game = game;
+    public SpellAbilityPicker(Player player) {
+        this.game = player.getGame();
         this.player = player;
     }
 

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
@@ -176,17 +176,18 @@ public class SpellAbilityPicker {
             }
         }
 
-        // To make the AI hold-off on playing creatures in MAIN1 if they give no other benefits,
-        // check the score for the bestSA while counting summon sick creatures for 0.
+        // To make the AI hold off on plays that only add unavailable resources, check the score
+        // while excluding phased-out permanents and summon sick creatures before MAIN2.
         // Do it here on the best SA, rather than for all evaluations, so that if the best SA
         // is indeed a creature spell, we don't pick something else to play now and then have
         // no mana to play the truly best SA post-combat.
-        if (bestSa != null && bestSaValue.summonSickValue <= origGameScore.summonSickValue) {
+        if (bestSa != null && bestSaValue.availableValue <= origGameScore.availableValue) {
             bestSa = null;
         }
 
         long execTime = System.currentTimeMillis() - startTime;
-        print("BEST: " + abilityToString(bestSa) + " SCORE: " + bestSaValue.summonSickValue + " TIME: " + execTime);
+        print("BEST: " + abilityToString(bestSa) + " SCORE: "
+                + bestSaValue.availableValue + " TIME: " + execTime);
         this.bestScore = bestSaValue;
         return bestSa;
     }

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
@@ -186,8 +186,7 @@ public class SpellAbilityPicker {
         }
 
         long execTime = System.currentTimeMillis() - startTime;
-        print("BEST: " + abilityToString(bestSa) + " SCORE: "
-                + bestSaValue.availableValue + " TIME: " + execTime);
+        print("BEST: " + abilityToString(bestSa) + " SCORE: " + bestSaValue.availableValue + " TIME: " + execTime);
         this.bestScore = bestSaValue;
         return bestSa;
     }

--- a/forge-gui-desktop/src/test/java/forge/ai/controller/AutoPaymentTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/controller/AutoPaymentTest.java
@@ -39,7 +39,7 @@ public class AutoPaymentTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(mindstone.getFirstSpellAbility()).value;
 
         AssertJUnit.assertTrue(score > 0);
@@ -69,7 +69,7 @@ public class AutoPaymentTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(dragon.getFirstSpellAbility()).value;
 
         AssertJUnit.assertTrue(score > 0);
@@ -103,7 +103,7 @@ public class AutoPaymentTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(bears.getFirstSpellAbility()).value;
 
         AssertJUnit.assertTrue(score > 0);
@@ -135,7 +135,7 @@ public class AutoPaymentTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertTrue(sa.getHostCard().isCreature());
 

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
@@ -41,7 +41,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility outlastSA = findSAWithPrefix(herald, "Outlast");
         AssertJUnit.assertNotNull(outlastSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(outlastSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -84,7 +84,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility outlastSA = findSAWithPrefix(herald, "Outlast");
         AssertJUnit.assertNotNull(outlastSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(outlastSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -108,7 +108,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(1, lion.getAmountOfKeyword(Keyword.HEXPROOF));
         AssertJUnit.assertEquals(1, lion.getAmountOfKeyword(Keyword.INDESTRUCTIBLE));
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         Game simGame = sim.getSimulatedGameState();
         Card lionCopy = findCardWithName(simGame, lionCardName);
         AssertJUnit.assertTrue(lionCopy.isMonstrous());
@@ -129,7 +129,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
         AssertJUnit.assertEquals(1, bear.getAmountOfKeyword(Keyword.SHROUD));
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         Game simGame = sim.getSimulatedGameState();
         Card bearCopy = findCardWithName(simGame, bearCardName);
         AssertJUnit.assertEquals(1, bearCopy.getAmountOfKeyword(Keyword.SHROUD));
@@ -148,7 +148,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
         AssertJUnit.assertEquals(1, bear.getAmountOfKeyword(Keyword.LIFELINK));
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         Game simGame = sim.getSimulatedGameState();
         Card bearCopy = findCardWithName(simGame, bearCardName);
         AssertJUnit.assertEquals(1, bearCopy.getAmountOfKeyword(Keyword.LIFELINK));
@@ -170,7 +170,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility playMerchantSa = c.getSpellAbilities().get(0);
         playMerchantSa.setActivatingPlayer(p);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int origScore = sim.getScoreForOrigGame().value;
         int score = sim.simulateSpellAbility(playMerchantSa).value;
         AssertJUnit.assertTrue(String.format("score=%d vs. origScore=%d", score, origScore), score > origScore);
@@ -196,7 +196,7 @@ public class GameSimulationTest extends SimulationTest {
 
         AssertJUnit.assertEquals(20, game.getPlayers().get(0).getLife());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         Game simGame = sim.getSimulatedGameState();
 
         SpellAbility unmorphSA = findSAWithPrefix(ripper, "Morph — Reveal a black card");
@@ -219,7 +219,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p1);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p1);
+        GameSimulator sim = createSimulator(p1);
         Game simGame = sim.getSimulatedGameState();
 
         SpellAbility fractureSa = fractureP1.getSpellAbilities().get(0);
@@ -249,7 +249,7 @@ public class GameSimulationTest extends SimulationTest {
         minusTwo.setActivatingPlayer(p);
         AssertJUnit.assertTrue(minusTwo.canPlay());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(minusTwo);
         Game simGame = sim.getSimulatedGameState();
         Card vampireToken = findCardWithName(simGame, "Vampire Token");
@@ -294,7 +294,7 @@ public class GameSimulationTest extends SimulationTest {
         minusFour.setActivatingPlayer(p);
         AssertJUnit.assertTrue(minusFour.canPlay());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(minusFour);
         Game simGame = sim.getSimulatedGameState();
         Card simBear = findCardWithName(simGame, bearCardName);
@@ -320,7 +320,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility manifestSA = soulSummons.getSpellAbilities().get(0);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(manifestSA);
         Game simGame = sim.getSimulatedGameState();
         Card manifestedCreature = findCardWithName(simGame, "");
@@ -332,7 +332,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(2, manifestedCreature.getNetPower());
         AssertJUnit.assertFalse(manifestedCreature.hasKeyword(Keyword.FLYING));
 
-        GameSimulator sim2 = createSimulator(simGame, simGame.getPlayers().get(1));
+        GameSimulator sim2 = createSimulator(simGame.getPlayers().get(1));
         Game simGame2 = sim2.getSimulatedGameState();
         manifestedCreature = findCardWithName(simGame2, "");
         unmanifestSA = findSAWithPrefix(manifestedCreature.getAllPossibleAbilities(simGame2.getPlayers().get(1), false),
@@ -365,7 +365,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility manifestSA = soulSummons.getSpellAbilities().get(0);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(manifestSA);
         Game simGame = sim.getSimulatedGameState();
         Card manifestedCreature = findCardWithName(simGame, "");
@@ -392,7 +392,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility manifestSA = soulSummons.getSpellAbilities().get(0);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(manifestSA);
         Game simGame = sim.getSimulatedGameState();
         Card manifestedCreature = findCardWithName(simGame, "");
@@ -421,7 +421,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility becomeDragonSA = findSAWithPrefix(sarkhan, "+1");
         AssertJUnit.assertNotNull(becomeDragonSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(becomeDragonSA);
         Game simGame = sim.getSimulatedGameState();
         Card sarkhanSim = findCardWithName(simGame, sarkhanCardName);
@@ -456,7 +456,7 @@ public class GameSimulationTest extends SimulationTest {
 
         MultiTargetSelector selector = new MultiTargetSelector(sa, null);
         while (selector.selectNextTargets()) {
-            GameSimulator sim = createSimulator(game, p);
+            GameSimulator sim = createSimulator(p);
             sim.simulateSpellAbility(sa);
             Game simGame = sim.getSimulatedGameState();
             Card thopterSim = findCardWithName(simGame, ornithoperCardName);
@@ -487,7 +487,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertNotNull(sa);
         sa.setActivatingPlayer(p);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         boltSA.getTargets().add(p);
         sim.simulateSpellAbility(sa);
         sim.simulateSpellAbility(boltSA);
@@ -541,7 +541,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertNotNull(sa);
         sa.getTargets().add(depths);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(sa);
         Game simGame = sim.getSimulatedGameState();
 
@@ -567,7 +567,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertNotNull(sa);
         sa.getTargets().add(thespian);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(sa);
         Game simGame = sim.getSimulatedGameState();
         Card thespianSim = findCardWithName(simGame, "Thespian's Stage");
@@ -590,7 +590,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility dashSA = findSAWithPrefix(berserkerCard, "Dash");
         AssertJUnit.assertNotNull(dashSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(dashSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -604,7 +604,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility pumpSA = findSAWithPrefix(berserker, "{R}: CARDNAME gets +1/+0 until end of turn.");
         AssertJUnit.assertNotNull(pumpSA);
-        GameSimulator sim2 = createSimulator(simGame, (Player) sim.getGameCopier().find(p));
+        GameSimulator sim2 = createSimulator((Player) sim.getGameCopier().find(p));
         sim2.simulateSpellAbility(pumpSA);
         Game simGame2 = sim2.getSimulatedGameState();
 
@@ -628,7 +628,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility callTheScionsSA = callTheScionsCard.getSpellAbilities().get(0);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(callTheScionsSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -671,7 +671,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(3, giant.getNetToughness());
         AssertJUnit.assertEquals(0, giant.getDamage());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         shockSA.setTargetCard(giant);
         sim.simulateSpellAbility(shockSA);
         Game simGame = sim.getSimulatedGameState();
@@ -713,7 +713,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p1);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p1);
+        GameSimulator sim = createSimulator(p1);
         ignitionSA.setTargetCard(kalitas);
         sim.simulateSpellAbility(ignitionSA);
         Game simGame = sim.getSimulatedGameState();
@@ -766,7 +766,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p1);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p1);
+        GameSimulator sim = createSimulator(p1);
         ignitionSA.setTargetCard(kalitas);
         sim.simulateSpellAbility(ignitionSA);
         Game simGame = sim.getSimulatedGameState();
@@ -826,7 +826,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p1);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p1);
+        GameSimulator sim = createSimulator(p1);
         ignitionSA.setTargetCard(kalitas);
         sim.simulateSpellAbility(ignitionSA);
         Game simGame = sim.getSimulatedGameState();
@@ -892,7 +892,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p1);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p1);
+        GameSimulator sim = createSimulator(p1);
 
         sim.simulateSpellAbility(coneSA);
         Game simGame = sim.getSimulatedGameState();
@@ -920,7 +920,7 @@ public class GameSimulationTest extends SimulationTest {
         // second pard with Everlasting Torment
         addCard(tormentName, p2);
 
-        GameSimulator sim2 = createSimulator(game, p1);
+        GameSimulator sim2 = createSimulator(p1);
 
         sim2.simulateSpellAbility(coneSA);
         Game simGame2 = sim2.getSimulatedGameState();
@@ -956,7 +956,7 @@ public class GameSimulationTest extends SimulationTest {
         // third pard with Melira prevents wither
         addCard(meliraName, p2);
 
-        GameSimulator sim3 = createSimulator(game, p1);
+        GameSimulator sim3 = createSimulator(p1);
 
         sim3.simulateSpellAbility(coneSA);
         Game simGame3 = sim3.getSimulatedGameState();
@@ -1010,7 +1010,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(3, lilianaInPlay.getNetToughness());
 
         SpellAbility playLiliana = lilianaInHand.getSpellAbilities().get(0);
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(playLiliana);
         Game simGame = sim.getSimulatedGameState();
         AssertJUnit.assertNull(findCardWithName(simGame, lilianaCardName));
@@ -1040,7 +1040,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(0, p.getCounters(CounterEnumType.ENERGY));
 
         SpellAbility playTurtle = turtleCard.getSpellAbilities().get(0);
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(playTurtle);
         Game simGame = sim.getSimulatedGameState();
         Player simP = simGame.getPlayer(p.getId());
@@ -1067,7 +1067,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertTrue(p1.getManaPool().isEmpty());
 
         SpellAbility playRitual = darkRitualCard.getSpellAbilities().get(0);
-        GameSimulator sim = createSimulator(game, p1);
+        GameSimulator sim = createSimulator(p1);
         sim.simulateSpellAbility(playRitual);
         Game simGame = sim.getSimulatedGameState();
 
@@ -1079,7 +1079,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility playDarkConfidant2 = darkConfidantCard2.getSpellAbilities().get(0);
         Card deathriteCard2 = (Card) sim.getGameCopier().find(deathriteCard);
 
-        GameSimulator sim2 = createSimulator(simGame, simP1);
+        GameSimulator sim2 = createSimulator(simP1);
         sim2.simulateSpellAbility(playDarkConfidant2);
         Game sim2Game = sim2.getSimulatedGameState();
         Player sim2P = sim2Game.getPlayer(simP1.getId());
@@ -1089,7 +1089,7 @@ public class GameSimulationTest extends SimulationTest {
         Card deathriteCard3 = (Card) sim2.getGameCopier().find(deathriteCard2);
         SpellAbility playDeathriteCard3 = deathriteCard3.getSpellAbilities().get(0);
 
-        GameSimulator sim3 = createSimulator(sim2Game, sim2P);
+        GameSimulator sim3 = createSimulator(sim2P);
         sim3.simulateSpellAbility(playDeathriteCard3);
         Game sim3Game = sim3.getSimulatedGameState();
         Player sim3P = sim3Game.getPlayer(sim2P.getId());
@@ -1135,7 +1135,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(2, bear.getNetToughness());
         AssertJUnit.assertEquals(0, bear.getDamage());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         enKorSA.setTargetCard(bear);
         shockSA.setTargetCard(enKor);
         sim.simulateSpellAbility(enKorSA);
@@ -1197,7 +1197,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(2, bear.getNetToughness());
         AssertJUnit.assertEquals(0, bear.getDamage());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         preventSA.setTargetCard(razia);
         preventSA.getSubAbility().setTargetCard(bear);
         greetingSA.setTargetCard(razia);
@@ -1262,7 +1262,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(4, elemental.getNetToughness());
         AssertJUnit.assertEquals(0, elemental.getDamage());
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         preventSA.setTargetCard(razia);
         preventSA.getSubAbility().setTargetCard(elemental);
         shockSA1.setTargetCard(razia);
@@ -1310,7 +1310,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility wrathSA = wrathOfGod.getFirstSpellAbility();
         AssertJUnit.assertNotNull(wrathSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(wrathSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -1346,7 +1346,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertNotNull(electrifySA);
         electrifySA.setTargetCard(goblin2);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(fatalPushSA).value;
         AssertJUnit.assertTrue(score > 0);
         AssertJUnit.assertEquals(2, countCardsWithName(sim.getSimulatedGameState(), "Zombie Token"));
@@ -1561,7 +1561,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility goblinSA = goblin.getFirstSpellAbility();
         AssertJUnit.assertNotNull(goblinSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(goblinSA).value;
         AssertJUnit.assertTrue(score > 0);
 
@@ -1593,7 +1593,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility wrathSA = wrathOfGod.getFirstSpellAbility();
         AssertJUnit.assertNotNull(wrathSA);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(wrathSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -1623,7 +1623,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility secondSA = second.getFirstSpellAbility();
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(secondSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -1654,7 +1654,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility armageddonSA = armageddon.getFirstSpellAbility();
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(armageddonSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -1693,7 +1693,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility armageddonSA = armageddon.getFirstSpellAbility();
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(armageddonSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -1732,7 +1732,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility armageddonSA = armageddon.getFirstSpellAbility();
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(armageddonSA).value;
         AssertJUnit.assertTrue(score > 0);
         Game simGame = sim.getSimulatedGameState();
@@ -1775,7 +1775,7 @@ public class GameSimulationTest extends SimulationTest {
 
         cytoSA.getTargets().add(outlaw);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(cytoSA).value;
 
         AssertJUnit.assertTrue(score > 0);
@@ -1883,7 +1883,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility gideonSA = gideon.getFirstSpellAbility();
         SpellAbility sparkDoubleSA = sparkDouble.getFirstSpellAbility();
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(gideonSA);
         sim.simulateSpellAbility(sparkDoubleSA);
 
@@ -1917,7 +1917,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility cytoSA = cytoshape.getFirstSpellAbility();
         cytoSA.getTargets().add(tgtLand);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(vituSA);
         sim.simulateSpellAbility(cytoSA);
 
@@ -1943,7 +1943,7 @@ public class GameSimulationTest extends SimulationTest {
         Card ooze = addCardToZone("Necrotic Ooze", p, ZoneType.Hand);
 
         SpellAbility oozeSA = ooze.getFirstSpellAbility();
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(oozeSA);
 
         Card oozeOTB = findCardWithName(sim.getSimulatedGameState(), "Necrotic Ooze");
@@ -1969,7 +1969,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility saAnimate = animate.getFirstSpellAbility();
         saAnimate.getTargets().add(epo);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(saAnimate);
 
         Card epoOTB = findCardWithName(sim.getSimulatedGameState(), "Epochrasite");
@@ -2005,7 +2005,7 @@ public class GameSimulationTest extends SimulationTest {
 
         // Clone Jushi first
         saDimirClone.getTargets().add(jushi);
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(saDimirClone).value;
         AssertJUnit.assertTrue(score > 0);
 
@@ -2021,7 +2021,7 @@ public class GameSimulationTest extends SimulationTest {
 
         // make new simulator so new SpellAbility is found
         Game simGame = sim.getSimulatedGameState();
-        sim = createSimulator(simGame, p);
+        sim = createSimulator(p);
 
         Player copiedPlayer = (Player) sim.getGameCopier().find(p);
         int handSize = copiedPlayer.getCardsIn(ZoneType.Hand).size();
@@ -2041,7 +2041,7 @@ public class GameSimulationTest extends SimulationTest {
 
         // make new simulator so new SpellAbility is found
         simGame = sim.getSimulatedGameState();
-        sim = createSimulator(simGame, p);
+        sim = createSimulator(p);
 
         // bear = (Card)sim.getGameCopier().find(bear);
 
@@ -2115,7 +2115,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p0);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p0);
+        GameSimulator sim = createSimulator(p0);
         Game simGame = sim.getSimulatedGameState();
 
         SpellAbility actSA = actOfTreason.getSpellAbilities().get(0);
@@ -2153,7 +2153,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility playSa = c.getSpellAbilities().get(0);
         playSa.setActivatingPlayer(p);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int origScore = sim.getScoreForOrigGame().value;
         int score = sim.simulateSpellAbility(playSa).value;
         AssertJUnit.assertTrue(String.format("score=%d vs. origScore=%d", score, origScore), score > origScore);
@@ -2188,7 +2188,7 @@ public class GameSimulationTest extends SimulationTest {
         playSa.getTargets().add(cardWaywardServant);
         playSa.getTargets().add(cardRagingGoblin);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int origScore = sim.getScoreForOrigGame().value;
         int score = sim.simulateSpellAbility(playSa).value;
         AssertJUnit.assertTrue(String.format("score=%d vs. origScore=%d", score, origScore), score > origScore);
@@ -2227,7 +2227,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(pyroSA);
         Game simGame = sim.getSimulatedGameState();
         Card simPolukranos = findCardWithName(simGame, polukranosCardName);
@@ -2271,7 +2271,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p2);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p2);
+        GameSimulator sim = createSimulator(p2);
         alphaBrawlSA.setTargetCard(nishoba);
         sim.simulateSpellAbility(alphaBrawlSA);
         Game simGame = sim.getSimulatedGameState();
@@ -2337,7 +2337,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertNotNull(saGlarecaster);
         saGlarecaster.getTargets().add(p2);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(saGlarecaster).value;
         AssertJUnit.assertTrue(score > 0);
         sim.simulateSpellAbility(infernoSA);
@@ -2370,7 +2370,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(mowuSA);
         Game simGame = sim.getSimulatedGameState();
 
@@ -2399,7 +2399,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(corpsejackSA);
         Game simGame = sim.getSimulatedGameState();
 
@@ -2434,7 +2434,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(everSA);
         Game simGame = sim.getSimulatedGameState();
 
@@ -2472,7 +2472,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(genesisSA);
         Game simGame = sim.getSimulatedGameState();
 
@@ -2501,7 +2501,7 @@ public class GameSimulationTest extends SimulationTest {
 
         SpellAbility transformSA = findSAWithPrefix(heliod, "{3}{U/P}: Transform");
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         AssertJUnit.assertNotNull(transformSA);
         sim.simulateSpellAbility(transformSA);
 
@@ -2541,7 +2541,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility fizzleSA = fizzle.getFirstSpellAbility();
         fizzleSA.getTargets().add(bear);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         game = sim.getSimulatedGameState();
 
         sim.simulateSpellAbility(destroySA, false);
@@ -2565,7 +2565,7 @@ public class GameSimulationTest extends SimulationTest {
         addCard("Vedalken Orrery", opp);
         Card control = addCardToZone("Mind Control", opp, ZoneType.Hand);
 
-        GameSimulator sim = createSimulator(game, opp);
+        GameSimulator sim = createSimulator(opp);
         game = sim.getSimulatedGameState();
 
         SpellAbility controlSA = control.getFirstSpellAbility();
@@ -2578,7 +2578,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility confiscateSA = confiscate.getFirstSpellAbility();
         confiscateSA.getTargets().add(control);
 
-        sim = createSimulator(game, p);
+        sim = createSimulator(p);
         game = sim.getSimulatedGameState();
         bear = findCardWithName(game, "Bear Cub");
 
@@ -2627,7 +2627,7 @@ public class GameSimulationTest extends SimulationTest {
         List<SpellAbility> sas = spell.getAllPossibleAbilities(p, true);
         SpellAbility blitz = sas.get(1);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         game = sim.getSimulatedGameState();
         sim.simulateSpellAbility(blitz);
         spell = findCardWithName(game, "Serra Angel");
@@ -2670,7 +2670,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility playVoloSA = c.getFirstSpellAbility();
         playVoloSA.setActivatingPlayer(p);
 
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(playVoloSA);
         Game simGame = sim.getSimulatedGameState();
 
@@ -2836,7 +2836,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility woundSA = woundCard.getFirstSpellAbility();
         woundSA.setActivatingPlayer(p);
         woundSA.getTargets().add(cadet);
-        GameSimulator sim = createSimulator(game, p);
+        GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(woundSA);
         Game simGame = sim.getSimulatedGameState();
         AssertJUnit.assertEquals(1, findCardWithName(simGame, cadetName).getCounters(CounterEnumType.M1M1));
@@ -2846,7 +2846,7 @@ public class GameSimulationTest extends SimulationTest {
         SpellAbility growthSA = growthCard.getFirstSpellAbility();
         growthSA.setActivatingPlayer(p);
         growthSA.getTargets().add(cadet);
-        sim = createSimulator(game, p);
+        sim = createSimulator(p);
         sim.simulateSpellAbility(growthSA);
         simGame = sim.getSimulatedGameState();
         AssertJUnit.assertEquals(1, findCardWithName(simGame, cadetName).getCounters(CounterEnumType.P1P1));

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulatorSpellChoiceTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulatorSpellChoiceTest.java
@@ -184,7 +184,7 @@ public class GameSimulatorSpellChoiceTest extends SimulationTest {
     }
 
     private GameSimulator simulate(Game game, Player player, SpellAbility ability) {
-        GameSimulator simulator = createSimulator(game, player);
+        GameSimulator simulator = createSimulator(player);
         simulator.simulateSpellAbility(ability);
         return simulator;
     }

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameStateEvaluatorTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameStateEvaluatorTest.java
@@ -1,0 +1,70 @@
+package forge.ai.simulation;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+public class GameStateEvaluatorTest extends SimulationTest {
+    private final GameStateEvaluator evaluator = new GameStateEvaluator();
+
+    @Test
+    public void testAlliedResourcesImproveTeamScore() {
+        Game game = initAndCreateThreePlayerGame();
+        Player ai = game.getPlayers().get(1);
+        Player ally = game.getPlayers().get(2);
+        game.getPlayers().get(0).setTeam(1);
+        ai.setTeam(0);
+        ally.setTeam(0);
+        moveToMain2(game, ai);
+
+        int score = evaluate(game, ai);
+        addCard("Shivan Dragon", ally);
+        AssertJUnit.assertTrue("An allied permanent should improve the team's position",
+                evaluate(game, ai) > score);
+
+        score = evaluate(game, ai);
+        ally.setLife(ally.getLife() + 2, null);
+        AssertJUnit.assertTrue("Allied life should improve the team's position",
+                evaluate(game, ai) > score);
+
+        score = evaluate(game, ai);
+        addCardToZone("Runeclaw Bear", ally, ZoneType.Hand);
+        AssertJUnit.assertTrue("An allied card should improve the team's position",
+                evaluate(game, ai) > score);
+    }
+
+    @Test
+    public void testPhasedPermanentRetainsLongTermValue() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card mountain = addCard("Mountain", ai);
+        addCardToZone("Shivan Dragon", ai, ZoneType.Hand);
+        moveToMain2(game, ai);
+
+        int score = evaluate(game, ai);
+        mountain.setPhasedOut(ai);
+
+        AssertJUnit.assertEquals("Phasing should not make a permanent a long-term loss",
+                score, evaluate(game, ai));
+    }
+
+    @Test
+    public void testLostPlayerGetsTerminalScoreInMultiplayerGame() {
+        Game game = initAndCreateThreePlayerGame();
+        Player ai = game.getPlayers().get(1);
+        moveToMain2(game, ai);
+        ai.concede();
+
+        AssertJUnit.assertFalse("The multiplayer game should continue after one player loses",
+                game.isGameOver());
+        AssertJUnit.assertEquals(Integer.MIN_VALUE, evaluate(game, ai));
+    }
+
+    private int evaluate(Game game, Player ai) {
+        return evaluator.getScoreForGameState(game, ai).value;
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameStateEvaluatorTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameStateEvaluatorTest.java
@@ -38,18 +38,27 @@ public class GameStateEvaluatorTest extends SimulationTest {
     }
 
     @Test
-    public void testPhasedPermanentRetainsLongTermValue() {
+    public void testPhasingSeparatesStrategicAndAvailableValue() {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
         Card mountain = addCard("Mountain", ai);
         addCardToZone("Shivan Dragon", ai, ZoneType.Hand);
         moveToMain2(game, ai);
 
-        int score = evaluate(game, ai);
-        mountain.setPhasedOut(ai);
+        GameStateEvaluator.Score score = evaluator.getScoreForGameState(game, ai);
+        mountain.phase(false);
+        GameStateEvaluator.Score phasedScore = evaluator.getScoreForGameState(game, ai);
 
-        AssertJUnit.assertEquals("Phasing should not make a permanent a long-term loss",
-                score, evaluate(game, ai));
+        AssertJUnit.assertEquals("Normal phasing should retain strategic value",
+                score.value, phasedScore.value);
+        AssertJUnit.assertTrue("A phased-out permanent should not be currently available",
+                phasedScore.availableValue < score.availableValue);
+
+        mountain.setWontPhaseInNormal(true);
+        GameStateEvaluator.Score contingentScore =
+                evaluator.getScoreForGameState(game, ai);
+        AssertJUnit.assertTrue("A contingent return should not retain strategic value",
+                contingentScore.value < score.value);
     }
 
     @Test
@@ -61,7 +70,23 @@ public class GameStateEvaluatorTest extends SimulationTest {
 
         AssertJUnit.assertFalse("The multiplayer game should continue after one player loses",
                 game.isGameOver());
-        AssertJUnit.assertEquals(Integer.MIN_VALUE, evaluate(game, ai));
+        AssertJUnit.assertTrue("A real loss should not use the failed-simulation sentinel",
+                evaluate(game, ai) > Integer.MIN_VALUE);
+    }
+
+    @Test
+    public void testFinishedWinnerGetsTerminalScoreInMultiplayerGame() {
+        Game game = initAndCreateThreePlayerGame();
+        Player ai = game.getPlayers().get(1);
+        moveToMain2(game, ai);
+        ai.onGameOver();
+
+        AssertJUnit.assertFalse("The multiplayer game should still be open",
+                game.isGameOver());
+        AssertJUnit.assertFalse("The winner should have a final player outcome",
+                ai.isInGame());
+        AssertJUnit.assertTrue("A finished winner should receive a terminal win score",
+                GameStateEvaluator.isWinning(evaluate(game, ai)));
     }
 
     private int evaluate(Game game, Player ai) {

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/OnePlaySafetyCheckerTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/OnePlaySafetyCheckerTest.java
@@ -148,6 +148,41 @@ public class OnePlaySafetyCheckerTest extends SimulationTest {
     }
 
     @Test
+    public void testAllowsNormalPhasingRescue() {
+        Game game = initAndCreateGame(true);
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Plains", 4, ai);
+        Card dragon = addCard("Shivan Dragon", ai);
+        // Keep Convoke's tap choice from affecting this phasing-only assertion.
+        dragon.setTapped(true);
+        Card concealment = addCardToZone("Clever Concealment", ai, ZoneType.Hand);
+        moveToMain2(game, ai);
+
+        SpellAbility ability = concealment.getFirstSpellAbility();
+        ability.setActivatingPlayer(ai);
+        ability.getTargets().add(dragon);
+        AssertJUnit.assertTrue("A guaranteed phase-in should retain strategic value",
+                OnePlaySafetyChecker.isAcceptable(ai, ability));
+    }
+
+    @Test
+    public void testRejectsOublietteOnOwnCreature() {
+        Game game = initAndCreateGame(true);
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Swamp", 3, ai);
+        addCard("Shivan Dragon", ai);
+        Card oubliette = addCardToZone("Oubliette", ai, ZoneType.Hand);
+        moveToMain2(game, ai);
+
+        SpellAbility ability = oubliette.getFirstSpellAbility();
+        ability.setActivatingPlayer(ai);
+        AssertJUnit.assertFalse("A contingent phase-in should remain a strategic loss",
+                OnePlaySafetyChecker.isAcceptable(ai, ability));
+    }
+
+    @Test
     public void testScoreRejectsBadRemovalIntoGravePact() {
         AssertJUnit.assertFalse("Trading the AI's best creature for Serra Angel is a regression",
                 evaluateMurderIntoGravePact("Blightsteel Colossus", "Serra Angel"));

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/OnePlaySafetyCheckerTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/OnePlaySafetyCheckerTest.java
@@ -148,20 +148,28 @@ public class OnePlaySafetyCheckerTest extends SimulationTest {
     }
 
     @Test
-    public void testAllowsNormalPhasingRescue() {
+    public void testAllowsWideBoardPhasingRescue() {
         Game game = initAndCreateGame(true);
         Player ai = game.getPlayers().get(1);
 
         addCards("Plains", 4, ai);
-        Card dragon = addCard("Shivan Dragon", ai);
+        Card[] creatures = {
+                addCard("Shivan Dragon", ai),
+                addCard("Serra Angel", ai),
+                addCard("Runeclaw Bear", ai)
+        };
         // Keep Convoke's tap choice from affecting this phasing-only assertion.
-        dragon.setTapped(true);
+        for (Card creature : creatures) {
+            creature.setTapped(true);
+        }
         Card concealment = addCardToZone("Clever Concealment", ai, ZoneType.Hand);
         moveToMain2(game, ai);
 
         SpellAbility ability = concealment.getFirstSpellAbility();
         ability.setActivatingPlayer(ai);
-        ability.getTargets().add(dragon);
+        for (Card creature : creatures) {
+            ability.getTargets().add(creature);
+        }
         AssertJUnit.assertTrue("A guaranteed phase-in should retain strategic value",
                 OnePlaySafetyChecker.isAcceptable(ai, ability));
     }

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
@@ -45,7 +45,7 @@ public class SimulationTest extends AITest {
         return game;
     }
 
-    protected GameSimulator createSimulator(Game game, Player p) {
-        return new GameSimulator(new SimulationController(new Score(0), 0), game, p, null);
+    protected GameSimulator createSimulator(Player p) {
+        return new GameSimulator(new SimulationController(new Score(0), 0), p.getGame(), p, null);
     }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -37,7 +37,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         AssertJUnit.assertNull(sa.getTargetCard());
@@ -59,7 +59,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         AssertJUnit.assertEquals(bearCard, sa.getTargetCard());
@@ -81,7 +81,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertTrue(sa.isLandAbility());
         AssertJUnit.assertEquals(mountain, sa.getHostCard());
@@ -108,7 +108,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(tatyova, sa.getHostCard());
 
@@ -137,7 +137,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // Expected: All creatures get -2/-2 to kill the bear.
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(spell.getSpellAbilities().get(0), sa);
         AssertJUnit.assertEquals("Dromar's Charm -> Target creature gets -2/-2 until end of turn.",
@@ -158,7 +158,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // Expected: Gain 5 life, since other modes aren't helpful.
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(spell.getSpellAbilities().get(0), sa);
         AssertJUnit.assertEquals("Dromar's Charm -> You gain 5 life.", picker.getPlan().getDecisions().get(0).modesStr);
@@ -180,7 +180,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // Expected: 2x 1 damage to each creature, 1x 2 damage to each opponent.
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(spell.getSpellAbilities().get(0), sa);
 
@@ -206,7 +206,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // Expected: 3x 2 damage to each opponent.
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(spell.getSpellAbilities().get(0), sa);
 
@@ -231,7 +231,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(spell.getSpellAbilities().get(0), sa);
         AssertJUnit.assertEquals(bear, sa.getTargetCard());
@@ -264,7 +264,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         AssertJUnit.assertEquals(10, darkDepths.getCounters(ice));
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(cropRotation.getSpellAbilities().get(0), sa);
         // Expected: Sac a Forest to get an Urborg.
@@ -295,7 +295,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // ensure that the tapland is paid
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
@@ -314,7 +314,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // ensure that the tapland is played
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
@@ -334,7 +334,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // ensure that the tron land is played
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
@@ -350,7 +350,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // ensure that the land is played
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
@@ -371,7 +371,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // ensure that the basic land is played
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
@@ -395,7 +395,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
 
         // ensure that the land is played
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getTargetCard());
     }
@@ -454,7 +454,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
 
             GameStateEvaluator.Score s = new GameStateEvaluator().getScoreForGameState(game, p);
             System.out.println("Starting score: " + s);
-            SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+            SpellAbilityPicker picker = new SpellAbilityPicker(p);
             List<SpellAbility> candidateSAs = picker.getCandidateSpellsAndAbilities();
             for (int i = 0; i < candidateSAs.size(); i++) {
                 SpellAbility sa = candidateSAs.get(i);
@@ -499,7 +499,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         // 1. Play Abbot.
         // 2. Play land exiled by Abbot.
         // 3. Play Bolt targeting opponent.
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(abbot.getSpellAbilities().get(0), sa);
         Plan plan = picker.getPlan();
@@ -528,7 +528,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         // Expected plan:
         // 1. Play Abbot.
         // 3. Play Bolt exiled by Abbot.
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(abbot.getSpellAbilities().get(0), sa);
         Plan plan = picker.getPlan();
@@ -555,7 +555,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         AssertJUnit.assertNull(picker.chooseSpellAbilityToPlay(null));
 
         game.getPhaseHandler().devAdvanceToPhase(PhaseType.COMBAT_BEGIN);
@@ -603,7 +603,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         AssertJUnit.assertEquals(furor.getSpellAbilities().get(0), sa);
@@ -626,7 +626,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         AssertJUnit.assertEquals("Destroy target nonblack creature.", sa.toString());
@@ -668,7 +668,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         AssertJUnit.assertEquals("Chaos Warp", sa.getHostCard().getName());
@@ -687,7 +687,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNull(sa);
         AssertJUnit.assertEquals(0, picker.getNumSimulations());
@@ -705,7 +705,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         // Only one land drop should be simulated, since the cards are identical.
@@ -726,7 +726,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         AssertJUnit.assertEquals(expectedTarget, sa.getTargetCard());
@@ -749,7 +749,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         // Expected: Runeclaw Bear fights Flying Men
@@ -770,7 +770,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
          picker.chooseSpellAbilityToPlay(null);
         // Only mode "Creatures with power 3 or less can't block this turn" should be simulated.
         AssertJUnit.assertEquals(1, picker.getNumSimulations());
@@ -788,7 +788,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         picker.chooseSpellAbilityToPlay(null);
         // TODO: Ideally, this would be 0 simulations, but we currently only determine there are no
         // valid modes in SpellAbilityChoicesIterator, which runs already when we're simulating.
@@ -812,7 +812,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         MultiTargetSelector.Targets targets = picker.getPlan().getSelectedDecision().targets;
@@ -837,7 +837,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNull(sa);
     }
@@ -857,7 +857,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbilityPicker picker = new SpellAbilityPicker(p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertNotNull(sa);
         MultiTargetSelector.Targets targets = picker.getPlan().getSelectedDecision().targets;
@@ -876,7 +876,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         addCard("Flying Men", p);
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
 
-        final SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        final SpellAbilityPicker picker = new SpellAbilityPicker(p);
         Runnable assertPickIsGoblinBombardmentTargetingOpponent = () -> {
             game.getAction().checkStateEffects(true);
             SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
@@ -934,7 +934,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
         game.getAction().checkStateEffects(true);
-        SpellAbilityPicker picker = new SpellAbilityPicker(game, ai);
+        SpellAbilityPicker picker = new SpellAbilityPicker(ai);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
 
         AssertJUnit.assertNotNull(sa);


### PR DESCRIPTION
## Summary

This improves `GameStateEvaluator` fidelity for multiplayer teams, phasing, and eliminated players.

Previously, the evaluator assumed every player other than the AI was an opponent. This caused allied cards, life, and permanents to reduce the AI's score. The evaluator now classifies resources using `isOpponentOf()` while preserving the existing weighting in normal one-on-one games.

Phased-out permanents are also included in long-term board and mana-base evaluation. Since they will phase back in, temporarily phasing a valuable permanent should not be scored as permanently losing it.

Finally, an AI player that has already lost now receives the terminal minimum score even when a multiplayer game continues.

## Tests

Added focused coverage confirming that:

- Allied permanents, life, and cards improve the team score.
- Phased permanents retain their long-term board and mana-base value.
- An eliminated player receives the minimum score in a continuing multiplayer game.

Thanks to Codex for help with code and tests!