### PR TITLE
Make Adventure action animations frame-aware

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
+++ b/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
  */
 
 public class CharacterSprite extends MapActor {
+    private static final float DEFAULT_ANIMATION_FRAME_DURATION = 0.2f;
+    private static final float MAX_DEATH_ANIMATION_DURATION = 3f;
     private static final float MAX_ACTION_ANIMATION_DURATION = 5f;
     private final HashMap<AnimationTypes, HashMap<AnimationDirections, Animation<TextureRegion>>> animations = new HashMap<>();
     float timer;
@@ -63,7 +65,11 @@ public class CharacterSprite extends MapActor {
                     anim = Config.instance().getAnimatedSprites(path, stand.toString() + dir.toString());
 
                 if (anim.size != 0) {
-                    dirs.put(dir, new Animation<>(0.2f, anim));
+                    float frameDuration = DEFAULT_ANIMATION_FRAME_DURATION;
+                    if (stand == AnimationTypes.Death) {
+                        frameDuration = Math.min(frameDuration, MAX_DEATH_ANIMATION_DURATION / anim.size);
+                    }
+                    dirs.put(dir, new Animation<>(frameDuration, anim));
                     if (getWidth() == 0.0)//init size onload
                     {
                         setWidth(anim.first().getWidth());

--- a/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
+++ b/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
  */
 
 public class CharacterSprite extends MapActor {
+    private static final float MAX_ACTION_ANIMATION_DURATION = 5f;
     private final HashMap<AnimationTypes, HashMap<AnimationDirections, Animation<TextureRegion>>> animations = new HashMap<>();
     float timer;
     private Animation<TextureRegion> currentAnimation = null;
@@ -143,12 +144,13 @@ public class CharacterSprite extends MapActor {
     }
 
     /**
-     * Returns the duration of an animation in the sprite's current direction.
+     * Returns the capped duration of an action animation in the sprite's current direction.
      * Uses the supplied fallback when the atlas does not define that animation.
      */
-    public float getAnimationDuration(AnimationTypes type, float fallbackDuration) {
+    public float getActionAnimationDuration(AnimationTypes type, float fallbackDuration) {
         Animation<TextureRegion> animation = getAnimation(type, currentAnimationDir);
-        return animation == null ? fallbackDuration : animation.getAnimationDuration();
+        float duration = animation == null ? fallbackDuration : animation.getAnimationDuration();
+        return Math.min(duration, MAX_ACTION_ANIMATION_DURATION);
     }
 
     private Animation<TextureRegion> getAnimation(AnimationTypes type, AnimationDirections direction) {

--- a/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
+++ b/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
@@ -130,8 +130,34 @@ public class CharacterSprite extends MapActor {
     public void setAnimation(AnimationTypes type) {
         if (currentAnimationType != type) {
             currentAnimationType = type;
+            if (isOneShotAnimation(type)) {
+                timer = 0.0f;
+            }
             updateAnimation();
         }
+    }
+
+    /**
+     * Returns the duration of an animation in the sprite's current direction.
+     * Uses the supplied fallback when the atlas does not define that animation.
+     */
+    public float getAnimationDuration(AnimationTypes type, float fallbackDuration) {
+        HashMap<AnimationDirections, Animation<TextureRegion>> dirs = animations.get(type);
+        if (dirs == null || dirs.isEmpty()) {
+            return fallbackDuration;
+        }
+
+        Animation<TextureRegion> animation = dirs.get(currentAnimationDir);
+        if (animation == null) {
+            animation = dirs.get(AnimationDirections.Right);
+        }
+        return animation == null ? fallbackDuration : animation.getAnimationDuration();
+    }
+
+    private boolean isOneShotAnimation(AnimationTypes type) {
+        return type == AnimationTypes.Attack
+                || type == AnimationTypes.Death
+                || type == AnimationTypes.Hit;
     }
 
     private void updateAnimation() {
@@ -249,7 +275,7 @@ public class CharacterSprite extends MapActor {
         if (currentAnimationType.equals(AnimationTypes.Wake)) {
             currentFrame = currentAnimation.getKeyFrame(wakeTimer, false);
         } else {
-            currentFrame = currentAnimation.getKeyFrame(timer, true);
+            currentFrame = currentAnimation.getKeyFrame(timer, !isOneShotAnimation(currentAnimationType));
         }
 
         float scale = 1f;

--- a/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
+++ b/forge-gui-mobile/src/forge/adventure/character/CharacterSprite.java
@@ -128,12 +128,17 @@ public class CharacterSprite extends MapActor {
     }
 
     public void setAnimation(AnimationTypes type) {
-        if (currentAnimationType != type) {
+        Animation<TextureRegion> animation = getAnimation(type, currentAnimationDir);
+        if (animation == null) {
+            return;
+        }
+
+        if (currentAnimationType != type || currentAnimation != animation || isOneShotAnimation(type)) {
             currentAnimationType = type;
+            currentAnimation = animation;
             if (isOneShotAnimation(type)) {
                 timer = 0.0f;
             }
-            updateAnimation();
         }
     }
 
@@ -142,16 +147,18 @@ public class CharacterSprite extends MapActor {
      * Uses the supplied fallback when the atlas does not define that animation.
      */
     public float getAnimationDuration(AnimationTypes type, float fallbackDuration) {
+        Animation<TextureRegion> animation = getAnimation(type, currentAnimationDir);
+        return animation == null ? fallbackDuration : animation.getAnimationDuration();
+    }
+
+    private Animation<TextureRegion> getAnimation(AnimationTypes type, AnimationDirections direction) {
         HashMap<AnimationDirections, Animation<TextureRegion>> dirs = animations.get(type);
         if (dirs == null || dirs.isEmpty()) {
-            return fallbackDuration;
+            return null;
         }
 
-        Animation<TextureRegion> animation = dirs.get(currentAnimationDir);
-        if (animation == null) {
-            animation = dirs.get(AnimationDirections.Right);
-        }
-        return animation == null ? fallbackDuration : animation.getAnimationDuration();
+        Animation<TextureRegion> animation = dirs.get(direction);
+        return animation == null ? dirs.get(AnimationDirections.Right) : animation;
     }
 
     private boolean isOneShotAnimation(AnimationTypes type) {
@@ -161,23 +168,13 @@ public class CharacterSprite extends MapActor {
     }
 
     private void updateAnimation() {
-        AnimationTypes aniType = currentAnimationType;
-        AnimationDirections aniDir = currentAnimationDir;
-        if (!animations.containsKey(aniType)) {
-            aniType = AnimationTypes.Idle;
+        Animation<TextureRegion> animation = getAnimation(currentAnimationType, currentAnimationDir);
+        if (animation == null) {
+            animation = getAnimation(AnimationTypes.Idle, currentAnimationDir);
         }
-        if (!animations.containsKey(aniType)) {
-            return;
+        if (animation != null) {
+            currentAnimation = animation;
         }
-        HashMap<AnimationDirections, Animation<TextureRegion>> dirs = animations.get(aniType);
-
-        if (!dirs.containsKey(aniDir)) {
-            aniDir = AnimationDirections.Right;
-        }
-        if (!dirs.containsKey(aniDir)) {
-            return;
-        }
-        currentAnimation = dirs.get(aniDir);
     }
 
     public void setDirection(AnimationDirections dir) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -658,7 +658,7 @@ public abstract class GameStage extends Stage {
             PlayerSprite playerSprite = getPlayerSprite();
             playerSprite.setAnimation(CharacterSprite.AnimationTypes.Death);
             playerSprite.playEffect(Paths.EFFECT_BLOOD, 0.5f);
-            float deathDuration = playerSprite.getAnimationDuration(CharacterSprite.AnimationTypes.Death, 1f);
+            float deathDuration = playerSprite.getActionAnimationDuration(CharacterSprite.AnimationTypes.Death, 1f);
             Timer.schedule(new Timer.Task() {
                 @Override
                 public void run() {
@@ -682,7 +682,7 @@ public abstract class GameStage extends Stage {
         PlayerSprite playerSprite = getPlayerSprite();
         playerSprite.setAnimation(CharacterSprite.AnimationTypes.Hit);
         playerSprite.playEffect(Paths.EFFECT_BLOOD, 0.5f);
-        float hitDuration = playerSprite.getAnimationDuration(CharacterSprite.AnimationTypes.Hit, 1f);
+        float hitDuration = playerSprite.getActionAnimationDuration(CharacterSprite.AnimationTypes.Hit, 1f);
         Timer.schedule(new Timer.Task() {
             @Override
             public void run() {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -655,8 +655,10 @@ public abstract class GameStage extends Stage {
         PointOfInterest poi = Current.world().findPointsOfInterest("Spawn");
         if (poi != null) {
             Forge.advFreezePlayerControls = true;
-            getPlayerSprite().setAnimation(CharacterSprite.AnimationTypes.Death);
-            getPlayerSprite().playEffect(Paths.EFFECT_BLOOD, 0.5f);
+            PlayerSprite playerSprite = getPlayerSprite();
+            playerSprite.setAnimation(CharacterSprite.AnimationTypes.Death);
+            playerSprite.playEffect(Paths.EFFECT_BLOOD, 0.5f);
+            float deathDuration = playerSprite.getAnimationDuration(CharacterSprite.AnimationTypes.Death, 1f);
             Timer.schedule(new Timer.Task() {
                 @Override
                 public void run() {
@@ -669,7 +671,7 @@ public abstract class GameStage extends Stage {
                         Forge.clearTransitionScreen();
                     }, Forge.takeScreenshot()))));
                 }
-            }, 1f);
+            }, deathDuration);
         }//Spawn shouldn't be null
     }
 
@@ -677,14 +679,16 @@ public abstract class GameStage extends Stage {
         if (!Current.player().hasEquippedItem())
             return;
         Forge.advFreezePlayerControls = true;
-        getPlayerSprite().setAnimation(CharacterSprite.AnimationTypes.Hit);
-        getPlayerSprite().playEffect(Paths.EFFECT_BLOOD, 0.5f);
+        PlayerSprite playerSprite = getPlayerSprite();
+        playerSprite.setAnimation(CharacterSprite.AnimationTypes.Hit);
+        playerSprite.playEffect(Paths.EFFECT_BLOOD, 0.5f);
+        float hitDuration = playerSprite.getAnimationDuration(CharacterSprite.AnimationTypes.Hit, 1f);
         Timer.schedule(new Timer.Task() {
             @Override
             public void run() {
                 showImageDialog(Current.generateDefeatMessage(false), getDefeatBadge(), () -> Forge.advFreezePlayerControls = false);
             }
-        }, 1f);
+        }, hitDuration);
     }
 
     private FBufferedImage getDefeatBadge() {

--- a/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
@@ -828,13 +828,16 @@ public class MapStage extends GameStage {
             currentMob.clearCollisionHeight();
             Current.player().win();
             player.setAnimation(CharacterSprite.AnimationTypes.Attack);
+            float attackDuration = Math.max(1f,
+                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 1f));
             currentMob.playEffect(Paths.EFFECT_BLOOD, 0.5f);
             Timer.schedule(new Timer.Task() {
                 @Override
                 public void run() {
                     currentMob.setAnimation(CharacterSprite.AnimationTypes.Death);
                     currentMob.resetCollisionHeight();
-                    startPause(0.3f, () -> {
+                    float deathDuration = currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Death, 0.3f);
+                    startPause(deathDuration, () -> {
                         MapStage.this.getReward();
                         AdventureQuestController.instance().updateQuestsWin(currentMob,enemies);
                         AdventureQuestController.instance().showQuestDialogs(MapStage.this);
@@ -842,12 +845,15 @@ public class MapStage extends GameStage {
                     });
                     player.setAnimation(CharacterSprite.AnimationTypes.Idle);
                 }
-            }, 1f);
+            }, attackDuration);
         } else {
             currentMob.clearCollisionHeight();
             player.setAnimation(CharacterSprite.AnimationTypes.Hit);
             currentMob.setAnimation(CharacterSprite.AnimationTypes.Attack);
-            startPause(0.3f, () -> {
+            float resultAnimationDuration = Math.max(
+                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Hit, 0.3f),
+                    currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.3f));
+            startPause(resultAnimationDuration, () -> {
                 player.setAnimation(CharacterSprite.AnimationTypes.Idle);
                 currentMob.setAnimation(CharacterSprite.AnimationTypes.Idle);
                 currentMob.resetCollisionHeight();
@@ -1145,7 +1151,10 @@ public class MapStage extends GameStage {
         HapticEngine.vibrate(FPref.UI_VIBRATE_ON_ENEMY_ENCOUNTER, mob.getData().boss ? 400 : 200);
         Forge.advFreezePlayerControls = true;
         player.clearCollisionHeight();
-        startPause(0.8f, () -> {
+        float attackDuration = Math.max(
+                player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f),
+                mob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f));
+        startPause(attackDuration, () -> {
             if (started)
                 return;
             started = true;

--- a/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
@@ -829,14 +829,14 @@ public class MapStage extends GameStage {
             Current.player().win();
             player.setAnimation(CharacterSprite.AnimationTypes.Attack);
             float attackDuration = Math.max(1f,
-                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 1f));
+                    player.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 1f));
             currentMob.playEffect(Paths.EFFECT_BLOOD, 0.5f);
             Timer.schedule(new Timer.Task() {
                 @Override
                 public void run() {
                     currentMob.setAnimation(CharacterSprite.AnimationTypes.Death);
                     currentMob.resetCollisionHeight();
-                    float deathDuration = currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Death, 0.3f);
+                    float deathDuration = currentMob.getActionAnimationDuration(CharacterSprite.AnimationTypes.Death, 0.3f);
                     startPause(deathDuration, () -> {
                         MapStage.this.getReward();
                         AdventureQuestController.instance().updateQuestsWin(currentMob,enemies);
@@ -851,8 +851,8 @@ public class MapStage extends GameStage {
             player.setAnimation(CharacterSprite.AnimationTypes.Hit);
             currentMob.setAnimation(CharacterSprite.AnimationTypes.Attack);
             float resultAnimationDuration = Math.max(
-                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Hit, 0.3f),
-                    currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.3f));
+                    player.getActionAnimationDuration(CharacterSprite.AnimationTypes.Hit, 0.3f),
+                    currentMob.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.3f));
             startPause(resultAnimationDuration, () -> {
                 player.setAnimation(CharacterSprite.AnimationTypes.Idle);
                 currentMob.setAnimation(CharacterSprite.AnimationTypes.Idle);
@@ -1152,8 +1152,8 @@ public class MapStage extends GameStage {
         Forge.advFreezePlayerControls = true;
         player.clearCollisionHeight();
         float attackDuration = Math.max(
-                player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f),
-                mob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f));
+                player.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f),
+                mob.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f));
         startPause(attackDuration, () -> {
             if (started)
                 return;

--- a/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
@@ -121,7 +121,10 @@ public class WorldStage extends GameStage implements SaveFileContent {
                     HapticEngine.vibrate(FPref.UI_VIBRATE_ON_ENEMY_ENCOUNTER, mob.getData().boss ? 400 : 200);
                     Forge.advFreezePlayerControls = true;
                     player.clearCollisionHeight();
-                    startPause(0.8f, () -> {
+                    float attackDuration = Math.max(
+                            player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f),
+                            mob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f));
+                    startPause(attackDuration, () -> {
                         Forge.setCursor(null, Forge.magnifyToggle ? "1" : "2");
                         SoundSystem.instance.play(SoundEffectType.ManaBurn, false);
                         DuelScene duelScene = DuelScene.instance();
@@ -164,13 +167,16 @@ public class WorldStage extends GameStage implements SaveFileContent {
             currentMob.clearCollisionHeight();
             Current.player().win();
             player.setAnimation(CharacterSprite.AnimationTypes.Attack);
+            float attackDuration = Math.max(1f,
+                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 1f));
             currentMob.playEffect(Paths.EFFECT_BLOOD, 0.5f);
             Timer.schedule(new Timer.Task() {
                 @Override
                 public void run() {
                     currentMob.setAnimation(CharacterSprite.AnimationTypes.Death);
                     currentMob.resetCollisionHeight();
-                    startPause(0.3f, () -> {
+                    float deathDuration = currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Death, 0.3f);
+                    startPause(deathDuration, () -> {
                         RewardScene.instance().loadRewards(currentMob.getRewards(), RewardScene.Type.Loot, null);
                         WorldStage.this.removeEnemy(currentMob);
                         AdventureQuestController.instance().updateQuestsWin(currentMob);
@@ -179,12 +185,15 @@ public class WorldStage extends GameStage implements SaveFileContent {
                         currentMob = null;
                     });
                 }
-            }, 1f);
+            }, attackDuration);
         } else {
             currentMob.clearCollisionHeight();
             player.setAnimation(CharacterSprite.AnimationTypes.Hit);
             currentMob.setAnimation(CharacterSprite.AnimationTypes.Attack);
-            startPause(0.5f, () -> {
+            float resultAnimationDuration = Math.max(
+                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Hit, 0.5f),
+                    currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.5f));
+            startPause(resultAnimationDuration, () -> {
                 currentMob.resetCollisionHeight();
                 boolean defeated = Current.player().defeated();
                 AdventureQuestController.instance().updateQuestsLose(currentMob);

--- a/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
@@ -122,8 +122,8 @@ public class WorldStage extends GameStage implements SaveFileContent {
                     Forge.advFreezePlayerControls = true;
                     player.clearCollisionHeight();
                     float attackDuration = Math.max(
-                            player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f),
-                            mob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f));
+                            player.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f),
+                            mob.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.8f));
                     startPause(attackDuration, () -> {
                         Forge.setCursor(null, Forge.magnifyToggle ? "1" : "2");
                         SoundSystem.instance.play(SoundEffectType.ManaBurn, false);
@@ -168,14 +168,14 @@ public class WorldStage extends GameStage implements SaveFileContent {
             Current.player().win();
             player.setAnimation(CharacterSprite.AnimationTypes.Attack);
             float attackDuration = Math.max(1f,
-                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 1f));
+                    player.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 1f));
             currentMob.playEffect(Paths.EFFECT_BLOOD, 0.5f);
             Timer.schedule(new Timer.Task() {
                 @Override
                 public void run() {
                     currentMob.setAnimation(CharacterSprite.AnimationTypes.Death);
                     currentMob.resetCollisionHeight();
-                    float deathDuration = currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Death, 0.3f);
+                    float deathDuration = currentMob.getActionAnimationDuration(CharacterSprite.AnimationTypes.Death, 0.3f);
                     startPause(deathDuration, () -> {
                         RewardScene.instance().loadRewards(currentMob.getRewards(), RewardScene.Type.Loot, null);
                         WorldStage.this.removeEnemy(currentMob);
@@ -191,8 +191,8 @@ public class WorldStage extends GameStage implements SaveFileContent {
             player.setAnimation(CharacterSprite.AnimationTypes.Hit);
             currentMob.setAnimation(CharacterSprite.AnimationTypes.Attack);
             float resultAnimationDuration = Math.max(
-                    player.getAnimationDuration(CharacterSprite.AnimationTypes.Hit, 0.5f),
-                    currentMob.getAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.5f));
+                    player.getActionAnimationDuration(CharacterSprite.AnimationTypes.Hit, 0.5f),
+                    currentMob.getActionAnimationDuration(CharacterSprite.AnimationTypes.Attack, 0.5f));
             startPause(resultAnimationDuration, () -> {
                 currentMob.resetCollisionHeight();
                 boolean defeated = Current.player().defeated();


### PR DESCRIPTION
- Many vanilla Adventure sprites already contain detailed action sequences that fixed delays cut short; frame-aware timing lets those authored frames finish.
- Vanilla Shade attack: the current 0.8-second delay displays 4 of 16 frames, while frame-aware playback displays all 16 over 3.2 seconds.

  ![Vanilla Shade attack before and after frame-aware timing](https://oldborder-shandalar.net/pr-assets/frame-aware-animations/shade-attack-before-after-v2.gif)

- Vanilla Wandering Giant death: the current 0.3-second delay displays only the opening of its 24-frame sequence, while frame-aware playback displays all 24 frames over 4.8 seconds.

  ![Vanilla Wandering Giant death before and after frame-aware timing](https://oldborder-shandalar.net/pr-assets/frame-aware-animations/wandering-giant-death-before-after-v2.gif)

- Replace fixed Adventure encounter and result delays with durations derived from each sprite's frame count at the existing 0.2-second frame rate.
- Play Attack, Hit, and Death animations once, hold their final frame, and restart explicitly requested actions.
- Preserve existing fallback timing and looping behavior for atlases without the requested action regions.
- Cap action-animation waits at five seconds so unusually large atlases cannot create excessive delays.
- Wait for the longer player or enemy action so neither animation is cut short.

I understand that it could be irritating to wait, but it's definitely closer to what the sprite artists intended to have. 
