### PR TITLE
Equip loop fix

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1534,13 +1534,6 @@ public class AiController {
     }
 
     private SpellAbility getSpellAbilityToPlay() {
-        if (skipped != null) {
-            //FIXME: this is for failed SA to skip temporarily, don't know why AI computation for mana fails, maybe due to auto mana compute?
-            for (SpellAbility sa : skipped) {
-                //System.out.println("Unskip: " + sa.toString() + " (" +  sa.getHostCard().getName() + ").");
-                sa.setSkip(false);
-            }
-        }
         CardCollection cards = ComputerUtilAbility.getAvailableCards(game, player);
         cards = ComputerUtilCard.dedupeCards(cards);
         List<SpellAbility> saList = Lists.newArrayList();
@@ -1566,6 +1559,7 @@ public class AiController {
                 saList = ComputerUtilAbility.getSpellAbilities(cards, player); // get the SA list early to check for copy SAs
                 if (ComputerUtilAbility.getFirstCopySASpell(saList) == null) {
                     // Nothing to copy the spell with, so do nothing.
+                    clearSkippedSpellAbilities();
                     return null;
                 }
             }
@@ -1589,20 +1583,36 @@ public class AiController {
             // TODO allow when experimental profile?
             return spellAbility.isLandAbility() || (spellAbility.getHostCard() != null && ComputerUtilCard.isCardRemAIDeck(spellAbility.getHostCard()));
         });
-        //removed skipped SA
+        // Keep failed SAs skipped for this priority sequence. Unskip only when passing so a later
+        // priority (new mana / board state) can retry — unskipping every choose caused equip loops.
         skipped = saList.stream().filter(SpellAbility::isSkip).collect(Collectors.toList());
-        if (!skipped.isEmpty())
+        if (!skipped.isEmpty()) {
             saList.removeAll(skipped);
+        }
         //update LivingEndPlayer
         useLivingEnd = IterableUtil.any(player.getZone(ZoneType.Library), CardPredicates.nameEquals("Living End"));
 
         SpellAbility chosenSa = chooseSpellAbilityToPlayFromList(saList, true);
 
         if (topOwnedByAI && !mustRespond && chosenSa != ComputerUtilAbility.getFirstCopySASpell(saList)) {
+            clearSkippedSpellAbilities();
             return null; // not planning to copy the spell and not marked as something the AI would respond to
         }
 
+        if (chosenSa == null) {
+            clearSkippedSpellAbilities();
+        }
         return chosenSa;
+    }
+
+    private void clearSkippedSpellAbilities() {
+        if (skipped == null || skipped.isEmpty()) {
+            return;
+        }
+        for (SpellAbility sa : skipped) {
+            sa.setSkip(false);
+        }
+        skipped.clear();
     }
 
     private SpellAbility chooseSpellAbilityToPlayFromList(final List<SpellAbility> all, boolean skipCounter) {

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -837,11 +837,13 @@ public class PlayerControllerAi extends PlayerController {
         if (sa.isLandAbility()) {
             if (sa.canPlay()) {
                 sa.resolve();
+                return true;
             }
-        } else {
-            ComputerUtil.handlePlayingSpellAbility(player, sa, getDeferredTargetingPlayerAction(sa));
+            return false;
         }
-        return true;
+        // Must return the real result: always-true made PhaseHandler treat failed equips/spells as
+        // successful plays, so the AI re-chose the same SA until "AI looped too much".
+        return ComputerUtil.handlePlayingSpellAbility(player, sa, getDeferredTargetingPlayerAction(sa));
     }
 
     /**


### PR DESCRIPTION
Found the AI to be looping with Equip activations.

I was able to reproduce it with a test using the following cards in play and no mana in the pool:

Nahiri, Storm of Stone (Equip cost -1)
Kor Halberd (Equip 1 -> 0)
Nahiri, Forged in Fury (Target)