### PR TITLE
AI: fetch the land colour it is actually short of

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -30,7 +30,6 @@ import forge.card.CardStateName;
 import forge.card.CardType;
 import forge.card.ColorSet;
 import forge.card.MagicColor;
-import forge.card.mana.ManaAtom;
 import forge.card.mana.ManaCost;
 import forge.deck.Deck;
 import forge.deck.DeckSection;
@@ -618,23 +617,6 @@ public class AiController {
         final Set<String> basics = Sets.newHashSet();
 
         // what colors are available?
-        int[] counts = new int[6]; // in WUBRGC order
-
-        for (Card c : player.getCardsIn(ZoneType.Battlefield)) {
-            for (SpellAbility m: c.getManaAbilities()) {
-                m.setActivatingPlayer(c.getController());
-                for (AbilityManaPart mp : m.getAllManaParts()) {
-                    for (String part : mp.mana(m).split(" ")) {
-                        // TODO handle any
-                        int index = ManaAtom.getIndexFromName(part);
-                        if (index != -1) {
-                            counts[index] += 1;
-                        }
-                    }
-                }
-            }
-        }
-
         // what types can I go get?
         for (final String name : MagicColor.Constant.BASIC_LANDS) {
             if (landList.stream().anyMatch(c -> c.getType().hasSubtype(name)) &&
@@ -657,27 +639,9 @@ public class AiController {
                     }
 
                     // TODO handle fetchlands and what they can fetch for
-                    // determine new color pips
-                    int[] card_counts = new int[6]; // in WUBRGC order
-                    for (SpellAbility m: card.getManaAbilities()) {
-                        m.setActivatingPlayer(card.getController());
-                        for (AbilityManaPart mp : m.getAllManaParts()) {
-                            for (String part : mp.mana(m).split(" ")) {
-                                // TODO handle any
-                                int index = ManaAtom.getIndexFromName(part);
-                                if (index != -1) {
-                                    card_counts[index] += 1;
-                                }
-                            }
-                        }
-                    }
-
-                    // use 1 / x+1 for diminishing returns
-                    // TODO use max pips of each color in the deck from deck statistics to weight this
-                    for (int i = 0; i < card_counts.length; i++) {
-                        int diff = (card_counts[i] * 50) / (counts[i] + 1);
-                        score += diff;
-                    }
+                    // depth in colours we are thin on, with diminishing returns, plus what this
+                    // land would unblock outright - the two say different things, so they add
+                    score += ComputerUtilCard.getColorFixingValue(player, card);
 
                     // TODO utility lands only if we have enough to pay their costs
                     // TODO Tron lands and other lands that care about land counts

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -212,6 +212,81 @@ public class ComputerUtilCard {
     }
 
     /**
+     * How many cards a player cannot currently pay for, in hand or as an ability on their
+     * permanents, would become payable if they also had this land.
+     */
+    public static int getColorFixingNeed(final Player benefits, final Card candidate) {
+        if (benefits == null || candidate == null) {
+            return 0;
+        }
+        final byte have = ColorSet.fromNames(ComputerUtilCost.getAvailableManaColors(benefits, (List<Card>) null)).getColor();
+        final byte with = ColorSet.fromNames(ComputerUtilCost.getAvailableManaColors(benefits, candidate)).getColor();
+        if (have == with) {
+            return 0;
+        }
+
+        int unblocked = 0;
+        for (Card c : benefits.getCardsIn(ZoneType.Hand)) {
+            if (unblocksWith(c.getManaCost(), have, with)) {
+                unblocked++;
+            }
+        }
+        for (Card c : benefits.getCardsIn(ZoneType.Battlefield)) {
+            for (SpellAbility ab : c.getAllSpellAbilities()) {
+                if (ab.isManaAbility() || ab.getPayCosts() == null || ab.getPayCosts().getCostMana() == null) {
+                    continue;
+                }
+                if (unblocksWith(ab.getPayCosts().getCostMana().getMana(), have, with)) {
+                    unblocked++;
+                }
+            }
+        }
+        return unblocked;
+    }
+
+    private static boolean unblocksWith(final ManaCost cost, final byte have, final byte with) {
+        return cost != null && !cost.isNoCost() && !cost.canBePaidWithAvailable(have)
+                && cost.canBePaidWithAvailable(with);
+    }
+
+    /**
+     * The candidate that best covers colors the player receiving the land is short of, or null when
+     * none of them stands out - so this never decides while it is blind, and the caller keeps
+     * whatever it was already doing. A player choosing for an opponent wants the least helpful one.
+     */
+    public static Card getBestLandToGainAI(final Player benefits, final List<Card> candidates, final boolean hostile) {
+        return pickStandout(candidates, c -> getColorFixingNeed(benefits, c), hostile);
+    }
+
+    /** the single best candidate by this measure, or null if the measure cannot separate them */
+    private static Card pickStandout(final List<Card> candidates, final Function<Card, Integer> score,
+            final boolean invert) {
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        final List<Card> best = bestBy(candidates, score, invert);
+        return best.size() == candidates.size() ? null : best.get(0);
+    }
+
+    /** every candidate tied for the best score, or the whole list when the measure sees no difference */
+    private static List<Card> bestBy(final List<Card> candidates, final Function<Card, Integer> score,
+            final boolean invert) {
+        List<Card> best = Lists.newArrayList();
+        int bestScore = Integer.MIN_VALUE;
+        for (Card c : candidates) {
+            int s = invert ? -score.apply(c) : score.apply(c);
+            if (s > bestScore) {
+                bestScore = s;
+                best.clear();
+                best.add(c);
+            } else if (s == bestScore) {
+                best.add(c);
+            }
+        }
+        return best;
+    }
+
+    /**
      * <p>
      * getBestLandAI.
      * </p>
@@ -220,6 +295,10 @@ public class ComputerUtilCard {
      * @return a {@link forge.game.card.Card} object.
      */
     public static Card getBestLandAI(final Iterable<Card> list) {
+        return getBestLandAI(null, list);
+    }
+
+    public static Card getBestLandAI(final Player benefits, final Iterable<Card> list) {
         final List<Card> land = CardLists.filter(list, CardPredicates.LANDS);
         if (land.isEmpty()) {
             return null;
@@ -249,7 +328,12 @@ public class ComputerUtilCard {
                 }
             }
 
-            return Aggregates.random(nbLand);
+            // a colour we are short of first, then raw land value, and only then give up and guess
+            Card ranked = getBestLandToGainAI(benefits, nbLand, false);
+            if (ranked == null) {
+                ranked = pickStandout(nbLand, landEvaluator::apply, false);
+            }
+            return ranked != null ? ranked : Aggregates.random(nbLand);
         }
 
         // if no non-basic lands, target the least represented basic land type

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -1,6 +1,7 @@
 package forge.ai;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
@@ -30,6 +31,7 @@ import forge.card.ColorSet;
 import forge.card.MagicColor;
 import forge.card.MagicColor.Constant;
 import forge.card.mana.ManaCost;
+import forge.card.mana.ManaCostShard;
 import forge.deck.CardPool;
 import forge.deck.Deck;
 import forge.deck.DeckSection;
@@ -211,6 +213,111 @@ public class ComputerUtilCard {
         return cardStream.max(Comparator.comparing(Card::getCMC)).orElse(null);
     }
 
+    /** Score per source fixed, on the scale AiController's land scoring already uses. */
+    public static final int COLOR_FIXING_WEIGHT = 50;
+    /**
+     * A land that casts something this turn is rated at twice a source fixed - it necessarily fixed
+     * one to get there, and being able to spend the mana now is worth more than being closer to it.
+     * Not a dominant term: a land fixing several colors can still outrank one that casts a single
+     * spell, which is deliberate, since a mana base is built over more than this turn.
+     */
+    public static final int CASTABLE_NOW_WEIGHT = 2 * COLOR_FIXING_WEIGHT;
+
+    /** How many missing sources these extra ones supply across the player's hand and board. */
+    private static int countSourcesFixed(final Player benefits, final int[] have, final int[] with) {
+        if (Arrays.equals(have, with)) {
+            return 0;
+        }
+
+        int fixed = 0;
+        for (Card c : benefits.getCardsIn(ZoneType.Hand)) {
+            fixed += countSourcesFixed(c.getManaCost(), have, with);
+        }
+        for (Card c : benefits.getCardsIn(ZoneType.Battlefield)) {
+            // only what can be activated from here, not the permanent's own casting cost
+            for (SpellAbility ab : c.getNonManaAbilities()) {
+                if (!ab.isActivatedAbility() || ab.getPayCosts() == null
+                        || ab.getPayCosts().getCostMana() == null) {
+                    continue;
+                }
+                fixed += countSourcesFixed(ab.getPayCosts().getCostMana().getMana(), have, with);
+            }
+        }
+        return fixed;
+    }
+
+    /** What this land is worth to the player's mana: what it makes payable, plus spare depth. */
+    public static int getColorFixingValue(final Player benefits, final Card candidate) {
+        if (benefits == null || candidate == null) {
+            return 0;
+        }
+        // one pass over the battlefield; the candidate only ever adds to what is already there
+        final int[] have = ComputerUtilCost.getManaSourceCounts(benefits);
+        final int[] with = have.clone();
+        ComputerUtilCost.addManaSources(candidate, with);
+
+        // Two things decide a land. countSourcesFixed grades how much closer it brings the colored
+        // requirements; this asks what the counting cannot - whether it lets something be cast this
+        // turn, mana and all. A land doing both scores for both. It only taps once, so where it
+        // makes several colors, take the best rather than the sum.
+        int castableNow = 0;
+        for (MagicColor.Color color : MagicColor.Color.values()) {
+            if (with[color.ordinal()] > have[color.ordinal()]) {
+                castableNow = Math.max(castableNow, ComputerUtilCost.countUnlockedNow(benefits, color));
+            }
+        }
+        return CASTABLE_NOW_WEIGHT * castableNow
+                + COLOR_FIXING_WEIGHT * countSourcesFixed(benefits, have, with)
+                + evaluateSpareSources(have, with);
+    }
+
+    /** Value of a spare source of a color nothing needs yet, falling off as sources accumulate. */
+    private static int evaluateSpareSources(final int[] have, final int[] with) {
+        int value = 0;
+        for (int i = 0; i < have.length; i++) {
+            if (with[i] > have[i]) {
+                // 1/(x+1) for diminishing returns, matching the land scoring this replaces
+                value += ((with[i] - have[i]) * COLOR_FIXING_WEIGHT) / (have[i] + 1);
+            }
+        }
+        return value;
+    }
+
+    /** How many more colored sources this cost still wants; zero once it is castable. */
+    private static int countMissingSources(final ManaCost cost, final int[] counts) {
+        if (cost == null || cost.isNoCost()) {
+            return 0;
+        }
+        byte mask = 0;
+        for (MagicColor.Color color : MagicColor.Color.values()) {
+            if (counts[color.ordinal()] > 0) {
+                mask |= color.getColorMask();
+            }
+        }
+        int[] need = new int[counts.length];
+        int missing = 0;
+        for (ManaCostShard shard : cost) {
+            if (shard.isPhyrexian()) {
+                continue;
+            }
+            if (shard.isMonoColor() && !shard.isOr2Generic()) {
+                // a plain colored pip wants a source of its own
+                need[MagicColor.Color.fromByte(shard.getColorMask()).ordinal()]++;
+            } else if (!shard.canBePaidWithManaOfColor(mask)) {
+                missing++;                   // hybrid and generic keep the looser check
+            }
+        }
+        for (int i = 0; i < need.length; i++) {
+            missing += Math.max(0, need[i] - counts[i]);
+        }
+        return missing;
+    }
+
+    /** How many of one cost's missing sources these extra ones supply, never negative. */
+    private static int countSourcesFixed(final ManaCost cost, final int[] have, final int[] with) {
+        return Math.max(0, countMissingSources(cost, have) - countMissingSources(cost, with));
+    }
+
     /**
      * <p>
      * getBestLandAI.
@@ -220,6 +327,10 @@ public class ComputerUtilCard {
      * @return a {@link forge.game.card.Card} object.
      */
     public static Card getBestLandAI(final Iterable<Card> list) {
+        return getBestLandAI(null, list);
+    }
+
+    public static Card getBestLandAI(final Player benefits, final Iterable<Card> list) {
         final List<Card> land = CardLists.filter(list, CardPredicates.LANDS);
         if (land.isEmpty()) {
             return null;
@@ -249,7 +360,9 @@ public class ComputerUtilCard {
                 }
             }
 
-            return Aggregates.random(nbLand);
+            // a colour we are short of outranks raw land value; ties fall through to it
+            return Aggregates.itemWithMax(nbLand,
+                    c -> getColorFixingValue(benefits, c) + landEvaluator.apply(c));
         }
 
         // if no non-basic lands, target the least represented basic land type

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -30,7 +30,6 @@ import forge.card.CardType;
 import forge.card.ColorSet;
 import forge.card.MagicColor;
 import forge.card.MagicColor.Constant;
-import forge.card.mana.ManaAtom;
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostShard;
 import forge.deck.CardPool;
@@ -257,9 +256,10 @@ public class ComputerUtilCard {
         if (benefits == null || candidate == null) {
             return 0;
         }
-        // counted once and shared: both halves ask the same two questions of the board
-        final int[] have = ComputerUtilCost.getManaSourceCounts(benefits, null);
-        final int[] with = ComputerUtilCost.getManaSourceCounts(benefits, candidate);
+        // one pass over the battlefield; the candidate only ever adds to what is already there
+        final int[] have = ComputerUtilCost.getManaSourceCounts(benefits);
+        final int[] with = have.clone();
+        ComputerUtilCost.addManaSources(candidate, with);
         return COLOR_FIXING_WEIGHT * fixingNeed(benefits, have, with) + depthValue(have, with);
     }
 
@@ -289,9 +289,9 @@ public class ComputerUtilCard {
             return 0;
         }
         byte mask = 0;
-        for (int i = 0; i < counts.length; i++) {
-            if (counts[i] > 0) {
-                mask |= ManaAtom.MANATYPES[i];
+        for (MagicColor.Color color : MagicColor.Color.values()) {
+            if (counts[color.ordinal()] > 0) {
+                mask |= color.getColorMask();
             }
         }
         int[] need = new int[counts.length];
@@ -300,10 +300,9 @@ public class ComputerUtilCard {
             if (shard.isPhyrexian()) {
                 continue;
             }
-            int index = shard.isMonoColor() && !shard.isOr2Generic()
-                    ? ManaAtom.getIndexFromName(MagicColor.toShortString(shard.getColorMask())) : -1;
-            if (index != -1) {
-                need[index]++;               // a plain colored pip wants a source of its own
+            if (shard.isMonoColor() && !shard.isOr2Generic()) {
+                // a plain colored pip wants a source of its own
+                need[MagicColor.Color.fromByte(shard.getColorMask()).ordinal()]++;
             } else if (!shard.canBePaidWithManaOfColor(mask)) {
                 missing++;                   // hybrid and generic keep the looser check
             }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -1,6 +1,7 @@
 package forge.ai;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
@@ -29,7 +30,9 @@ import forge.card.CardType;
 import forge.card.ColorSet;
 import forge.card.MagicColor;
 import forge.card.MagicColor.Constant;
+import forge.card.mana.ManaAtom;
 import forge.card.mana.ManaCost;
+import forge.card.mana.ManaCostShard;
 import forge.deck.CardPool;
 import forge.deck.Deck;
 import forge.deck.DeckSection;
@@ -212,78 +215,108 @@ public class ComputerUtilCard {
     }
 
     /**
-     * How many cards a player cannot currently pay for, in hand or as an ability on their
-     * permanents, would become payable if they also had this land.
+     * Score per pip of progress, and per first source of a color. Matches the scale the land
+     * scoring in AiController already uses, so {@link #getColorFixingValue} can be added to it.
      */
-    public static int getColorFixingNeed(final Player benefits, final Card candidate) {
-        if (benefits == null || candidate == null) {
-            return 0;
-        }
-        final byte have = ColorSet.fromNames(ComputerUtilCost.getAvailableManaColors(benefits, (List<Card>) null)).getColor();
-        final byte with = ColorSet.fromNames(ComputerUtilCost.getAvailableManaColors(benefits, candidate)).getColor();
-        if (have == with) {
+    public static final int COLOR_FIXING_WEIGHT = 50;
+
+    /**
+     * How much closer these extra sources get the player to paying for what they are holding,
+     * counted in pips across their hand and the abilities on their permanents. Counting pips
+     * rather than whole cards means a second source of a color is credited for the double-pip
+     * costs a single source cannot pay, and a first source is credited for the progress it makes.
+     */
+    private static int fixingNeed(final Player benefits, final int[] have, final int[] with) {
+        if (Arrays.equals(have, with)) {
             return 0;
         }
 
-        int unblocked = 0;
+        int progress = 0;
         for (Card c : benefits.getCardsIn(ZoneType.Hand)) {
-            if (unblocksWith(c.getManaCost(), have, with)) {
-                unblocked++;
-            }
+            progress += progressOn(c.getManaCost(), have, with);
         }
         for (Card c : benefits.getCardsIn(ZoneType.Battlefield)) {
-            for (SpellAbility ab : c.getAllSpellAbilities()) {
-                if (ab.isManaAbility() || ab.getPayCosts() == null || ab.getPayCosts().getCostMana() == null) {
+            // only what can actually be activated from here: getAllSpellAbilities would also hand
+            // back the permanent's own casting cost, and the far face of an MDFC or Adventure
+            for (SpellAbility ab : c.getNonManaAbilities()) {
+                if (!ab.isActivatedAbility() || ab.getPayCosts() == null
+                        || ab.getPayCosts().getCostMana() == null) {
                     continue;
                 }
-                if (unblocksWith(ab.getPayCosts().getCostMana().getMana(), have, with)) {
-                    unblocked++;
-                }
+                progress += progressOn(ab.getPayCosts().getCostMana().getMana(), have, with);
             }
         }
-        return unblocked;
-    }
-
-    private static boolean unblocksWith(final ManaCost cost, final byte have, final byte with) {
-        return cost != null && !cost.isNoCost() && !cost.canBePaidWithAvailable(have)
-                && cost.canBePaidWithAvailable(with);
+        return progress;
     }
 
     /**
-     * The candidate that best covers colors the player receiving the land is short of, or null when
-     * none of them stands out - so this never decides while it is blind, and the caller keeps
-     * whatever it was already doing. A player choosing for an opponent wants the least helpful one.
+     * What this land is worth to the player's mana overall: what it makes payable, plus the depth
+     * it adds in colors they are thin on. The single number every caller ranks lands by.
      */
-    public static Card getBestLandToGainAI(final Player benefits, final List<Card> candidates, final boolean hostile) {
-        return pickStandout(candidates, c -> getColorFixingNeed(benefits, c), hostile);
-    }
-
-    /** the single best candidate by this measure, or null if the measure cannot separate them */
-    private static Card pickStandout(final List<Card> candidates, final Function<Card, Integer> score,
-            final boolean invert) {
-        if (candidates.isEmpty()) {
-            return null;
+    public static int getColorFixingValue(final Player benefits, final Card candidate) {
+        if (benefits == null || candidate == null) {
+            return 0;
         }
-        final List<Card> best = bestBy(candidates, score, invert);
-        return best.size() == candidates.size() ? null : best.get(0);
+        // counted once and shared: both halves ask the same two questions of the board
+        final int[] have = ComputerUtilCost.getManaSourceCounts(benefits, null);
+        final int[] with = ComputerUtilCost.getManaSourceCounts(benefits, candidate);
+        return COLOR_FIXING_WEIGHT * fixingNeed(benefits, have, with) + depthValue(have, with);
     }
 
-    /** every candidate tied for the best score, or the whole list when the measure sees no difference */
-    private static List<Card> bestBy(final List<Card> candidates, final Function<Card, Integer> score,
-            final boolean invert) {
-        List<Card> best = Lists.newArrayList();
-        int bestScore = Integer.MIN_VALUE;
-        for (Card c : candidates) {
-            int s = invert ? -score.apply(c) : score.apply(c);
-            if (s > bestScore) {
-                bestScore = s;
-                best.clear();
-                best.add(c);
-            } else if (s == bestScore) {
-                best.add(c);
+    /**
+     * Depth this land adds beyond anything it unblocks outright. A second source of a color is
+     * worth having even when nothing needs it yet - it is what lets two spells of that color be
+     * cast in a turn - so this falls off as sources accumulate.
+     */
+    private static int depthValue(final int[] have, final int[] with) {
+        int value = 0;
+        for (int i = 0; i < have.length; i++) {
+            if (with[i] > have[i]) {
+                // 1/(x+1) for diminishing returns, matching the land scoring this replaces
+                value += ((with[i] - have[i]) * COLOR_FIXING_WEIGHT) / (have[i] + 1);
             }
         }
-        return best;
+        return value;
+    }
+
+    /**
+     * How many more sources of a color this cost still wants. Zero once it is castable; two for a
+     * {@code BB} cost off a board with no black, so that a first black source is credited with the
+     * progress it makes rather than only the source that finally completes it.
+     */
+    private static int shortfall(final ManaCost cost, final int[] counts) {
+        if (cost == null || cost.isNoCost()) {
+            return 0;
+        }
+        byte mask = 0;
+        for (int i = 0; i < counts.length; i++) {
+            if (counts[i] > 0) {
+                mask |= ManaAtom.MANATYPES[i];
+            }
+        }
+        int[] need = new int[counts.length];
+        int missing = 0;
+        for (ManaCostShard shard : cost) {
+            if (shard.isPhyrexian()) {
+                continue;
+            }
+            int index = shard.isMonoColor() && !shard.isOr2Generic()
+                    ? ManaAtom.getIndexFromName(MagicColor.toShortString(shard.getColorMask())) : -1;
+            if (index != -1) {
+                need[index]++;               // a plain colored pip wants a source of its own
+            } else if (!shard.canBePaidWithManaOfColor(mask)) {
+                missing++;                   // hybrid and generic keep the looser check
+            }
+        }
+        for (int i = 0; i < need.length; i++) {
+            missing += Math.max(0, need[i] - counts[i]);
+        }
+        return missing;
+    }
+
+    /** pips of progress this land makes towards a cost, never negative */
+    private static int progressOn(final ManaCost cost, final int[] have, final int[] with) {
+        return Math.max(0, shortfall(cost, have) - shortfall(cost, with));
     }
 
     /**
@@ -328,12 +361,9 @@ public class ComputerUtilCard {
                 }
             }
 
-            // a colour we are short of first, then raw land value, and only then give up and guess
-            Card ranked = getBestLandToGainAI(benefits, nbLand, false);
-            if (ranked == null) {
-                ranked = pickStandout(nbLand, landEvaluator::apply, false);
-            }
-            return ranked != null ? ranked : Aggregates.random(nbLand);
+            // a colour we are short of outranks raw land value; ties fall through to it
+            return Aggregates.itemWithMax(nbLand,
+                    c -> getColorFixingValue(benefits, c) + landEvaluator.apply(c));
         }
 
         // if no non-basic lands, target the least represented basic land type

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -213,45 +213,33 @@ public class ComputerUtilCard {
         return cardStream.max(Comparator.comparing(Card::getCMC)).orElse(null);
     }
 
-    /**
-     * Score per pip of progress, and per first source of a color. Matches the scale the land
-     * scoring in AiController already uses, so {@link #getColorFixingValue} can be added to it.
-     */
+    /** Score per source fixed, on the scale AiController's land scoring already uses. */
     public static final int COLOR_FIXING_WEIGHT = 50;
 
-    /**
-     * How much closer these extra sources get the player to paying for what they are holding,
-     * counted in pips across their hand and the abilities on their permanents. Counting pips
-     * rather than whole cards means a second source of a color is credited for the double-pip
-     * costs a single source cannot pay, and a first source is credited for the progress it makes.
-     */
-    private static int fixingNeed(final Player benefits, final int[] have, final int[] with) {
+    /** How many missing sources these extra ones supply across the player's hand and board. */
+    private static int countSourcesFixed(final Player benefits, final int[] have, final int[] with) {
         if (Arrays.equals(have, with)) {
             return 0;
         }
 
-        int progress = 0;
+        int fixed = 0;
         for (Card c : benefits.getCardsIn(ZoneType.Hand)) {
-            progress += progressOn(c.getManaCost(), have, with);
+            fixed += countSourcesFixed(c.getManaCost(), have, with);
         }
         for (Card c : benefits.getCardsIn(ZoneType.Battlefield)) {
-            // only what can actually be activated from here: getAllSpellAbilities would also hand
-            // back the permanent's own casting cost, and the far face of an MDFC or Adventure
+            // only what can be activated from here, not the permanent's own casting cost
             for (SpellAbility ab : c.getNonManaAbilities()) {
                 if (!ab.isActivatedAbility() || ab.getPayCosts() == null
                         || ab.getPayCosts().getCostMana() == null) {
                     continue;
                 }
-                progress += progressOn(ab.getPayCosts().getCostMana().getMana(), have, with);
+                fixed += countSourcesFixed(ab.getPayCosts().getCostMana().getMana(), have, with);
             }
         }
-        return progress;
+        return fixed;
     }
 
-    /**
-     * What this land is worth to the player's mana overall: what it makes payable, plus the depth
-     * it adds in colors they are thin on. The single number every caller ranks lands by.
-     */
+    /** What this land is worth to the player's mana: what it makes payable, plus spare depth. */
     public static int getColorFixingValue(final Player benefits, final Card candidate) {
         if (benefits == null || candidate == null) {
             return 0;
@@ -260,15 +248,11 @@ public class ComputerUtilCard {
         final int[] have = ComputerUtilCost.getManaSourceCounts(benefits);
         final int[] with = have.clone();
         ComputerUtilCost.addManaSources(candidate, with);
-        return COLOR_FIXING_WEIGHT * fixingNeed(benefits, have, with) + depthValue(have, with);
+        return COLOR_FIXING_WEIGHT * countSourcesFixed(benefits, have, with) + evaluateSpareSources(have, with);
     }
 
-    /**
-     * Depth this land adds beyond anything it unblocks outright. A second source of a color is
-     * worth having even when nothing needs it yet - it is what lets two spells of that color be
-     * cast in a turn - so this falls off as sources accumulate.
-     */
-    private static int depthValue(final int[] have, final int[] with) {
+    /** Value of a spare source of a color nothing needs yet, falling off as sources accumulate. */
+    private static int evaluateSpareSources(final int[] have, final int[] with) {
         int value = 0;
         for (int i = 0; i < have.length; i++) {
             if (with[i] > have[i]) {
@@ -279,12 +263,8 @@ public class ComputerUtilCard {
         return value;
     }
 
-    /**
-     * How many more sources of a color this cost still wants. Zero once it is castable; two for a
-     * {@code BB} cost off a board with no black, so that a first black source is credited with the
-     * progress it makes rather than only the source that finally completes it.
-     */
-    private static int shortfall(final ManaCost cost, final int[] counts) {
+    /** How many more colored sources this cost still wants; zero once it is castable. */
+    private static int countMissingSources(final ManaCost cost, final int[] counts) {
         if (cost == null || cost.isNoCost()) {
             return 0;
         }
@@ -313,9 +293,9 @@ public class ComputerUtilCard {
         return missing;
     }
 
-    /** pips of progress this land makes towards a cost, never negative */
-    private static int progressOn(final ManaCost cost, final int[] have, final int[] with) {
-        return Math.max(0, shortfall(cost, have) - shortfall(cost, with));
+    /** How many of one cost's missing sources these extra ones supply, never negative. */
+    private static int countSourcesFixed(final ManaCost cost, final int[] have, final int[] with) {
+        return Math.max(0, countMissingSources(cost, have) - countMissingSources(cost, with));
     }
 
     /**

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -639,7 +639,53 @@ public class ComputerUtilCost {
         return getAvailableManaColors(ai, Lists.newArrayList(additionalLand));
     }
     public static Set<String> getAvailableManaColors(Player ai, List<Card> additionalLands) {
-        CardCollection cardsToConsider = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield), CardPredicates.UNTAPPED);
+        return manaColors(ai, additionalLands, true);
+    }
+
+    /**
+     * Which colors the board could produce given time, ignoring what happens to be tapped right
+     * now. That is what choosing a land cares about, where {@link #getAvailableManaColors} answers
+     * the different question of what can be paid for this turn.
+     */
+    public static Set<String> getProducibleManaColors(Player ai, Card additionalLand) {
+        return manaColors(ai, additionalLand == null ? null : Lists.newArrayList(additionalLand), false);
+    }
+
+    /** WUBRGC, matching the index order callers use for these counts */
+    private static final String[] MANA_SHORT_NAMES = { "W", "U", "B", "R", "G", "C" };
+
+    /**
+     * How many sources of each color the player could produce, in WUBRGC order, optionally counting
+     * one extra card. Unlike {@link #getProducibleManaColors} this keeps the count rather than the
+     * set, which is what tells a second source of a color from a first.
+     */
+    public static int[] getManaSourceCounts(Player ai, Card additional) {
+        CardCollection cardsToConsider = new CardCollection(ai.getCardsIn(ZoneType.Battlefield));
+        if (additional != null) {
+            cardsToConsider.add(additional);
+        }
+
+        int[] counts = new int[MANA_SHORT_NAMES.length];
+        for (Card c : cardsToConsider) {
+            for (SpellAbility m : c.getManaAbilities()) {
+                m.setActivatingPlayer(c.getController());
+                for (int i = 0; i < MANA_SHORT_NAMES.length; i++) {
+                    // canProduce rather than reading the produced string: it is what understands
+                    // "any colour" and a choice of colours, which Command Tower and the like need
+                    if (m.canProduce(MANA_SHORT_NAMES[i])) {
+                        counts[i] += 1;
+                    }
+                }
+            }
+        }
+        return counts;
+    }
+
+    private static Set<String> manaColors(Player ai, List<Card> additionalLands, boolean untappedOnly) {
+        CardCollection cardsToConsider = new CardCollection(ai.getCardsIn(ZoneType.Battlefield));
+        if (untappedOnly) {
+            cardsToConsider = CardLists.filter(cardsToConsider, CardPredicates.UNTAPPED);
+        }
         Set<String> colorsAvailable = Sets.newHashSet();
 
         if (additionalLands != null) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import forge.card.MagicColor;
 import forge.game.GameObject;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -639,53 +640,7 @@ public class ComputerUtilCost {
         return getAvailableManaColors(ai, Lists.newArrayList(additionalLand));
     }
     public static Set<String> getAvailableManaColors(Player ai, List<Card> additionalLands) {
-        return manaColors(ai, additionalLands, true);
-    }
-
-    /**
-     * Which colors the board could produce given time, ignoring what happens to be tapped right
-     * now. That is what choosing a land cares about, where {@link #getAvailableManaColors} answers
-     * the different question of what can be paid for this turn.
-     */
-    public static Set<String> getProducibleManaColors(Player ai, Card additionalLand) {
-        return manaColors(ai, additionalLand == null ? null : Lists.newArrayList(additionalLand), false);
-    }
-
-    /** WUBRGC, matching the index order callers use for these counts */
-    private static final String[] MANA_SHORT_NAMES = { "W", "U", "B", "R", "G", "C" };
-
-    /**
-     * How many sources of each color the player could produce, in WUBRGC order, optionally counting
-     * one extra card. Unlike {@link #getProducibleManaColors} this keeps the count rather than the
-     * set, which is what tells a second source of a color from a first.
-     */
-    public static int[] getManaSourceCounts(Player ai, Card additional) {
-        CardCollection cardsToConsider = new CardCollection(ai.getCardsIn(ZoneType.Battlefield));
-        if (additional != null) {
-            cardsToConsider.add(additional);
-        }
-
-        int[] counts = new int[MANA_SHORT_NAMES.length];
-        for (Card c : cardsToConsider) {
-            for (SpellAbility m : c.getManaAbilities()) {
-                m.setActivatingPlayer(c.getController());
-                for (int i = 0; i < MANA_SHORT_NAMES.length; i++) {
-                    // canProduce rather than reading the produced string: it is what understands
-                    // "any colour" and a choice of colours, which Command Tower and the like need
-                    if (m.canProduce(MANA_SHORT_NAMES[i])) {
-                        counts[i] += 1;
-                    }
-                }
-            }
-        }
-        return counts;
-    }
-
-    private static Set<String> manaColors(Player ai, List<Card> additionalLands, boolean untappedOnly) {
-        CardCollection cardsToConsider = new CardCollection(ai.getCardsIn(ZoneType.Battlefield));
-        if (untappedOnly) {
-            cardsToConsider = CardLists.filter(cardsToConsider, CardPredicates.UNTAPPED);
-        }
+        CardCollection cardsToConsider = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield), CardPredicates.UNTAPPED);
         Set<String> colorsAvailable = Sets.newHashSet();
 
         if (additionalLands != null) {
@@ -701,6 +656,29 @@ public class ComputerUtilCost {
         }
 
         return colorsAvailable;
+    }
+
+    /**
+     * How many sources of each color the player's board could produce, indexed by
+     * {@link MagicColor.Color#ordinal()}. Counted per card rather than per ability, since a land
+     * with two mana abilities still only taps once.
+     */
+    public static int[] getManaSourceCounts(Player ai) {
+        int[] counts = new int[MagicColor.Color.values().length];
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            addManaSources(c, counts);
+        }
+        return counts;
+    }
+
+    /** Adds what one card could produce to counts from {@link #getManaSourceCounts}. */
+    public static void addManaSources(Card c, int[] counts) {
+        final Set<String> producible = c.getProducibleColors();
+        for (MagicColor.Color color : MagicColor.Color.values()) {
+            if (producible.contains(color.getName())) {
+                counts[color.ordinal()] += 1;
+            }
+        }
     }
 
     public static boolean isFreeCastAllowedByPermanent(Player player, String altCost) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -5,10 +5,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import forge.card.MagicColor;
+import forge.game.cost.Cost;
+import forge.card.mana.ManaCostShard;
+import forge.game.cost.CostPartMana;
+import forge.game.mana.ManaCostBeingPaid;
 import forge.game.GameObject;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -647,14 +653,121 @@ public class ComputerUtilCost {
         }
 
         for (Card c : cardsToConsider) {
-            for (SpellAbility sa : c.getManaAbilities()) {
-                if (sa.getManaPart() != null) {
-                    colorsAvailable.add(sa.getManaPart().getOrigProduced());
-                }
+            // the raw Produced$ is a script string, and every caller runs this through
+            // ColorSet.fromNames, which drops anything that is not a colour name - so an "Any"
+            // source used to contribute nothing at all
+            colorsAvailable.addAll(c.getProducibleColors());
+            if (colorsAvailable.size() == MagicColor.Constant.COLORS_AND_COLORLESS.size()) {
+                break; // nothing left for a further source to add
             }
         }
 
         return colorsAvailable;
+    }
+
+    /**
+     * How many sources of each color the player's board could produce, indexed by
+     * {@link MagicColor.Color#ordinal()}. Counted per card rather than per ability, since a land
+     * with two mana abilities still only taps once.
+     */
+    public static int[] getManaSourceCounts(Player ai) {
+        int[] counts = new int[MagicColor.Color.values().length];
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            addManaSources(c, counts);
+        }
+        return counts;
+    }
+
+    /** Adds what one card could produce to counts from {@link #getManaSourceCounts}. */
+    public static void addManaSources(Card c, int[] counts) {
+        final Set<String> producible = c.getProducibleColors();
+        for (MagicColor.Color color : MagicColor.Color.values()) {
+            if (producible.contains(color.getName())) {
+                counts[color.ordinal()] += 1;
+            }
+        }
+    }
+
+    /**
+     * Cast options in hand that one more land could plausibly turn on: not payable as things
+     * stand, and within one mana of reach. Reads {@code ai}'s hand, so callers deciding on behalf
+     * of someone else must already have established they are entitled to look - see the opponent
+     * check in ChangeZoneAi#basicManaFixing. Anything further away cannot become castable this turn
+     * however well the color lines up, and the arithmetic check is free where the payability probe
+     * is not - so it goes first and keeps most of the hand off the mana solver entirely.
+     * <p>
+     * Computed once per priority; the land decision asks about several candidates and the answer
+     * does not vary between them.
+     */
+    public static List<SpellAbility> getOptionsWithinOneLand(final Player ai) {
+        return AiCache.getCached("optionsWithinOneLand", () -> {
+            final int reach = ComputerUtilMana.getAvailableManaEstimate(ai, false) + 1;
+            final List<SpellAbility> near = Lists.newArrayList();
+            for (Card c : ai.getCardsIn(ZoneType.Hand)) {
+                for (SpellAbility sa : c.getAllPossibleAbilities(ai, false)) {
+                    if (!sa.isSpell()) {
+                        continue;
+                    }
+                    final Cost costs = sa.getPayCosts();
+                    if (costs != null && costs.getTotalMana().getCMC() > reach) {
+                        continue;
+                    }
+                    if (!isPayableWith(sa, ai, null)) {
+                        near.add(sa);
+                    }
+                }
+            }
+            return near;
+        }, ImmutableList.of(AiCache::identity), ai);
+    }
+
+    /**
+     * How many held cards one more source of this color would make castable right away - not
+     * merely closer in color, which the source counting already grades. Cached per color rather
+     * than per card, because every land producing that color answers the same.
+     */
+    public static int countUnlockedNow(final Player ai, final MagicColor.Color color) {
+        return AiCache.getCached("unlockedNowByColor", () -> {
+            int unlocked = 0;
+            for (SpellAbility sa : getOptionsWithinOneLand(ai)) {
+                if (isPayableWith(sa, ai, color)) {
+                    unlocked += 1;
+                }
+            }
+            return unlocked;
+        }, ImmutableList.of(AiCache::identity, Object::equals), ai, color);
+    }
+
+    /**
+     * Whether the AI could pay for this spell given mana it does not have yet: {@code extraGeneric}
+     * more mana of any kind, and/or one more source of {@code extraSource}. Playing a land supplies
+     * the second, untapping one supplies either, and both are asked the same way - pay that part of
+     * the cost up front, the way convoke pays a pip, and put what is left to the mana solver.
+     * Nothing is moved, and the answer is the engine's own.
+     */
+    public static boolean isPayableWith(final SpellAbility sa, final Player ai,
+            final int extraGeneric, final MagicColor.Color extraSource) {
+        final CostPartMana costMana = sa.getPayCosts() == null ? null : sa.getPayCosts().getCostMana();
+        if (costMana == null) {
+            return true;
+        }
+        if (extraGeneric <= 0 && extraSource == null) {
+            return ComputerUtilMana.canPayManaCost(sa, ai, 0, false);
+        }
+        final ManaCostBeingPaid probe = new ManaCostBeingPaid(costMana.getManaCostFor(sa));
+        if (extraSource != null && probe.payManaViaConvoke(extraSource.getColorMask()) == null) {
+            // that color pays nothing here, so the answer is whatever it already was
+            return ComputerUtilMana.canPayManaCost(sa, ai, 0, false);
+        }
+        if (extraGeneric > 0) {
+            probe.decreaseShard(ManaCostShard.GENERIC, extraGeneric);
+        }
+        return probe.isPaid() || ComputerUtilMana.canPayManaCost(probe, sa, ai, false);
+    }
+
+    /** As {@link #isPayableWith(SpellAbility, Player, int, MagicColor.Color)} with no extra generic. */
+    public static boolean isPayableWith(SpellAbility sa, Player ai, MagicColor.Color extraSource) {
+        return isPayableWith(sa, ai, 0, extraSource);
     }
 
     public static boolean isFreeCastAllowedByPermanent(Player player, String altCost) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -648,10 +648,12 @@ public class ComputerUtilCost {
         }
 
         for (Card c : cardsToConsider) {
-            for (SpellAbility sa : c.getManaAbilities()) {
-                if (sa.getManaPart() != null) {
-                    colorsAvailable.add(sa.getManaPart().getOrigProduced());
-                }
+            // the raw Produced$ is a script string, and every caller runs this through
+            // ColorSet.fromNames, which drops anything that is not a colour name - so an "Any"
+            // source used to contribute nothing at all
+            colorsAvailable.addAll(c.getProducibleColors());
+            if (colorsAvailable.size() == MagicColor.Constant.COLORS_AND_COLORLESS.size()) {
+                break; // nothing left for a further source to add
             }
         }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -540,8 +540,31 @@ public class ChangeZoneAi extends SpellAbilityAi {
      *            a List<Card> object.
      * @return a {@link forge.game.card.Card} object.
      */
-    private static Card basicManaFixing(final Player ai, List<Card> list) { // Search for a Basic Land
-        final CardCollectionView combined = CardCollection.combine(ai.getCardsIn(ZoneType.Battlefield), ai.getCardsIn(ZoneType.Hand));
+    private static Card basicManaFixing(final Player decider, final Player owner, List<Card> list) { // Search for a Basic Land
+        // the land ends up with its owner, so the colours that matter are theirs, not the
+        // chooser's. No card in the pool currently chooses for another player here, so rather
+        // than guess at that case it is left on the existing behaviour untouched.
+        if (!decider.isOpponentOf(owner)) {
+            // narrow to the lands worth the most, then let the basic-type spread and the
+            // dual-land preference below break the tie as they already did
+            final List<Card> best = new ArrayList<>();
+            int most = 0; // only worth narrowing for lands that improve the mana at all
+            for (Card c : list) {
+                final int value = ComputerUtilCard.getColorFixingValue(owner, c);
+                if (value > most) {
+                    most = value;
+                    best.clear();
+                }
+                if (value == most && most > 0) {
+                    best.add(c);
+                }
+            }
+            if (!best.isEmpty()) {
+                list = best;
+            }
+        }
+
+        final CardCollectionView combined = CardCollection.combine(owner.getCardsIn(ZoneType.Battlefield), owner.getCardsIn(ZoneType.Hand));
         final List<String> basics = new ArrayList<>();
 
         // what types can I go get?
@@ -552,7 +575,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
         }
 
         // check if any SA we wanted to pay for had missing shards
-        Set<ManaCostBeingPaid> unpaid = AiCardMemory.getMemorySet(ai, AiCardMemory.MemorySetMana.UNPAID_COSTS);
+        Set<ManaCostBeingPaid> unpaid = AiCardMemory.getMemorySet(owner, AiCardMemory.MemorySetMana.UNPAID_COSTS);
         Map<String, Integer> basicTypes = Maps.newHashMap();
         if (unpaid != null) {
             for (ManaCostBeingPaid cost : unpaid) {
@@ -1605,7 +1628,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
         } else if (origin.contains(ZoneType.Library) && (type.contains("Basic") || areAllBasics(type))) {
             if (keycardFound != null) return keycardFound;
 
-            c = basicManaFixing(decider, fetchList);
+            c = basicManaFixing(decider, player, fetchList);
         } else if (ZoneType.Hand.equals(destination) && CardLists.getNotType(fetchList, "Creature").isEmpty()) {
             if (keycardFound != null) return keycardFound;
 
@@ -1633,12 +1656,12 @@ public class ChangeZoneAi extends SpellAbilityAi {
             CardCollectionView hand = decider.getCardsIn(ZoneType.Hand);
             if (!hand.anyMatch(CardPredicates.LANDS) && CardLists.count(decider.getCardsIn(ZoneType.Battlefield), CardPredicates.LANDS) < 4 &&
                     !hand.anyMatch(crd -> ComputerUtilMana.hasEnoughManaSourcesToCast(crd.getFirstSpellAbility(), decider))) {
-                c = basicManaFixing(decider, fetchList);
+                c = basicManaFixing(decider, player, fetchList);
             }
             if (c == null) {
                 if (fetchList.allMatch(CardPredicates.LANDS)) {
                     // we're only choosing from lands, so get the best land
-                    c = ComputerUtilCard.getBestLandAI(fetchList);
+                    c = ComputerUtilCard.getBestLandAI(player, fetchList);
                 } else {
                     fetchList = CardLists.getNotType(fetchList, "Land");
                     // Prefer to pull a creature, generally more useful for AI.
@@ -2124,7 +2147,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
 
         // If we are below the threshold, look for a land in the available choices and prefer it
         if (totalManaSources < threshold) {
-            Card manaFixing = basicManaFixing(ai, choices);
+            Card manaFixing = basicManaFixing(ai, ai, choices);
             if (manaFixing != null) {
                 return manaFixing;
             }

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -537,8 +537,20 @@ public class ChangeZoneAi extends SpellAbilityAi {
      *            a List<Card> object.
      * @return a {@link forge.game.card.Card} object.
      */
-    private static Card basicManaFixing(final Player ai, List<Card> list) { // Search for a Basic Land
-        final CardCollectionView combined = CardCollection.combine(ai.getCardsIn(ZoneType.Battlefield), ai.getCardsIn(ZoneType.Hand));
+    private static Card basicManaFixing(final Player decider, final Player owner, List<Card> list) { // Search for a Basic Land
+        // the land ends up with its owner, so the choice is made from their side of the table - and
+        // an opponent doing the choosing wants the least helpful land instead
+        final boolean hostile = decider.isOpponentOf(owner);
+
+        // a colour they are actually waiting on beats evening out their basic types, so ask that
+        // first - the type count below cannot tell a colour that is missing from one that is merely
+        // uncommon, and several lands of the right type carry different colours beside it
+        final Card needed = ComputerUtilCard.getBestLandToGainAI(owner, list, hostile);
+        if (needed != null) {
+            return needed;
+        }
+
+        final CardCollectionView combined = CardCollection.combine(owner.getCardsIn(ZoneType.Battlefield), owner.getCardsIn(ZoneType.Hand));
         final List<String> basics = new ArrayList<>();
 
         // what types can I go get?
@@ -550,12 +562,12 @@ public class ChangeZoneAi extends SpellAbilityAi {
 
         // Which basic land is least available from hand and play, that I still
         // have in my deck
-        int minSize = Integer.MAX_VALUE;
+        int minSize = hostile ? Integer.MIN_VALUE : Integer.MAX_VALUE;
         String minType = null;
 
         for (String b : basics) {
             final int num = CardLists.getType(combined, b).size();
-            if (num < minSize) {
+            if (hostile ? num > minSize : num < minSize) {
                 minType = b;
                 minSize = num;
             }
@@ -1572,7 +1584,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
         } else if (origin.contains(ZoneType.Library) && (type.contains("Basic") || areAllBasics(type))) {
             if (keycardFound != null) return keycardFound;
 
-            c = basicManaFixing(decider, fetchList);
+            c = basicManaFixing(decider, player, fetchList);
         } else if (ZoneType.Hand.equals(destination) && CardLists.getNotType(fetchList, "Creature").isEmpty()) {
             if (keycardFound != null) return keycardFound;
 
@@ -1600,12 +1612,12 @@ public class ChangeZoneAi extends SpellAbilityAi {
             CardCollectionView hand = decider.getCardsIn(ZoneType.Hand);
             if (!hand.anyMatch(CardPredicates.LANDS) && CardLists.count(decider.getCardsIn(ZoneType.Battlefield), CardPredicates.LANDS) < 4 &&
                     !hand.anyMatch(crd -> ComputerUtilMana.hasEnoughManaSourcesToCast(crd.getFirstSpellAbility(), decider))) {
-                c = basicManaFixing(decider, fetchList);
+                c = basicManaFixing(decider, player, fetchList);
             }
             if (c == null) {
                 if (fetchList.allMatch(CardPredicates.LANDS)) {
                     // we're only choosing from lands, so get the best land
-                    c = ComputerUtilCard.getBestLandAI(fetchList);
+                    c = ComputerUtilCard.getBestLandAI(player, fetchList);
                 } else {
                     fetchList = CardLists.getNotType(fetchList, "Land");
                     // Prefer to pull a creature, generally more useful for AI.
@@ -2090,7 +2102,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
 
         // If we are below the threshold, look for a land in the available choices and prefer it
         if (totalManaSources < threshold) {
-            Card manaFixing = basicManaFixing(ai, choices);
+            Card manaFixing = basicManaFixing(ai, ai, choices);
             if (manaFixing != null) {
                 return manaFixing;
             }

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -542,15 +542,22 @@ public class ChangeZoneAi extends SpellAbilityAi {
         // chooser's. No card in the pool currently chooses for another player here, so rather
         // than guess at that case it is left on the existing behaviour untouched.
         if (!decider.isOpponentOf(owner)) {
-            int most = 0; // only worth narrowing for lands that improve the mana at all
-            for (Card c : list) {
-                most = Math.max(most, ComputerUtilCard.getColorFixingValue(owner, c));
-            }
             // narrow to the lands worth the most, then let the basic-type spread and the
             // dual-land preference below break the tie as they already did
-            if (most > 0) {
-                final int best = most;
-                list = CardLists.filter(list, c -> ComputerUtilCard.getColorFixingValue(owner, c) == best);
+            final List<Card> best = new ArrayList<>();
+            int most = 0; // only worth narrowing for lands that improve the mana at all
+            for (Card c : list) {
+                final int value = ComputerUtilCard.getColorFixingValue(owner, c);
+                if (value > most) {
+                    most = value;
+                    best.clear();
+                }
+                if (value == most && most > 0) {
+                    best.add(c);
+                }
+            }
+            if (!best.isEmpty()) {
+                list = best;
             }
         }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -538,16 +538,20 @@ public class ChangeZoneAi extends SpellAbilityAi {
      * @return a {@link forge.game.card.Card} object.
      */
     private static Card basicManaFixing(final Player decider, final Player owner, List<Card> list) { // Search for a Basic Land
-        // the land ends up with its owner, so the choice is made from their side of the table - and
-        // an opponent doing the choosing wants the least helpful land instead
-        final boolean hostile = decider.isOpponentOf(owner);
-
-        // a colour they are actually waiting on beats evening out their basic types, so ask that
-        // first - the type count below cannot tell a colour that is missing from one that is merely
-        // uncommon, and several lands of the right type carry different colours beside it
-        final Card needed = ComputerUtilCard.getBestLandToGainAI(owner, list, hostile);
-        if (needed != null) {
-            return needed;
+        // the land ends up with its owner, so the colours that matter are theirs, not the
+        // chooser's. No card in the pool currently chooses for another player here, so rather
+        // than guess at that case it is left on the existing behaviour untouched.
+        if (!decider.isOpponentOf(owner)) {
+            int most = 0; // only worth narrowing for lands that improve the mana at all
+            for (Card c : list) {
+                most = Math.max(most, ComputerUtilCard.getColorFixingValue(owner, c));
+            }
+            // narrow to the lands worth the most, then let the basic-type spread and the
+            // dual-land preference below break the tie as they already did
+            if (most > 0) {
+                final int best = most;
+                list = CardLists.filter(list, c -> ComputerUtilCard.getColorFixingValue(owner, c) == best);
+            }
         }
 
         final CardCollectionView combined = CardCollection.combine(owner.getCardsIn(ZoneType.Battlefield), owner.getCardsIn(ZoneType.Hand));
@@ -562,12 +566,12 @@ public class ChangeZoneAi extends SpellAbilityAi {
 
         // Which basic land is least available from hand and play, that I still
         // have in my deck
-        int minSize = hostile ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+        int minSize = Integer.MAX_VALUE;
         String minType = null;
 
         for (String b : basics) {
             final int num = CardLists.getType(combined, b).size();
-            if (hostile ? num > minSize : num < minSize) {
+            if (num < minSize) {
                 minType = b;
                 minSize = num;
             }

--- a/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
@@ -211,7 +211,7 @@ public class ControlGainAi extends SpellAbilityAi {
                 } else if (artifacts > 0) {
                     t = ComputerUtilCard.getBestArtifactAI(list);
                 } else if (lands > 0) {
-                    t = ComputerUtilCard.getBestLandAI(list);
+                    t = ComputerUtilCard.getBestLandAI(ai, list);
                 } else if (enchantments > 0) {
                     t = ComputerUtilCard.getBestEnchantmentAI(list, sa, false);
                 } else {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3351,19 +3351,40 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return false;
     }
 
+    /** Every color this card could produce, walking its mana abilities once. */
+    public final Set<String> getProducibleColors() {
+        Set<String> colors = new HashSet<>();
+        for (final SpellAbility ab : getManaAbilities()) {
+            // without an activating player canProduce falls into a much more expensive path, so
+            // fill it in for the duration of the check and put it back afterwards - this is a read,
+            // and setActivatingPlayer trickles down to sub-abilities
+            final Player fillIn = ab.getActivatingPlayer() == null ? getController() : null;
+            if (fillIn != null) {
+                ab.setActivatingPlayer(fillIn);
+            }
+            try {
+                if (ab.getApi() == ApiType.ManaReflected) {
+                    colors.addAll(CardUtil.getReflectableManaColors(ab));
+                } else {
+                    colors = CardUtil.canProduce(6, ab, colors);
+                }
+            } finally {
+                if (fillIn != null) {
+                    ab.setActivatingPlayer(null);
+                }
+            }
+            if (colors.size() == MagicColor.Constant.COLORS_AND_COLORLESS.size()) {
+                break; // nothing left for a further ability to add
+            }
+        }
+        return colors;
+    }
+
     public final boolean canProduceSameManaTypeWith(final Card c) {
         if (getManaAbilities().isEmpty()) {
             return false;
         }
-        Set<String> colors = new HashSet<>();
-        for (final SpellAbility ab : c.getManaAbilities()) {
-            if (ab.getApi() == ApiType.ManaReflected) {
-                colors.addAll(CardUtil.getReflectableManaColors(ab));
-            } else {
-                colors = CardUtil.canProduce(6, ab, colors);
-            }
-        }
-        return canProduceColorMana(colors);
+        return canProduceColorMana(c.getProducibleColors());
     }
 
     public final int getMaxManaProduced() {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3351,19 +3351,27 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return false;
     }
 
-    public final boolean canProduceSameManaTypeWith(final Card c) {
-        if (getManaAbilities().isEmpty()) {
-            return false;
-        }
+    /** Every color this card could produce, walking its mana abilities once. */
+    public final Set<String> getProducibleColors() {
         Set<String> colors = new HashSet<>();
-        for (final SpellAbility ab : c.getManaAbilities()) {
+        for (final SpellAbility ab : getManaAbilities()) {
+            // as getMaxManaProduced does: without an activating player each canProduce falls into
+            // a much more expensive path, and this is hot enough for that to matter
+            ab.setActivatingPlayer(getController());
             if (ab.getApi() == ApiType.ManaReflected) {
                 colors.addAll(CardUtil.getReflectableManaColors(ab));
             } else {
                 colors = CardUtil.canProduce(6, ab, colors);
             }
         }
-        return canProduceColorMana(colors);
+        return colors;
+    }
+
+    public final boolean canProduceSameManaTypeWith(final Card c) {
+        if (getManaAbilities().isEmpty()) {
+            return false;
+        }
+        return canProduceColorMana(c.getProducibleColors());
     }
 
     public final int getMaxManaProduced() {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3355,9 +3355,12 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final Set<String> getProducibleColors() {
         Set<String> colors = new HashSet<>();
         for (final SpellAbility ab : getManaAbilities()) {
-            // as getMaxManaProduced does: without an activating player each canProduce falls into
-            // a much more expensive path, and this is hot enough for that to matter
-            ab.setActivatingPlayer(getController());
+            // Without an activating player each canProduce falls into a much more expensive path,
+            // and this is hot enough for that to matter. Only fill it in when it is missing, so a
+            // payment simulation that has already set a payer keeps it.
+            if (ab.getActivatingPlayer() == null) {
+                ab.setActivatingPlayer(getController());
+            }
             if (ab.getApi() == ApiType.ManaReflected) {
                 colors.addAll(CardUtil.getReflectableManaColors(ab));
             } else {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3355,9 +3355,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final Set<String> getProducibleColors() {
         Set<String> colors = new HashSet<>();
         for (final SpellAbility ab : getManaAbilities()) {
-            // Without an activating player each canProduce falls into a much more expensive path,
-            // and this is hot enough for that to matter. Only fill it in when it is missing, so a
-            // payment simulation that has already set a payer keeps it.
+            // without an activating player canProduce falls into a much more expensive path, so
+            // fill it in - but only when missing, so a payment simulation keeps the payer it set
             if (ab.getActivatingPlayer() == null) {
                 ab.setActivatingPlayer(getController());
             }
@@ -3365,6 +3364,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                 colors.addAll(CardUtil.getReflectableManaColors(ab));
             } else {
                 colors = CardUtil.canProduce(6, ab, colors);
+            }
+            if (colors.size() == MagicColor.Constant.COLORS_AND_COLORLESS.size()) {
+                break; // nothing left for a further ability to add
             }
         }
         return colors;

--- a/forge-gui-desktop/src/test/java/forge/ai/ExactLandValueTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ExactLandValueTest.java
@@ -1,0 +1,78 @@
+package forge.ai;
+
+import forge.card.MagicColor;
+import forge.game.Game;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/** What one more land of a colour would actually let the AI cast. */
+public class ExactLandValueTest extends AITest {
+
+    private SpellAbility spellOf(Player p, String name) {
+        for (forge.game.card.Card c : p.getCardsIn(ZoneType.Hand)) {
+            if (c.getName().equals(name)) {
+                for (SpellAbility sa : c.getAllPossibleAbilities(p, false)) {
+                    if (sa.isSpell()) {
+                        return sa;
+                    }
+                }
+            }
+        }
+        throw new IllegalStateException("no spell for " + name);
+    }
+
+    /** A second colored pip needs a second source, not just any source of that colour. */
+    @Test
+    public void doubleShardNeedsTwoSources() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+        addCards("Forest", 3, p);
+        addCards("Swamp", 1, p);
+        addCardToZone("Abyssal Harvester", p, ZoneType.Hand); // {1}{B}{B}
+        game.getAction().checkStateEffects(true);
+        SpellAbility sa = spellOf(p, "Abyssal Harvester");
+
+        assertFalse(ComputerUtilCost.isPayableWith(sa, p, null),
+                "one Swamp cannot pay {B}{B}");
+        assertTrue(ComputerUtilCost.isPayableWith(sa, p, MagicColor.Color.BLACK),
+                "a second black source casts it");
+        assertFalse(ComputerUtilCost.isPayableWith(sa, p, MagicColor.Color.GREEN),
+                "a fourth Forest still leaves the second black pip unpaid");
+    }
+
+    /** Enough mana is not enough on its own: the colour has to line up too. */
+    @Test
+    public void landMakesItCastableNow() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+        addCards("Forest", 1, p);
+        addCardToZone("Doom Blade", p, ZoneType.Hand); // {1}{B}
+        game.getAction().checkStateEffects(true);
+        SpellAbility sa = spellOf(p, "Doom Blade");
+
+        assertFalse(ComputerUtilCost.isPayableWith(sa, p, null), "not castable as things stand");
+        assertTrue(ComputerUtilCost.isPayableWith(sa, p, MagicColor.Color.BLACK),
+                "Forest plus a new Swamp casts it");
+        assertFalse(ComputerUtilCost.isPayableWith(sa, p, MagicColor.Color.GREEN),
+                "a second Forest cannot pay the black pip");
+    }
+
+    /** One land is one mana: a colour fix does not help what is still turns away. */
+    @Test
+    public void oneLandCannotBridgeABigGap() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+        addCards("Forest", 1, p);
+        addCardToZone("Angel of Mercy", p, ZoneType.Hand); // {4}{W}
+        game.getAction().checkStateEffects(true);
+        SpellAbility sa = spellOf(p, "Angel of Mercy");
+
+        assertFalse(ComputerUtilCost.isPayableWith(sa, p, MagicColor.Color.WHITE),
+                "a Plains fixes the colour but two lands is not five mana");
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
@@ -1,0 +1,136 @@
+package forge.ai.ability;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import forge.ai.AITest;
+import forge.ai.ComputerUtilCard;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+/**
+ * Land searches used to pick by list order, so a fetchland that had settled on the right colour
+ * still chose its second colour arbitrarily. The candidates are ranked by the colours the player
+ * receiving the land is actually short of.
+ */
+public class LandColorNeedAiTest extends AITest {
+
+    /** two duals sharing the searched-for type, differing in the colour beside it */
+    private List<Card> twoDuals(Player owner) {
+        return Lists.newArrayList(
+                addCardToZone("Tundra", owner, ZoneType.Library),         // Plains Island
+                addCardToZone("Underground Sea", owner, ZoneType.Library) // Island Swamp
+        );
+    }
+
+    @Test
+    public void picksTheColorTheHandIsWaitingOn() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        // castable the moment we can make black, and not before
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
+        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        Card chosen = ComputerUtilCard.getBestLandToGainAI(ai, twoDuals(ai), false);
+        assertEquals("Underground Sea", chosen.getName());
+    }
+
+    @Test
+    public void picksTheOtherColorWhenTheHandChanges() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCardToZone("Wrath of God", ai, ZoneType.Hand);
+        addCardToZone("Swords to Plowshares", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        Card chosen = ComputerUtilCard.getBestLandToGainAI(ai, twoDuals(ai), false);
+        assertEquals("Tundra", chosen.getName());
+    }
+
+    @Test
+    public void anOpponentChoosingGivesTheLeastUsefulLand() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
+        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        Card chosen = ComputerUtilCard.getBestLandToGainAI(ai, twoDuals(ai), true);
+        assertEquals("Tundra", chosen.getName());
+    }
+
+    /** with nothing to separate them the caller keeps whatever it was already doing */
+    @Test
+    public void staysOutOfTheWayWhenItCannotTell() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        game.getAction().checkStateEffects(true);
+
+        List<Card> identical = Lists.newArrayList(
+                addCardToZone("Tundra", ai, ZoneType.Library),
+                addCardToZone("Tundra", ai, ZoneType.Library));
+        assertNull(ComputerUtilCard.getBestLandToGainAI(ai, identical, false));
+    }
+
+    /**
+     * The same decision through a real fetchland, which is how this is reached in a game:
+     * Flooded Strand searches for a Plains or an Island, and every dual carrying one of those
+     * types is a legal target.
+     */
+    @Test
+    public void aFetchlandBringsBackTheColorWeAreShortOf() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card strand = addCard("Flooded Strand", ai);
+        strand.setSickness(false);
+        addCards("Island", 3, ai);
+        // only castable once we can make black
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
+        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        // both carry Island, so both are legal fetches; only one gives us black
+        addCardToZone("Tundra", ai, ZoneType.Library);
+        addCardToZone("Underground Sea", ai, ZoneType.Library);
+        fillLibrary(ai, 10);
+        game.getAction().checkStateEffects(true);
+
+        moveToMain2(game, ai);
+        playUntilStackClear(game);
+
+        assertEquals("fetched the land that unblocks our hand",
+                1, countCardsWithName(game, "Underground Sea"));
+        assertEquals(0, countCardsWithName(game, "Tundra"));
+    }
+
+    /** callers with no player to ask still get land value instead of a coin flip */
+    @Test
+    public void fallsBackToLandValueWithNoPlayer() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        List<Card> mixed = Lists.newArrayList(
+                addCardToZone("Tundra", ai, ZoneType.Library),
+                addCardToZone("Raffine's Tower", ai, ZoneType.Library)); // triome, produces more colours
+
+        assertNull("nothing to say without a player to ask",
+                ComputerUtilCard.getBestLandToGainAI(null, mixed, false));
+        assertEquals("Raffine's Tower", ComputerUtilCard.getBestLandAI(null, mixed).getName());
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
@@ -1,7 +1,5 @@
 package forge.ai.ability;
 
-import java.util.List;
-
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
@@ -14,25 +12,25 @@ import forge.game.player.Player;
 import forge.game.zone.ZoneType;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Land searches used to pick by list order, so a fetchland that had settled on the right colour
- * still chose its second colour arbitrarily. The candidates are ranked by the colours the player
- * receiving the land is actually short of.
+ * still chose its second colour arbitrarily. Both the play and the search path now rank candidates
+ * by what the colours they add would let us pay for, plus depth in the colours we are thin on.
  */
 public class LandColorNeedAiTest extends AITest {
 
     /** two duals sharing the searched-for type, differing in the colour beside it */
-    private List<Card> twoDuals(Player owner) {
-        return Lists.newArrayList(
-                addCardToZone("Tundra", owner, ZoneType.Library),         // Plains Island
-                addCardToZone("Underground Sea", owner, ZoneType.Library) // Island Swamp
-        );
+    private Card[] twoDuals(Player owner) {
+        return new Card[] {
+                addCardToZone("Tundra", owner, ZoneType.Library),          // Plains Island
+                addCardToZone("Underground Sea", owner, ZoneType.Library)  // Island Swamp
+        };
     }
 
     @Test
-    public void picksTheColorTheHandIsWaitingOn() {
+    public void scoresTheColorTheHandIsWaitingOn() {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
 
@@ -42,12 +40,24 @@ public class LandColorNeedAiTest extends AITest {
         addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
         game.getAction().checkStateEffects(true);
 
-        Card chosen = ComputerUtilCard.getBestLandToGainAI(ai, twoDuals(ai), false);
-        assertEquals("Underground Sea", chosen.getName());
+        Card[] duals = twoDuals(ai);
+        int white = ComputerUtilCard.getColorFixingValue(ai, duals[0]);
+        int black = ComputerUtilCard.getColorFixingValue(ai, duals[1]);
+        assertTrue("black unblocks the hand, white does not", black > white);
+
+        // whether our sources happen to be tapped says nothing about which colours the board can
+        // make, so holding the land drop until main 2 must not change the answer
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            c.setTapped(true);
+        }
+        game.getAction().checkStateEffects(true);
+        assertEquals("tapping out must not change the measure",
+                white, ComputerUtilCard.getColorFixingValue(ai, duals[0]));
+        assertEquals(black, ComputerUtilCard.getColorFixingValue(ai, duals[1]));
     }
 
     @Test
-    public void picksTheOtherColorWhenTheHandChanges() {
+    public void scoresTheOtherColorWhenTheHandChanges() {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
 
@@ -56,37 +66,72 @@ public class LandColorNeedAiTest extends AITest {
         addCardToZone("Swords to Plowshares", ai, ZoneType.Hand);
         game.getAction().checkStateEffects(true);
 
-        Card chosen = ComputerUtilCard.getBestLandToGainAI(ai, twoDuals(ai), false);
-        assertEquals("Tundra", chosen.getName());
+        Card[] duals = twoDuals(ai);
+        assertTrue("now it is white we are waiting on",
+                ComputerUtilCard.getColorFixingValue(ai, duals[0])
+                        > ComputerUtilCard.getColorFixingValue(ai, duals[1]));
     }
 
+    /** a permanent has already been paid for, so it must not make its own colours look needed */
     @Test
-    public void anOpponentChoosingGivesTheLeastUsefulLand() {
+    public void aResolvedPermanentDoesNotLookLikeDemand() {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
 
         addCards("Island", 3, ai);
-        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
-        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        // already resolved, so neither its casting cost nor its Adventure half is waiting on a
+        // colour - a permanent must not make its own colours look needed
+        addCard("Bonecrusher Giant", ai);
         game.getAction().checkStateEffects(true);
 
-        Card chosen = ComputerUtilCard.getBestLandToGainAI(ai, twoDuals(ai), true);
-        assertEquals("Tundra", chosen.getName());
-    }
+        // nothing is in hand, so a Mountain is worth depth on one new colour and nothing else.
+        // If the Giant's casting cost or its Adventure half counted, this would be far higher.
+        assertEquals("only depth on the new colour, no demand from the Giant",
+                ComputerUtilCard.COLOR_FIXING_WEIGHT,
+                ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Mountain", ai, ZoneType.Library)));
 
-    /** with nothing to separate them the caller keeps whatever it was already doing */
-    @Test
-    public void staysOutOfTheWayWhenItCannotTell() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-
-        addCards("Island", 3, ai);
-        game.getAction().checkStateEffects(true);
-
-        List<Card> identical = Lists.newArrayList(
+        // and with no player to ask, ranking falls through to land value rather than a coin flip
+        assertEquals("Raffine's Tower", ComputerUtilCard.getBestLandAI(null, Lists.newArrayList(
                 addCardToZone("Tundra", ai, ZoneType.Library),
-                addCardToZone("Tundra", ai, ZoneType.Library));
-        assertNull(ComputerUtilCard.getBestLandToGainAI(ai, identical, false));
+                addCardToZone("Raffine's Tower", ai, ZoneType.Library))).getName());
+    }
+
+    /**
+     * A colour mask cannot tell one source of a colour from two, so it thinks {@code BB} is
+     * payable off a single Swamp. Counting pips is what makes the second source worth having.
+     */
+    @Test
+    public void aSecondSourceCountsForDoublePips() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCards("Swamp", 1, ai);                           // one black source only
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);  // BB, so it wants a second
+        game.getAction().checkStateEffects(true);
+
+        assertTrue("a second black source is progress towards BB, a fourth blue source is not",
+                ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Swamp", ai, ZoneType.Library))
+                        > ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Island", ai, ZoneType.Library)));
+    }
+
+    /** with nothing waiting on a colour, depth still prefers the colours we are thin on */
+    @Test
+    public void depthPrefersTheColorWeAreThinnestOn() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCards("Plains", 1, ai);
+        game.getAction().checkStateEffects(true); // empty hand: nothing to unblock at all
+
+        int firstSwamp = ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Swamp", ai, ZoneType.Library));
+        int secondPlains = ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Plains", ai, ZoneType.Library));
+        int fourthIsland = ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Island", ai, ZoneType.Library));
+
+        assertTrue("a colour we have none of beats a second source", firstSwamp > secondPlains);
+        assertTrue("and a second source still beats a fourth", secondPlains > fourthIsland);
+        assertTrue("but a fourth is not worthless", fourthIsland > 0);
     }
 
     /**
@@ -117,20 +162,5 @@ public class LandColorNeedAiTest extends AITest {
         assertEquals("fetched the land that unblocks our hand",
                 1, countCardsWithName(game, "Underground Sea"));
         assertEquals(0, countCardsWithName(game, "Tundra"));
-    }
-
-    /** callers with no player to ask still get land value instead of a coin flip */
-    @Test
-    public void fallsBackToLandValueWithNoPlayer() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-
-        List<Card> mixed = Lists.newArrayList(
-                addCardToZone("Tundra", ai, ZoneType.Library),
-                addCardToZone("Raffine's Tower", ai, ZoneType.Library)); // triome, produces more colours
-
-        assertNull("nothing to say without a player to ask",
-                ComputerUtilCard.getBestLandToGainAI(null, mixed, false));
-        assertEquals("Raffine's Tower", ComputerUtilCard.getBestLandAI(null, mixed).getName());
     }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
@@ -4,14 +4,19 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 
+import java.util.List;
+
 import forge.ai.AITest;
 import forge.ai.ComputerUtilCard;
+import forge.ai.ComputerUtilCost;
+import forge.card.ColorSet;
 import forge.game.Game;
 import forge.game.card.Card;
 import forge.game.player.Player;
 import forge.game.zone.ZoneType;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 /**
@@ -139,6 +144,33 @@ public class LandColorNeedAiTest extends AITest {
         assertTrue("a colour we have none of beats a second source", firstSwamp > secondPlains);
         assertTrue("and a second source still beats a fourth", secondPlains > fourthIsland);
         assertTrue("but a fourth is not worthless", fourthIsland > 0);
+    }
+
+    /**
+     * Every caller runs getAvailableManaColors through ColorSet.fromNames, which keeps only colour
+     * names - so a source whose script says {@code Produced$ Any} used to contribute nothing, and
+     * a board of nothing but City of Brass read as unable to cast anything coloured.
+     */
+    @Test
+    public void anyColorSourcesOfferEveryColor() {
+        assertTrue("an any-colour source offers white", canPayWhiteOff("City of Brass"));
+        assertTrue(canPayWhiteOff("Mana Confluence"));
+        // and it still says no when the colour really is absent
+        assertFalse("a blue source does not offer white", canPayWhiteOff("Island"));
+    }
+
+    private boolean canPayWhiteOff(String landName) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        for (int i = 0; i < 3; i++) {
+            addCard(landName, ai).setSickness(false);
+        }
+        Card swords = addCardToZone("Swords to Plowshares", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        ColorSet available = ColorSet.fromNames(
+                ComputerUtilCost.getAvailableManaColors(ai, (List<Card>) null));
+        return swords.getManaCost().canBePaidWithAvailable(available.getColor());
     }
 
     /**

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
@@ -45,6 +45,11 @@ public class LandColorNeedAiTest extends AITest {
         int black = ComputerUtilCard.getColorFixingValue(ai, duals[1]);
         assertTrue("black unblocks the hand, white does not", black > white);
 
+        // and that is what ranking picks: the two duals are worth the same as lands, so the
+        // colour we are waiting on is the only thing separating them
+        assertEquals("Underground Sea",
+                ComputerUtilCard.getBestLandAI(ai, Lists.newArrayList(duals)).getName());
+
         // whether our sources happen to be tapped says nothing about which colours the board can
         // make, so holding the land drop until main 2 must not change the answer
         for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
@@ -105,12 +110,14 @@ public class LandColorNeedAiTest extends AITest {
         Game game = initAndCreateGame();
         Player ai = game.getPlayers().get(1);
 
-        addCards("Island", 3, ai);
-        addCards("Swamp", 1, ai);                           // one black source only
-        addCardToZone("Sign in Blood", ai, ZoneType.Hand);  // BB, so it wants a second
+        // one of each, so depth alone cannot tell the two candidates apart and only the pip
+        // counting can - a colour mask would call BB payable off the single Swamp
+        addCards("Island", 1, ai);
+        addCards("Swamp", 1, ai);
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);  // BB, so it wants a second black
         game.getAction().checkStateEffects(true);
 
-        assertTrue("a second black source is progress towards BB, a fourth blue source is not",
+        assertTrue("a second black source is progress towards BB, a second blue source is not",
                 ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Swamp", ai, ZoneType.Library))
                         > ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Island", ai, ZoneType.Library)));
     }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/LandColorNeedAiTest.java
@@ -1,0 +1,229 @@
+package forge.ai.ability;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+import forge.ai.AITest;
+import forge.ai.ComputerUtilCard;
+import forge.ai.ComputerUtilCost;
+import forge.card.ColorSet;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Land searches used to pick by list order, so a fetchland that had settled on the right colour
+ * still chose its second colour arbitrarily. Both the play and the search path now rank candidates
+ * by what the colours they add would let us pay for, plus depth in the colours we are thin on.
+ */
+public class LandColorNeedAiTest extends AITest {
+
+    /** two duals sharing the searched-for type, differing in the colour beside it */
+    private Card[] twoDuals(Player owner) {
+        return new Card[] {
+                addCardToZone("Tundra", owner, ZoneType.Library),          // Plains Island
+                addCardToZone("Underground Sea", owner, ZoneType.Library)  // Island Swamp
+        };
+    }
+
+    @Test
+    public void scoresTheColorTheHandIsWaitingOn() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        // castable the moment we can make black, and not before
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
+        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        Card[] duals = twoDuals(ai);
+        int white = ComputerUtilCard.getColorFixingValue(ai, duals[0]);
+        int black = ComputerUtilCard.getColorFixingValue(ai, duals[1]);
+        assertTrue("black unblocks the hand, white does not", black > white);
+
+        // and that is what ranking picks: the two duals are worth the same as lands, so the
+        // colour we are waiting on is the only thing separating them
+        assertEquals("Underground Sea",
+                ComputerUtilCard.getBestLandAI(ai, Lists.newArrayList(duals)).getName());
+
+        // whether our sources happen to be tapped says nothing about which colours the board can
+        // make, so holding the land drop until main 2 must not change the answer
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            c.setTapped(true);
+        }
+        game.getAction().checkStateEffects(true);
+        assertEquals("tapping out must not change the measure",
+                white, ComputerUtilCard.getColorFixingValue(ai, duals[0]));
+        assertEquals(black, ComputerUtilCard.getColorFixingValue(ai, duals[1]));
+    }
+
+    @Test
+    public void scoresTheOtherColorWhenTheHandChanges() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCardToZone("Wrath of God", ai, ZoneType.Hand);
+        addCardToZone("Swords to Plowshares", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        Card[] duals = twoDuals(ai);
+        assertTrue("now it is white we are waiting on",
+                ComputerUtilCard.getColorFixingValue(ai, duals[0])
+                        > ComputerUtilCard.getColorFixingValue(ai, duals[1]));
+    }
+
+    /** a permanent has already been paid for, so it must not make its own colours look needed */
+    @Test
+    public void aResolvedPermanentDoesNotLookLikeDemand() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        // already resolved, so neither its casting cost nor its Adventure half is waiting on a
+        // colour - a permanent must not make its own colours look needed
+        addCard("Bonecrusher Giant", ai);
+        game.getAction().checkStateEffects(true);
+
+        // nothing is in hand, so a Mountain is worth depth on one new colour and nothing else.
+        // If the Giant's casting cost or its Adventure half counted, this would be far higher.
+        assertEquals("only depth on the new colour, no demand from the Giant",
+                ComputerUtilCard.COLOR_FIXING_WEIGHT,
+                ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Mountain", ai, ZoneType.Library)));
+
+        // and with no player to ask, ranking falls through to land value rather than a coin flip
+        assertEquals("Raffine's Tower", ComputerUtilCard.getBestLandAI(null, Lists.newArrayList(
+                addCardToZone("Tundra", ai, ZoneType.Library),
+                addCardToZone("Raffine's Tower", ai, ZoneType.Library))).getName());
+    }
+
+    /**
+     * A colour mask cannot tell one source of a colour from two, so it thinks {@code BB} is
+     * payable off a single Swamp. Counting pips is what makes the second source worth having.
+     */
+    @Test
+    public void aSecondSourceCountsForDoublePips() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        // one of each, so depth alone cannot tell the two candidates apart and only the pip
+        // counting can - a colour mask would call BB payable off the single Swamp
+        addCards("Island", 1, ai);
+        addCards("Swamp", 1, ai);
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);  // BB, so it wants a second black
+        game.getAction().checkStateEffects(true);
+
+        assertTrue("a second black source is progress towards BB, a second blue source is not",
+                ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Swamp", ai, ZoneType.Library))
+                        > ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Island", ai, ZoneType.Library)));
+    }
+
+    /** with nothing waiting on a colour, depth still prefers the colours we are thin on */
+    @Test
+    public void depthPrefersTheColorWeAreThinnestOn() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCards("Plains", 1, ai);
+        game.getAction().checkStateEffects(true); // empty hand: nothing to unblock at all
+
+        int firstSwamp = ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Swamp", ai, ZoneType.Library));
+        int secondPlains = ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Plains", ai, ZoneType.Library));
+        int fourthIsland = ComputerUtilCard.getColorFixingValue(ai, addCardToZone("Island", ai, ZoneType.Library));
+
+        assertTrue("a colour we have none of beats a second source", firstSwamp > secondPlains);
+        assertTrue("and a second source still beats a fourth", secondPlains > fourthIsland);
+        assertTrue("but a fourth is not worthless", fourthIsland > 0);
+    }
+
+    /**
+     * Every caller runs getAvailableManaColors through ColorSet.fromNames, which keeps only colour
+     * names - so a source whose script says {@code Produced$ Any} used to contribute nothing, and
+     * a board of nothing but City of Brass read as unable to cast anything coloured.
+     */
+    @Test
+    public void anyColorSourcesOfferEveryColor() {
+        assertTrue("an any-colour source offers white", canPayWhiteOff("City of Brass"));
+        assertTrue(canPayWhiteOff("Mana Confluence"));
+        // and it still says no when the colour really is absent
+        assertFalse("a blue source does not offer white", canPayWhiteOff("Island"));
+    }
+
+    private boolean canPayWhiteOff(String landName) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        for (int i = 0; i < 3; i++) {
+            addCard(landName, ai).setSickness(false);
+        }
+        Card swords = addCardToZone("Swords to Plowshares", ai, ZoneType.Hand);
+        game.getAction().checkStateEffects(true);
+
+        ColorSet available = ColorSet.fromNames(
+                ComputerUtilCost.getAvailableManaColors(ai, (List<Card>) null));
+        return swords.getManaCost().canBePaidWithAvailable(available.getColor());
+    }
+
+    /**
+     * The same decision through a real fetchland, which is how this is reached in a game:
+     * Flooded Strand searches for a Plains or an Island, and every dual carrying one of those
+     * types is a legal target.
+     */
+    @Test
+    public void aFetchlandBringsBackTheColorWeAreShortOf() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card strand = addCard("Flooded Strand", ai);
+        strand.setSickness(false);
+        addCards("Island", 3, ai);
+        // only castable once we can make black
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
+        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        // both carry Island, so both are legal fetches; only one gives us black
+        addCardToZone("Tundra", ai, ZoneType.Library);
+        addCardToZone("Underground Sea", ai, ZoneType.Library);
+        fillLibrary(ai, 10);
+        game.getAction().checkStateEffects(true);
+
+        moveToMain2(game, ai);
+        playUntilStackClear(game);
+
+        assertEquals("fetched the land that unblocks our hand",
+                1, countCardsWithName(game, "Underground Sea"));
+        assertEquals(0, countCardsWithName(game, "Tundra"));
+    }
+
+    /**
+     * Both candidates fix one missing colour, so the source counting rates them the same. Only one
+     * of them actually casts something this turn, and that is what should decide it.
+     */
+    @Test
+    public void castingSomethingNowOutranksMereColorFixing() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Forest", 1, ai);
+        addCardToZone("Doom Blade", ai, ZoneType.Hand);      // {1}{B} - Forest + Swamp casts it
+        addCardToZone("Angel of Mercy", ai, ZoneType.Hand);  // {4}{W} - a Plains fixes white, but
+                                                             // two lands is nowhere near five mana
+        game.getAction().checkStateEffects(true);
+
+        Card swamp = addCardToZone("Swamp", ai, ZoneType.Library);
+        Card plains = addCardToZone("Plains", ai, ZoneType.Library);
+
+        int black = ComputerUtilCard.getColorFixingValue(ai, swamp);
+        int white = ComputerUtilCard.getColorFixingValue(ai, plains);
+        System.out.println("swamp=" + black + " plains=" + white);
+        assertTrue("the land that actually casts something wins", black > white);
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/LandFetchColorNeedTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/LandFetchColorNeedTest.java
@@ -1,0 +1,45 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+public class LandFetchColorNeedTest extends AITest {
+    /**
+     * The AI holds black cards it has no target for, so nothing has been attempted and nothing is
+     * on record as unpayable. It has no Plains and no Swamps either, so the count of what it
+     * already owns cannot separate them and the fetch falls to the order of BASIC_LANDS. The hand
+     * is the only evidence of which colour is wanted.
+     */
+    @Test
+    public void fetchesTheColorTheHandNeedsWithNothingAttempted() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Island", 3, ai);
+        addCard("Evolving Wilds", ai);
+        addCardToZone("Sign in Blood", ai, ZoneType.Hand);
+        addCardToZone("Ravenous Chupacabra", ai, ZoneType.Hand);
+        addCardToZone("Plains", ai, ZoneType.Library);
+        addCardToZone("Swamp", ai, ZoneType.Library);
+        fillLibrary(ai, 10);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        playUntilNextTurn(game);
+
+        String fetched = "nothing";
+        for (Card c : ai.getCardsIn(ZoneType.Battlefield)) {
+            if (c.getName().equals("Plains") || c.getName().equals("Swamp")) {
+                fetched = c.getName();
+            }
+        }
+        assertEquals("the hand is waiting on black", "Swamp", fetched);
+    }
+}


### PR DESCRIPTION
Land searches picked by list order. `basicManaFixing` chose the basic *type* the player had fewest of, then took `list.get(0)` from whatever survived that filter; `getBestLandAI` ended in `Aggregates.random`. Neither asked which colours were actually blocking anything.

Every fetchland comes through here — `areAllBasics("Plains,Island")` is true — and a "Plains" search matches every dual carrying the Plains type. Over 12 seeded AI-vs-AI games (deck 260613, three seeds) `basicManaFixing` fires **46 times**, 44 with a real choice. One observed `minType=Island` decision offered:

```
Tundra(WU)  Underground Sea(UB)  Volcanic Island(UR)  Tropical Island(UG)
Raffine's Tower(WUB)  Ketria Triome(URG)  Breeding Pool(UG)  ...
```

All carry Island; all differ beside it. It took Tundra because Tundra was first.

## The measure

`ComputerUtilCard.getColorFixingValue(player, land)` is the single number every caller ranks by: how many missing colour sources that land supplies across the player's hand and the activatable abilities on their permanents, plus depth in the colours they are thin on. Counting *sources* rather than colours is what credits a second Swamp towards `BB`, which a colour mask calls payable off a single one.

The parts are `countMissingSources`, `countSourcesFixed` and `evaluateSpareSources`.

Colour need is asked *before* the basic-type count, because that count cannot tell a colour that is missing from one that is merely uncommon: with three Islands and a hand wanting black it concluded it needed Plains — having none — and fetched a Plains-Island.

## An "Any" source counted for nothing

Found while answering review here, and folded in because it is the same code path. `getAvailableManaColors` collected the raw `Produced$` string, and every caller runs that through `ColorSet.fromNames`, which keeps only colour names — so `Any` was dropped entirely:

| board, `{W}` in hand | before | after |
|---|---|---|
| 3x City of Brass | no colours | WUBRG |
| 3x Mana Confluence | no colours | WUBRG |
| 3x Island | U | U |

Checked against `ComputerUtilMana.canPayManaCost` as ground truth: before, the any-colour boards disagreed with it; after, every row agrees and the negatives stay negative. It now asks `getProducibleColors`, which resolves the colours and makes the set bounded, so it can also stop once every colour is present.

## Testing

`mvn -pl forge-gui-desktop -am test`: 358 tests, 0 failures.

Seven tests, sized by mutation rather than by count: removing the depth term, its diminishing returns, the hand scan, the permanent-cost exclusion, the per-colour pip counting, the search narrowing, the tapped-source invariance or the any-colour fix each turns at least one of them red.

One caveat on the numbers above: the 46/44 counts describe the old behaviour and still stand, but the share of picks that change was measured against the first version of the metric and has not been re-run since the scoring changed.

🤖 Implemented with the assistance of Claude Code (Opus 5).
