### PR TITLE
Fix library cards showing as card backs for guest in multiplayer

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -622,8 +622,12 @@ public class CardView extends GameEntityView {
     }
     public boolean mayPlayerLook(PlayerView pv) {
         TrackableCollection<PlayerView> col = get(TrackableProperty.PlayerMayLook);
-        // TODO don't use contains as it only queries the backing HashSet which is problematic for netplay because of unsynchronized player ids
-        return col != null && col.indexOf(pv) != -1;
+        if (col == null) { return false; }
+        // compare by id, not reference: MP client/server PlayerViews are distinct objects
+        for (PlayerView p : col) {
+            if (p.getId() == pv.getId()) { return true; }
+        }
+        return false;
     }
     void setPlayerMayLook(Iterable<Player> list) {
         if (Iterables.isEmpty(list)) {


### PR DESCRIPTION
## Problem

`CardView.mayPlayerLook` looked up the may-look `PlayerView` collection with `indexOf` (reference equality):

```java
return col != null && col.indexOf(pv) != -1;
```

In network play the client's local `PlayerView`s are distinct objects from the deserialized server ones, so the lookup always missed. Cards a player should be able to see — their own revealed library top (Future Sight/Garruk's Horde), opponent-hand reveals, etc. — rendered as **card backs** for the guest.

## Fix

Compare by `getId()` instead of object reference. Single file, `forge-game` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
