### PR TITLE
Honour Scryfall rate limiting when fetching card images on desktop

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/util/SwingImageFetcher.java
+++ b/forge-gui-desktop/src/main/java/forge/util/SwingImageFetcher.java
@@ -7,8 +7,10 @@ import javax.swing.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 
 public class SwingImageFetcher extends ImageFetcher {
 
@@ -34,13 +36,41 @@ public class SwingImageFetcher extends ImageFetcher {
                 return false;
             }
 
+            if (inScryfallCooldown(urlToDownload)) {
+                return false;
+            }
+
             String newdespath = urlToDownload.contains(".fullborder.jpg") || urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) ?
                     TextUtil.fastReplace(destPath, ".full.jpg", ".fullborder.jpg") : destPath;
             if (!newdespath.contains(".full") && !newdespath.contains(".artcrop") && urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) && !destPath.startsWith(ForgeConstants.CACHE_TOKEN_PICS_DIR))
                 newdespath = newdespath.replace(".jpg", ".fullborder.jpg"); //fix planes/phenomenon for round border options
             URL url = new URL(urlToDownload);
             System.out.println("Attempting to fetch: " + url);
-            BufferedImage image = ImageIO.read(url);
+            paceScryfall(urlToDownload);
+
+            // Read through a connection rather than ImageIO.read(URL), which discards the response
+            // code - without it a 429 is indistinguishable from any other failure and we keep asking.
+            final URLConnection connection = url.openConnection();
+            connection.setRequestProperty("Accept", "*/*");
+            connection.setRequestProperty("User-Agent", BuildInfo.getUserAgent());
+            if (connection instanceof HttpURLConnection httpConnection) {
+                final int responseCode = httpConnection.getResponseCode();
+                if (responseCode != HttpURLConnection.HTTP_OK) {
+                    System.err.println("Failed to fetch image. HTTP code: " + responseCode
+                            + " (" + httpConnection.getResponseMessage() + ") for URL: " + urlToDownload);
+                    if (responseCode == 429 && isScryfall(urlToDownload)) {
+                        System.err.println("Rate limited by scryfall. Pausing image downloads.");
+                        noteScryfallRateLimited();
+                    }
+                    httpConnection.disconnect();
+                    return false;
+                }
+            }
+
+            BufferedImage image;
+            try (InputStream is = connection.getInputStream()) {
+                image = ImageIO.read(is);
+            }
             // First, save to a temporary file so that nothing tries to read
             // a partial download.
             File destFile = new File(newdespath + ".tmp");

--- a/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
+++ b/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
@@ -16,7 +16,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 public class LibGDXImageFetcher extends ImageFetcher {
@@ -56,15 +55,8 @@ public class LibGDXImageFetcher extends ImageFetcher {
                 return false;
             }
 
-            if (scryfallCooldownTime != null && urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD)) {
-                // Don't try to download card images from scryfall if we've been rate limited
-                if (scryfallCooldownTime.after(new Date())) {
-                    System.err.println("Currently in cooldown period for scryfall downloads. Skipping download attempt for: " + urlToDownload);
-                    return false;
-                } else {
-                    // Cooldown period has expired, reset the cooldown time
-                    scryfallCooldownTime = null;
-                }
+            if (inScryfallCooldown(urlToDownload)) {
+                return false;
             }
 
             String newdespath = urlToDownload.contains(".fullborder.") || urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) ?
@@ -91,8 +83,7 @@ public class LibGDXImageFetcher extends ImageFetcher {
                 if (responseCode == 429) {
                     System.err.println("Device has been rate limited. Adding reduction of download attempts for this device.");
                     Sentry.captureMessage("Device has been rate limited. Adding reduction of download attempts for this device. " + urlToDownload);
-                    // Don't try to download from scryfall for 5 minutes
-                    scryfallCooldownTime = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+                    noteScryfallRateLimited();
                 }
 
                 return false;

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -34,24 +34,29 @@ public abstract class ImageFetcher {
         return url != null && url.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD);
     }
 
-    /**
-     * Whether we are still backing off after Scryfall rate limited us. Clears the cooldown once it
-     * has expired, so callers can simply skip the fetch while this returns true.
-     */
-    protected static boolean inScryfallCooldown(final String url) {
-        if (!isScryfall(url)) {
-            return false;
-        }
+    /** Whether we are still backing off after Scryfall rate limited us. Clears an expired cooldown. */
+    protected static boolean scryfallCoolingDown() {
         final Date cooldown = scryfallCooldownTime;
         if (cooldown == null) {
             return false;
         }
         if (cooldown.after(new Date())) {
-            System.err.println("Currently in cooldown period for scryfall downloads. Skipping download attempt for: " + url);
             return true;
         }
         scryfallCooldownTime = null;
         return false;
+    }
+
+    /**
+     * Whether this particular download should be skipped because we are backing off Scryfall, so
+     * callers can simply skip the fetch while this returns true.
+     */
+    protected static boolean inScryfallCooldown(final String url) {
+        if (!isScryfall(url) || !scryfallCoolingDown()) {
+            return false;
+        }
+        System.err.println("Currently in cooldown period for scryfall downloads. Skipping download attempt for: " + url);
+        return true;
     }
 
     /** Record that Scryfall returned 429, so we stop asking for a while. */
@@ -469,6 +474,13 @@ public abstract class ImageFetcher {
     }
 
     private void setupObserver(final String destPath, final Callback callback, final ArrayList<String> downloadUrls) {
+        // Skip before registering rather than inside the download task: nothing removes a path from
+        // the in-flight set below, so a fetch registered during the cooldown would never be retried
+        // once the cooldown lifts. Only when every candidate is Scryfall - otherwise another source
+        // may still serve it.
+        if (scryfallCoolingDown() && downloadUrls.stream().allMatch(ImageFetcher::isScryfall)) {
+            return;
+        }
         // Note: No synchronization is needed here because this is executed on
         // EDT thread (see assert on top) and so is the notification of observers.
         HashSet<Callback> observers = currentFetches.get(destPath);

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -13,6 +13,7 @@ import forge.model.FModel;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public abstract class ImageFetcher {
@@ -20,8 +21,66 @@ public abstract class ImageFetcher {
     // https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
     private static final HashMap<String, String> langCodeMap = new HashMap<>();
     protected static final boolean disableHostedDownload = true;
-    protected static Date scryfallCooldownTime = null;
+    protected static volatile Date scryfallCooldownTime = null;
     private static final HashSet<String> fetching = new HashSet<>();
+
+    /** Minimum gap between Scryfall requests, matching what GuiDownloadService already keeps. */
+    private static final long SCRYFALL_MIN_INTERVAL_MS = 100;
+    private static final long SCRYFALL_COOLDOWN_MINUTES = 5;
+    private static final Object scryfallPacing = new Object();
+    private static long lastScryfallRequest = 0;
+
+    protected static boolean isScryfall(final String url) {
+        return url != null && url.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD);
+    }
+
+    /**
+     * Whether we are still backing off after Scryfall rate limited us. Clears the cooldown once it
+     * has expired, so callers can simply skip the fetch while this returns true.
+     */
+    protected static boolean inScryfallCooldown(final String url) {
+        if (!isScryfall(url)) {
+            return false;
+        }
+        final Date cooldown = scryfallCooldownTime;
+        if (cooldown == null) {
+            return false;
+        }
+        if (cooldown.after(new Date())) {
+            System.err.println("Currently in cooldown period for scryfall downloads. Skipping download attempt for: " + url);
+            return true;
+        }
+        scryfallCooldownTime = null;
+        return false;
+    }
+
+    /** Record that Scryfall returned 429, so we stop asking for a while. */
+    protected static void noteScryfallRateLimited() {
+        scryfallCooldownTime = new Date(System.currentTimeMillis()
+                + TimeUnit.MINUTES.toMillis(SCRYFALL_COOLDOWN_MINUTES));
+    }
+
+    /**
+     * Space Scryfall requests out. Downloads run on a work stealing pool, so without this a screen
+     * full of missing images asks for all of them at once. Called from the download task, never the
+     * EDT.
+     */
+    protected static void paceScryfall(final String url) {
+        if (!isScryfall(url)) {
+            return;
+        }
+        synchronized (scryfallPacing) {
+            final long wait = lastScryfallRequest + SCRYFALL_MIN_INTERVAL_MS - System.currentTimeMillis();
+            if (wait > 0) {
+                try {
+                    Thread.sleep(wait);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            lastScryfallRequest = System.currentTimeMillis();
+        }
+    }
 
     static {
         langCodeMap.put("en-US", "en");


### PR DESCRIPTION
The mobile fetcher checks the HTTP status when downloading a card image and, on a 429, backs off
Scryfall for five minutes. Desktop never got that - it calls `ImageIO.read(URL)`, which throws the
response code away, so a rate limit is indistinguishable from any other failed download and we
carry on asking. The cooldown field it would use is already declared on the shared base class;
only the mobile half was ever wired up, in 678aae47 back in February.

`SwingImageFetcher` now reads through a `URLConnection`, sends the User-Agent and Accept headers
Scryfall asks for, and records the cooldown on a 429. The cooldown logic moves up to `ImageFetcher`
so both platforms share one copy rather than mobile carrying its own.

Desktop also had no spacing between requests. Downloads are submitted to a work stealing pool, so a
screen of missing images - a deck editor grid, for instance - asks for all of them at once.
`paceScryfall` keeps a 100ms gap, the same interval `GuiDownloadService` already keeps for its bulk
downloads. Mobile already sleeps between attempts in its own loop, so it is left alone.

The pool this sleeps in has exactly two users, `ImageKeys` set lookup and `ImageFetcher` itself, so
pacing delays other image work and nothing else.

Not unit tested: the cooldown is static mutable state shared across the JVM, and setting it from a
test would leak a five minute Scryfall cooldown into the rest of the suite. Verified by build on
both the desktop and mobile modules, and the desktop suite - 351 tests, 0 failures.

Written with Claude Opus 5 (also recorded in the commit co-authors).
