### PR TITLE
Fix Gandalf Spark Starter

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/gandalf_spark_starter.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gandalf_spark_starter.txt
@@ -4,5 +4,5 @@ Types:Legendary Creature Avatar Wizard
 PT:4/3
 K:Reach
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDmg | TriggerDescription$ When NICKNAME enters, he deals 3 damage divided as you choose among one, two, or three targets.
-SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Creature | NumDmg$ 3 | TargetMin$ 1 | TargetMax$ 3 | DividedAsYouChoose$ 3
+SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | TargetMin$ 1 | TargetMax$ 3 | DividedAsYouChoose$ 3
 Oracle:Reach\nWhen Gandalf enters, he deals 3 damage divided as you choose among one, two, or three targets.


### PR DESCRIPTION
Fix Gandalf Spark Starter so that it can target anything instead of only creatures.
Closes #11518