### PR TITLE
Some Card Updates/Fixes

### DIFF
--- a/forge-gui/res/cardsfolder/d/dig_up_the_body.txt
+++ b/forge-gui/res/cardsfolder/d/dig_up_the_body.txt
@@ -2,7 +2,7 @@ Name:Dig Up the Body
 ManaCost:2 B
 Types:Instant
 K:Casualty:1
-A:SP$ Mill | NumCards$ 2 | SubAbility$ DBReturn | SpellDescription$ Mill two cards,
-SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ChangeType$ Creature.YouOwn | Hidden$ True | SpellDescription$ then return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)
+A:SP$ Mill | NumCards$ 2 | SubAbility$ DBReturn | SpellDescription$ Mill two cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)
+SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ChangeType$ Creature.YouOwn | Hidden$ True
 DeckHas:Ability$Graveyard|Mill|Sacrifice
 Oracle:Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nMill two cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)

--- a/forge-gui/res/cardsfolder/d/dig_up_the_body.txt
+++ b/forge-gui/res/cardsfolder/d/dig_up_the_body.txt
@@ -5,4 +5,4 @@ K:Casualty:1
 A:SP$ Mill | NumCards$ 2 | SubAbility$ DBReturn | SpellDescription$ Mill two cards,
 SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ChangeType$ Creature.YouOwn | Hidden$ True | SpellDescription$ then return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)
 DeckHas:Ability$Graveyard|Mill|Sacrifice
-Oracle:Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nMill two cards, then return a creature card from your graveyard to your hand. (To mill a card, a player puts the top card of their library into their graveyard.)
+Oracle:Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nMill two cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)

--- a/forge-gui/res/cardsfolder/e/echoing_cavern.txt
+++ b/forge-gui/res/cardsfolder/e/echoing_cavern.txt
@@ -1,8 +1,8 @@
 Name:Echoing Cavern
 ManaCost:no cost
-Types:Land
+Types:Land Cave
 K:ETBReplacement:Other:ChooseCT
-SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Creature | SpellDescription$ As CARDNAME enters, choose a creature type. | AILogic$ MostProminentInComputerDeckNonToken
+SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Creature | SpellDescription$ As this land enters, choose a creature type. | AILogic$ MostProminentInComputerDeckNonToken
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Any | RestrictValid$ Spell.ChosenType | SpellDescription$ Add one mana of any color. Spend this mana only to cast spells of the chosen type.
 A:AB$ Seek | Cost$ 4 T | Type$ Card.ChosenType | Exhaust$ True | SpellDescription$ Seek a card of the chosen type.

--- a/forge-gui/res/cardsfolder/e/electrostatic_blast.txt
+++ b/forge-gui/res/cardsfolder/e/electrostatic_blast.txt
@@ -1,8 +1,9 @@
 Name:Electrostatic Blast
 ManaCost:1 R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ DBDelayTrigger | SpellDescription$ CARDNAME deals 2 damage to any target. When you cast your next instant or sorcery spell, exile the top three cards of your library. You may play one of those cards until end of turn.
-SVar:DBDelayTrigger:DB$ DelayedTrigger | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ TrigExile | TriggerDescription$ When you cast your next instant or sorcery spell, exile the top three cards of your library. You may play one of those cards until end of turn.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ DBBoon | SpellDescription$ CARDNAME deals 2 damage to any target.
+SVar:DBBoon:DB$ Effect | Boon$ True | Duration$ Permanent | Triggers$ Boon | SpellDescription$ You get a one-time boon with "When you cast an instant or sorcery spell, exile the top three cards of your library. You may play one of those cards until end of turn."
+SVar:Boon:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ TrigExile | TriggerDescription$ When you cast an instant or sorcery spell, exile the top three cards of your library. You may play one of those cards until end of turn.
 SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 3 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | Triggers$ Play1,Play2 | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
 SVar:STPlay:Mode$ Continuous | AffectedZone$ Exile | Affected$ Card.IsRemembered | MayPlay$ True | Description$ You may play one of those cards until end of turn.
@@ -11,4 +12,4 @@ SVar:Play2:Mode$ LandPlayed | ValidCard$ Land.IsRemembered | TriggerZones$ Comma
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHints:Type$Instant|Sorcery
-Oracle:Electrostatic Blast deals 2 damage to any target. When you cast your next instant or sorcery spell, exile the top three cards of your library. You may play one of those cards until end of turn.
+Oracle:Electrostatic Blast deals 2 damage to any target. You get a one-time boon with "When you cast an instant or sorcery spell, exile the top three cards of your library. You may play one of those cards until end of turn."

--- a/forge-gui/res/cardsfolder/e/enigma_sphinx_avatar.txt
+++ b/forge-gui/res/cardsfolder/e/enigma_sphinx_avatar.txt
@@ -1,7 +1,7 @@
 Name:Enigma Sphinx Avatar
 ManaCost:no cost
 Types:Vanguard
-HandLifeModifier:+0/+5
+HandLifeModifier:-1/+5
 T:Mode$ SpellCast | ValidCard$ Artifact.nonColorless | ValidActivatingPlayer$ You | CheckSVar$ NumColoredCast | SVarCompare$ EQ1 | Execute$ TrigSearch | NoResolvingCheck$ True | TriggerZones$ Command | TriggerDescription$ Whenever you cast a colored artifact spell for the first time each turn, search your library for a colored artifact card chosen at random whose mana value is less than that spell's mana value. You may play that card without paying its mana cost. If you don't, put that card on the bottom of your library.
 SVar:TrigSearch:DB$ ChangeZone | AtRandom$ True | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | ChangeType$ Artifact.nonColorless+cmcLTX | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Defined$ Remembered | Controller$ You | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/f/fearsome_whelp.txt
+++ b/forge-gui/res/cardsfolder/f/fearsome_whelp.txt
@@ -3,9 +3,8 @@ ManaCost:1 R
 Types:Creature Dragon
 PT:1/1
 K:Flying
-K:Haste
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ At the beginning of your end step, each Dragon card in your hand perpetually gains "This spell costs {1} less to cast."
 SVar:TrigAnimate:DB$ AnimateAll | ValidCards$ Dragon.YouOwn | Zone$ Hand | staticAbilities$ DragonReduceCost | Duration$ Perpetual
 SVar:DragonReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.
 DeckHints:Type$Dragon
-Oracle:Flying, haste\nAt the beginning of your end step, each Dragon card in your hand perpetually gains "This spell costs {1} less to cast."
+Oracle:Flying\nAt the beginning of your end step, each Dragon card in your hand perpetually gains "This spell costs {1} less to cast."

--- a/forge-gui/res/cardsfolder/f/finders_keepers.txt
+++ b/forge-gui/res/cardsfolder/f/finders_keepers.txt
@@ -1,6 +1,6 @@
 Name:Finders, Keepers
 ManaCost:5 B
-Types:Instant
+Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Creature | SubAbility$ DBAssemble | SpellDescription$ Destroy target creature, then assemble a Contraption.
 SVar:DBAssemble:DB$ AssembleContraption
 Oracle:Destroy target creature, then assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)

--- a/forge-gui/res/cardsfolder/f/fire_magic.txt
+++ b/forge-gui/res/cardsfolder/f/fire_magic.txt
@@ -6,4 +6,4 @@ A:SP$ Charm | Choices$ DBFire,DBFira,DBFiraga
 SVar:DBFire:DB$ DamageAll | PrecostDesc$ Fire | ModeCost$ 0 | NumDmg$ 1 | ValidCards$ Creature | SpellDescription$ CARDNAME deals 1 damage to each creature.
 SVar:DBFira:DB$ DamageAll | PrecostDesc$ Fira | ModeCost$ 2 | NumDmg$ 2 | ValidCards$ Creature | SpellDescription$ CARDNAME deals 2 damage to each creature.
 SVar:DBFiraga:DB$ DamageAll | PrecostDesc$ Firaga | ModeCost$ 5 | NumDmg$ 3 | ValidCards$ Creature | SpellDescription$ CARDNAME deals 3 damage to each creature.
-Oracle:Tiered (Choose one additional cost.)\n• Fire — {0} — Fire Magic deals 1 damage to each creature.\n• Fira — {2} — Fire Magic deals 2 damage to each creature.\n• Firaga — {3} — Fire Magic deals 3 damage to each creature.
+Oracle:Tiered (Choose one additional cost.)\n• Fire — {0} — Fire Magic deals 1 damage to each creature.\n• Fira — {2} — Fire Magic deals 2 damage to each creature.\n• Firaga — {5} — Fire Magic deals 3 damage to each creature.

--- a/forge-gui/res/cardsfolder/f/flash.txt
+++ b/forge-gui/res/cardsfolder/f/flash.txt
@@ -1,8 +1,8 @@
 Name:Flash
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ 1 | SubAbility$ DBSac | RememberChanged$ True | SpellDescription$ You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by up to {2}.
-SVar:DBSac:DB$ SacrificeAll | Defined$ Remembered | UnlessCost$ DefinedCost_Remembered_Minus2 | UnlessPayer$ You | UnlessUpTo$ True | SubAbility$ DBCleanup
+A:SP$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ 1 | SubAbility$ DBSac | RememberChanged$ True | SpellDescription$ You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by {2}.
+SVar:DBSac:DB$ SacrificeAll | Defined$ Remembered | UnlessCost$ DefinedCost_Remembered_Minus2 | UnlessPayer$ You | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:All
-Oracle:You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by up to {2}.
+Oracle:You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by {2}.

--- a/forge-gui/res/cardsfolder/f/fleshformer.txt
+++ b/forge-gui/res/cardsfolder/f/fleshformer.txt
@@ -2,6 +2,6 @@ Name:Fleshformer
 ManaCost:2 B
 Types:Creature Human Wizard
 PT:2/2
-A:AB$ Pump | Cost$ W U B R G | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | KW$ Fear | ActivationLimit$ 1 | SubAbility$ DBPump | SpellDescription$ CARDNAME gets +2/+2 and gains fear until end of turn.
-SVar:DBPump:DB$ Pump | NumAtt$ -2 | NumDef$ -2 | ValidTgts$ Creature | IsCurse$ True | SpellDescription$ Target creature gets -2/-2 until end of turn. Activate only once each turn.
-Oracle:{W}{U}{B}{R}{G}: Fleshformer gets +2/+2 and gains fear until end of turn. Target creature gets -2/-2 until end of turn. Activate only during your turn. (A creature with fear can't be blocked except by artifact creatures and/or black creatures.)
+A:AB$ Pump | Cost$ W U B R G | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | KW$ Fear | ActivationLimit$ 1 | SubAbility$ DBPump | SpellDescription$ This creature gets +2/+2 and gains fear until end of turn.
+SVar:DBPump:DB$ Pump | NumAtt$ -2 | NumDef$ -2 | ValidTgts$ Creature | IsCurse$ True | SpellDescription$ Target creature gets -2/-2 until end of turn. Activate only during your turn.
+Oracle:{W}{U}{B}{R}{G}: This creature gets +2/+2 and gains fear until end of turn. Target creature gets -2/-2 until end of turn. Activate only during your turn. (A creature with fear can't be blocked except by artifact creatures and/or black creatures.)

--- a/forge-gui/res/cardsfolder/f/fleshformer.txt
+++ b/forge-gui/res/cardsfolder/f/fleshformer.txt
@@ -2,6 +2,6 @@ Name:Fleshformer
 ManaCost:2 B
 Types:Creature Human Wizard
 PT:2/2
-A:AB$ Pump | Cost$ W U B R G | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | KW$ Fear | ActivationLimit$ 1 | SubAbility$ DBPump | SpellDescription$ This creature gets +2/+2 and gains fear until end of turn.
+A:AB$ Pump | Cost$ W U B R G | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | KW$ Fear | PlayerTurn$ True | SubAbility$ DBPump | SpellDescription$ This creature gets +2/+2 and gains fear until end of turn.
 SVar:DBPump:DB$ Pump | NumAtt$ -2 | NumDef$ -2 | ValidTgts$ Creature | IsCurse$ True | SpellDescription$ Target creature gets -2/-2 until end of turn. Activate only during your turn.
 Oracle:{W}{U}{B}{R}{G}: This creature gets +2/+2 and gains fear until end of turn. Target creature gets -2/-2 until end of turn. Activate only during your turn. (A creature with fear can't be blocked except by artifact creatures and/or black creatures.)

--- a/forge-gui/res/cardsfolder/f/flotsam_jetsam.txt
+++ b/forge-gui/res/cardsfolder/f/flotsam_jetsam.txt
@@ -12,7 +12,7 @@ ALTERNATE
 
 Name:Jetsam
 ManaCost:4 UB UB
-Types:Instant
+Types:Sorcery
 A:SP$ Mill | Defined$ Opponent | NumCards$ 3 | SubAbility$ DBCast | SpellDescription$ Each opponent mills three cards, then you may cast a spell from each opponent's graveyard without paying its mana cost. If a spell cast this way would be put into a graveyard, exile it instead.
 SVar:DBCast:DB$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBChoose | SubAbility$ DBPlayAll
 SVar:DBChoose:DB$ ChooseCard | Choices$ Card.RememberedPlayerCtrl+nonLand | ChoiceZone$ Graveyard | Defined$ You | Amount$ 1 | RememberChosen$ True

--- a/forge-gui/res/cardsfolder/f/fluctuator.txt
+++ b/forge-gui/res/cardsfolder/f/fluctuator.txt
@@ -1,6 +1,6 @@
 Name:Fluctuator
 ManaCost:2
 Types:Artifact
-S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.Cycling | Activator$ You | Amount$ 2 | UpTo$ True | Description$ Cycling abilities you activate cost you up to {2} less to activate.
+S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.Cycling | Activator$ You | Amount$ 2 | Description$ Cycling abilities you activate cost you {2} less to activate.
 AI:RemoveDeck:Random
-Oracle:Cycling abilities you activate cost up to {2} less to activate.
+Oracle:Cycling abilities you activate cost {2} less to activate.

--- a/forge-gui/res/cardsfolder/f/foggy_swamp_vinebender.txt
+++ b/forge-gui/res/cardsfolder/f/foggy_swamp_vinebender.txt
@@ -1,6 +1,6 @@
 Name:Foggy Swamp Vinebender
 ManaCost:3 G
-Types:Creature Human Ranger Ally
+Types:Creature Human Plant Ally
 PT:4/3
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.powerLE2 | Description$ This creature can't be blocked by creatures with power 2 or less.
 A:AB$ PutCounter | Cost$ Waterbend<5> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | PlayerTurn$ True | SpellDescription$ Put a +1/+1 counter on this creature. Activate only during your turn.

--- a/forge-gui/res/cardsfolder/f/foundry_groundbreaker.txt
+++ b/forge-gui/res/cardsfolder/f/foundry_groundbreaker.txt
@@ -1,6 +1,6 @@
 Name:Foundry Groundbreaker
 ManaCost:3 G
-Types:Creature Artificer
+Types:Creature Human Artificer
 PT:3/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSacrifice | TriggerDescription$ When CARDNAME enters, sacrifice a land. Then conjure two cards named Mishra's Foundry onto the battlefield tapped.
 SVar:TrigSacrifice:DB$ Sacrifice | SacValid$ Land | Defined$ You | SubAbility$ DBConjure

--- a/forge-gui/res/cardsfolder/f/frenzied_geistblaster.txt
+++ b/forge-gui/res/cardsfolder/f/frenzied_geistblaster.txt
@@ -8,4 +8,4 @@ SVar:TrigSeek:AB$ Seek | Cost$ Discard<1/Card> | Type$ Instant,Sorcery
 SVar:X:Count$ValidGraveyard,Library,Hand Instant.YouOwn,Sorcery.YouOwn
 DeckHas:Ability$Discard
 DeckNeeds:Type$Instant|Sorcery
-Oracle:When Frenzied Geistblaster enters, if there are twenty or more instant and/or sorcery cards among cards in your graveyard, hand, and library, you may discard a card. If you do, seek an instant or sorcery card.
+Oracle:Prowess\nWhen this creature enters, if there are twenty or more instant and/or sorcery cards among cards in your graveyard, hand, and library, you may discard a card. If you do, seek an instant or sorcery card.

--- a/forge-gui/res/cardsfolder/f/fungal_fortitude.txt
+++ b/forge-gui/res/cardsfolder/f/fungal_fortitude.txt
@@ -7,4 +7,4 @@ SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | Description$ Enchanted creature gets +2/+0.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.EnchantedBy | Execute$ TrigReturn | TriggerController$ TriggeredCardController | TriggerDescription$ When enchanted creature dies, return it to the battlefield tapped under its owner's control.
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ TriggeredNewCardLKICopy
-Oracle:Flash\nEnchant creature\nWhen enchanted creature dies, return it to the battlefield tapped under its owner's control.
+Oracle:Flash\nEnchant creature\nEnchanted creature gets +2/+0.\nWhen enchanted creature dies, return it to the battlefield tapped under its owner's control.

--- a/forge-gui/res/cardsfolder/g/gale_conduit_of_the_arcane.txt
+++ b/forge-gui/res/cardsfolder/g/gale_conduit_of_the_arcane.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl
 DeckHints:Ability$Graveyard & Type$Sorcery|Instant
 AlternateMode:Specialize
-Oracle:When Gale, Conduit of the Arcane enters, if you cast it, return target instant or sorcery card from your graveyard to your hand.
+Oracle:Specialize {2}\nWhen Gale, Conduit of the Arcane enters, if you cast it, return target instant or sorcery card from your graveyard to your hand.
 
 SPECIALIZE:WHITE
 

--- a/forge-gui/res/cardsfolder/g/ghirapur.txt
+++ b/forge-gui/res/cardsfolder/g/ghirapur.txt
@@ -1,6 +1,6 @@
 Name:Ghirapur
 ManaCost:no cost
-Types:Plane Kaladesh
+Types:Plane Avishkar
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Command | Execute$ TrigAnimateAll | TriggerDescription$ At the beginning of combat on your turn, until end of turn, each noncreature, non-Vehicle artifact you control becomes a 5/3 Vehicle in addition to its other types and gains trample, haste, and crew 2.
 SVar:TrigAnimateAll:DB$ AnimateAll | ValidCards$ Artifact.nonCreature+YouCtrl+nonVehicle | Power$ 5 | Toughness$ 3 | Types$ Vehicle | Keywords$ Crew:2 & Trample & Haste
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, return target noncreature artifact card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/g/gnoll_hunting_party.txt
+++ b/forge-gui/res/cardsfolder/g/gnoll_hunting_party.txt
@@ -1,7 +1,7 @@
 Name:Gnoll Hunting Party
 ManaCost:5 R
 Types:Creature Gnoll
-PT:5/5
+PT:4/4
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature you attacked with this turn.
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ First Strike | Condition$ PlayerTurn | Description$ As long as it's your turn, CARDNAME has first strike.
 SVar:X:Count$AttackersDeclared

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -483,6 +483,7 @@ Antausia
 Apalapucia
 Arcavios
 Arkhos
+Avishkar
 Azgol
 Belenon
 Bolas's Meditation Realm
@@ -507,7 +508,6 @@ Iquatana
 Ir
 Ixalan
 Kaladesh
-Kaldheim
 Kamigawa
 Kandoka
 Karsus

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -507,7 +507,7 @@ Innistrad
 Iquatana
 Ir
 Ixalan
-Kaladesh
+Kaldheim
 Kamigawa
 Kandoka
 Karsus


### PR DESCRIPTION
Added changes/fixes for the following cards:
---

- **Dig Up the Body:** Update Oracle text to show that returning a card is optional.
- **Echoing Cavern:** _**Added Cave**_  to the card's type.
- **Electrostatic Blast:** _**Implemented the boon mechanic**_  to reflect the Oracle text's actual effect. _Implemented with assistance from Claude._
- **Enigma Sphinx Avatar:** Changed hand size modifier to **-1**. 
- **Fearsome Whelp:** _**Removed Haste**_  on the card's Oracle text and script.
- **Finders, Keepers:** Instant > **Sorcery**
- **Fire Magic:** Changed Firaga's cost in the Oracle text from _**3 to 5**_.
- **Flash:** _**Removed "UnlessUpTo$ True"**_  to reflect the current Oracle text.
- **Jetsam:** Instant > **Sorcery**
- **Fleshformer:** Changed _**"ActivationLimit$ 1" to "PlayerTurn$ True"**_  to reflect the actual Oracle text of the card. 
- **Fluctuator:** _**Removed "UpTo$ True"**_  to reflect the current Oracle text.
- **Foggy Swamp Vinebender:** Ranger > **Plant**
- **Foundry Groundbreaker:** _**Added Human**_  to the card's type.
- **Frenzied Geistblaster:** Update Oracle text to show that the card has _**Prowess**_.
- **Fungal Fortitude:** Update Oracle text to show that the card's enchant buff.
- **Gale, Conduit of the Arcane:** Update Oracle text to show that the card has _**Specialize**_.
- **Ghirapur:** Kaladesh > **Avishkar**. TypeLists updated to reflect the change.
- **Gnoll Hunting Party:** 5/5 > **4/4**.