### PR TITLE
CardDb: make loadCard idempotent (fix latent duplicate-PaperCard bug)

### DIFF
--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -445,6 +445,12 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
                 return;
             }
         }
+        // addSetCard appends unconditionally, so skip if this card's printing from this set
+        // is already loaded (presence in other sets isn't enough — loadCard also adds new-set printings)
+        CardEdition guardEd = editions.get(setCode);
+        if (guardEd != null && !guardEd.equals(CardEdition.UNKNOWN) && hasPrintingInSet(cr, guardEd)) {
+            return;
+        }
         boolean reIndexNecessary = false;
         CardEdition ed = editions.get(setCode);
         if (ed == null || ed.equals(CardEdition.UNKNOWN)) {
@@ -460,6 +466,18 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             rulesByPrimaryName.putIfAbsent(cardName, cr); //TODO: Cache alt names here too.
             reIndex();
         }
+    }
+
+    /** True if a printing of this card from edition is already loaded (no side effects, unlike getCardFromSet). */
+    private boolean hasPrintingInSet(CardRules cr, CardEdition edition) {
+        String code1 = edition.getCode(), code2 = edition.getCode2();
+        for (PaperCard pc : getAllCards(cr)) {
+            String ed = pc.getEdition();
+            if (ed.equalsIgnoreCase(code1) || ed.equalsIgnoreCase(code2)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void initialize(boolean logMissingPerEdition, boolean logMissingSummary, boolean enableUnknownCards) {


### PR DESCRIPTION
## Problem

`CardDb.loadCard` is not idempotent: `addSetCard` unconditionally increments the art index and appends a fresh `PaperCard`. A redundant call for a `(name, set)` printing that's already loaded therefore **duplicates** that `PaperCard` in `allCardsByName`.

## Fix

Skip when that exact `(name, set)` printing already exists, via a new side-effect-free `hasPrintingInSet` check. Guarding on card-name presence alone would break the "add a printing from a not-yet-loaded set" path (`StaticData.getOrLoadCommonCard`), where the card can already exist under other sets while the requested set's printing is still missing — so the guard is keyed on the specific edition.

## Why "any printing present" is a safe guard despite multi-printing sets

A set **can** contain multiple printings of the same name (`CardEdition.getCardInSet` returns a `List<EditionEntry>` — basic-land arts, showcase variants; that's what `artIndex` is for). The guard is still sound because `loadCard` is **all-or-nothing per `(name, set)`**: `addFromSetByName` loops over every `EditionEntry` of that name in the set and `addSetCard`s each one. `addSetCard` has exactly two callers — that loop, and the eager full-set path in `initialize` — so no code path ever adds a *subset* of a name's printings for a set. Any-printing-present therefore implies the `(name, set)` load already ran, art variants included. (Entries excluded by the functional-variant filter are excluded on every call equally, so the invariant holds.)

Single file, `forge-core` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
