### PR TITLE
Let the AI pay for converge and sunburst when X is the colour knob

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -85,6 +85,25 @@ public class ComputerUtilMana {
         return 0;
     }
 
+    /**
+     * Announce X on a converge or sunburst card, where its only job is to buy colors: the least X
+     * that still reaches the most of them. Returns the number of colors that will be paid.
+     */
+    public static int setXForBestConverge(final SpellAbility sa, final Player ai, final int maxX) {
+        int bestX = 0;
+        int bestColors = 0;
+        for (int i = 0; i <= maxX; i++) {
+            sa.setXManaCostPaid(i);
+            int colors = getConvergeCount(sa, ai);
+            if (colors > bestColors) {
+                bestColors = colors;
+                bestX = i;
+            }
+        }
+        sa.setXManaCostPaid(bestX);
+        return bestColors;
+    }
+
     // Does not check if mana sources can be used right now, just checks for potential chance.
     public static boolean hasEnoughManaSourcesToCast(final SpellAbility sa, final Player ai) {
         if (ai == null || sa == null)

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
@@ -79,17 +79,7 @@ public class PermanentAi extends SpellAbilityAi {
         if (mana.countX() > 0) {
             final int xPay = ComputerUtilCost.setMaxXValue(sa, ai, false);
             if (source.hasConverge()) {
-                int nColors = ComputerUtilMana.getConvergeCount(sa, ai);
-                for (int i = 1; i <= xPay; i++) {
-                    sa.setXManaCostPaid(i);
-                    int newColors = ComputerUtilMana.getConvergeCount(sa, ai);
-                    if (newColors > nColors) {
-                        nColors = newColors;
-                    } else {
-                        sa.setXManaCostPaid(i - 1);
-                        break;
-                    }
-                }
+                ComputerUtilMana.setXForBestConverge(sa, ai, xPay);
             } else if (xPay <= 0) {
                 return new AiAbilityDecision(0, AiPlayDecision.CantAffordX);
             }

--- a/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
@@ -81,6 +81,14 @@ public class TokenAi extends SpellAbilityAi {
             return pwPlus || sa.getSubAbility() != null;
         }
 
+        // A converge card counts its colors in a second SVar, because X is already the mana cost -
+        // so X is not the token count and the block below will not announce it, but it is still
+        // what buys the colors that count (e.g. Sweep the Skies)
+        if (!tokenHasX && source.hasConverge() && "Count$xPaid".equals(sa.getSVar("X"))) {
+            ComputerUtilMana.setXForBestConverge(sa, ai,
+                    ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger()));
+        }
+
         // X-cost spells
         if (tokenHasX) {
             int x = AbilityUtils.calculateAmount(sa.getHostCard(), tokenAmount, sa);

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ConvergeXCastTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ConvergeXCastTest.java
@@ -1,0 +1,83 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.ai.ComputerUtilMana;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.card.CounterEnumType;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+import org.testng.annotations.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * On a converge or sunburst card X only buys colors, so the AI announces the least X that reaches
+ * the most of them - whether the count lands on the card as counters or as the size of the effect.
+ */
+public class ConvergeXCastTest extends AITest {
+
+    @Test
+    public void sunburstCountsEveryColourItCouldPayFor() {
+        Game game = newGame();
+        Player ai = game.getPlayers().get(1);
+        fiveColours(ai);
+        addCardToZone("Engineered Explosives", ai, ZoneType.Hand);
+
+        settleAndPlay(game, ai);
+
+        Card ee = findCardWithName(game, "Engineered Explosives");
+        assertNotNull("the AI cast it", ee);
+        assertEquals("sunburst counted all five colours", 5,
+                ee.getCounters(CounterEnumType.CHARGE));
+    }
+
+    /**
+     * Sweep the Skies counts its colors in Y, so X is not the token count and is easy to leave
+     * unannounced - but it is still what buys the colors. Asserted on the announced X rather than
+     * on a played turn, because TokenAi gates token spells behind a random roll.
+     */
+    @Test
+    public void convergeSizesAnEffectTheCostDoesNotName() {
+        Game game = newGame();
+        Player ai = game.getPlayers().get(1);
+        fiveColours(ai);
+        addCard("Island", ai);
+        Card sweep = addCardToZone("Sweep the Skies", ai, ZoneType.Hand);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = sweep.getFirstSpellAbility();
+        sa.setActivatingPlayer(ai);
+        SpellApiToAi.Converter.get(sa.getApi()).canPlayWithSubs(ai, sa);
+
+        assertEquals("X paid for the four extra colours", 4, sa.getXManaCostPaid().intValue());
+        assertEquals("so all five are spent", 5, ComputerUtilMana.getConvergeCount(sa, ai));
+    }
+
+    private Game newGame() {
+        Game game = initAndCreateGame();
+        game.getPlayers().get(0).setTeam(1);
+        game.getPlayers().get(1).setTeam(0);
+        return game;
+    }
+
+    private void fiveColours(Player p) {
+        addCard("Plains", p);
+        addCard("Island", p);
+        addCard("Swamp", p);
+        addCard("Mountain", p);
+        addCard("Forest", p);
+    }
+
+    private void settleAndPlay(Game game, Player ai) {
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+    }
+}

--- a/forge-gui/res/cardsfolder/e/engineered_explosives.txt
+++ b/forge-gui/res/cardsfolder/e/engineered_explosives.txt
@@ -6,6 +6,5 @@ A:AB$ DestroyAll | Cost$ 2 Sac<1/CARDNAME> | ValidCards$ Permanent.nonLand+cmcEQ
 SVar:X:Count$xPaid
 SVar:Y:Count$CardCounters.CHARGE
 SVar:NonStackingEffect:True
-AI:RemoveDeck:All
 DeckHints:Ability$Proliferate
 Oracle:Sunburst (This enters with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with mana value equal to the number of charge counters on Engineered Explosives.


### PR DESCRIPTION
On a converge or sunburst card whose colour count lives in a second SVar, `X` has one job: buy colours. The AI was not announcing it, so those cards were cast for the minimum.

`ComputerUtilCost.setMaxXValue` ends with `sa.setXManaCostPaid(x)`, leaving X at the maximum. `PermanentAi` then measured its converge baseline *there*:

```java
final int xPay = ComputerUtilCost.setMaxXValue(sa, ai, false);   // X is now the max
if (source.hasConverge()) {
    int nColors = ComputerUtilMana.getConvergeCount(sa, ai);     // measured at max X
    for (int i = 1; i <= xPay; i++) {
        sa.setXManaCostPaid(i);
        int newColors = ComputerUtilMana.getConvergeCount(sa, ai);
        if (newColors > nColors) { nColors = newColors; }
        else { sa.setXManaCostPaid(i - 1); break; }
    }
}
```

The baseline is already the best colour count available, so the first step of the walk always compared worse and X collapsed to **0**. `TokenAi` had a different miss: its X block is guarded by `"X".equals(tokenAmount)`, so a card counting colours in `Y` never reached any X handling at all.

Both want the same thing, so it is now named once - `ComputerUtilMana.setXForBestConverge` - and `PermanentAi` shrinks by 10 lines calling it.

## Effect

All five cards in the pool whose cost has X and for which `Card.hasConverge()` is true, with five differently coloured lands untapped:

| | X before | X after | |
|---|---|---|---|
| Engineered Explosives | 0 | **5** | 0 charge counters, so it could only ever destroy 0-drops |
| Chamber Sentry | 0 | **5** | entered as a 0/0 and died |
| Skyrider Elf | 0 | **3** | entered as a 0/0 and died |
| Sweep the Skies | unannounced | **4** | converge 1 -> 5, so five thopters rather than one |
| Prismatic Ending | unannounced | unannounced | not fixed, see below |

**Only Engineered Explosives is flagged.** The other three that this fixes are in AI decks today - two of them entering as 0/0s and dying.

Edge cases behave: five Wastes gives X=0, and Plains/Plains/Island gives X=2 rather than paying for a colour already covered.

## Engineered Explosives unflagged

Casting it for X=0 was the only thing wrong with it. The activated half needs nothing: `DestroyAll` routes it through the same `DestroyAllAi.doMassRemovalLogic` as Wrath of God, and it matched Wrath's decision on every board I tried. Two charge counters, everything at cmc 2 so both cards hit the same permanents:

| AI creatures | opponent creatures | Engineered Explosives | Wrath of God |
|---|---|---|---|
| 161 | 307 | declines | declines |
| 161 | 468 | plays | plays |
| 322 | 629 | plays | plays |

It does wipe at a cost to itself when the swing justifies it, on the shared `CREATURE_EVAL_THRESHOLD` - not only when it risks nothing.

The flag was also self-fulfilling: `AiController.getSpellAbilityToPlayImpl` strips every ability of a flagged card before evaluating anything, so "the AI never plays it" held regardless of whether its AI worked.

## Prismatic Ending, not fixed

Announcing X takes its converge from 1 to 5 and it still declines, so X is necessary but not sufficient there. Its condition is `ConditionPresent$ Permanent.nonLand+cmcLEY`, and `Count$Converge` reads the colours *actually* paid:

```java
if (sq[0].contains("Converge")) {
    SpellAbility castSA = c.getCastSA();
    return doXMath(castSA == null ? 0 : castSA.getPayingColors().countColors(), expr, c, ctb);
}
```

Before the spell is cast `getCastSA()` is null, so Y is 0 and `cmcLEY` matches nothing above a 0-drop. The AI's `getConvergeCount` predicts converge by simulating payment, but the condition path uses the rules-side count; bridging the two is a separate piece of work and I have left the card flagged.

`DamageAllAi:30` and `DestroyAllAi:64` have the same `X`-only assumption, but no card in the pool currently reaches them through it.

## Testing

Two tests. Engineered Explosives plays a real turn and lands with five charge counters - that one has to go through the full `AiController` path, since it is the unflagging that needs proving. Sweep the Skies asserts the announced X instead, because `TokenAi` gates token spells behind a random roll and a played-turn assertion on it is flaky; both assertions were run repeatedly each way.

Each test fails without its own half of the change. 337 tests, 0 failures, checkstyle clean.

🤖 Implemented with the assistance of Claude Code (Opus 5).
