### PR TITLE
CardState: move IntrinsicSpell into LandTraitChanges

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3361,7 +3361,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final SpellAbility getFirstSpellAbility() {
-        return Iterables.getFirst(currentState.getNonManaAbilities(), null);
+        return currentState.getFirstSpellAbility();
     }
 
     public final SpellPermanent getSpellPermanent() {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -456,49 +456,47 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public final FCollectionView<SpellAbility> getSpellAbilities() {
-        FCollection<SpellAbility> newCol = new FCollection<>();
-        updateSpellAbilities(newCol);
-        newCol.addAll(abilities);
-        card.updateSpellAbilities(newCol, this);
-        return newCol;
+        FCollection<SpellAbility> result = new FCollection<>(abilities);
+        if (getStateName().equals(CardStateName.Original)) {
+            if (getCard().hasState(CardStateName.LeftSplit))
+                result.addAll(getCard().getState(CardStateName.LeftSplit).abilities);
+            if (getCard().hasState(CardStateName.RightSplit))
+                result.addAll(getCard().getState(CardStateName.RightSplit).abilities);
+        }
+        card.updateSpellAbilities(result, this);
+        return result;
     }
     public final FCollectionView<SpellAbility> getManaAbilities() {
-        FCollection<SpellAbility> newCol = new FCollection<>();
-        updateSpellAbilities(newCol);
-        newCol.addAll(abilities);
-        card.updateSpellAbilities(newCol, this);
-        newCol.removeIf(Predicate.not(SpellAbility::isManaAbility));
-        return newCol;
+        FCollection<SpellAbility> result = new FCollection<>(abilities);
+        if (getStateName().equals(CardStateName.Original)) {
+            if (getCard().hasState(CardStateName.LeftSplit))
+                result.addAll(getCard().getState(CardStateName.LeftSplit).abilities);
+            if (getCard().hasState(CardStateName.RightSplit))
+                result.addAll(getCard().getState(CardStateName.RightSplit).abilities);
+        }
+        card.updateSpellAbilities(result, this);
+        result.removeIf(Predicate.not(SpellAbility::isManaAbility));
+        return result;
     }
     public final FCollectionView<SpellAbility> getNonManaAbilities() {
-        FCollection<SpellAbility> newCol = new FCollection<>();
-        updateSpellAbilities(newCol);
-        newCol.addAll(abilities);
-        card.updateSpellAbilities(newCol, this);
-        newCol.removeIf(SpellAbility::isManaAbility);
-        return newCol;
+        FCollection<SpellAbility> result = new FCollection<>(abilities);
+        if (getStateName().equals(CardStateName.Original)) {
+            if (getCard().hasState(CardStateName.LeftSplit))
+                result.addAll(getCard().getState(CardStateName.LeftSplit).abilities);
+            if (getCard().hasState(CardStateName.RightSplit))
+                result.addAll(getCard().getState(CardStateName.RightSplit).abilities);
+        }
+        card.updateSpellAbilities(result, this);
+        result.removeIf(SpellAbility::isManaAbility);
+        return result;
     }
 
-    protected final void updateSpellAbilities(FCollection<SpellAbility> newCol) {
-        // add Split to Original
-        if (getStateName().equals(CardStateName.Original)) {
-            if (getCard().hasState(CardStateName.LeftSplit)) {
-                CardState leftState = getCard().getState(CardStateName.LeftSplit);
-                newCol.addAll(leftState.abilities);
-                leftState.updateSpellAbilities(newCol);
-            }
-            if (getCard().hasState(CardStateName.RightSplit)) {
-                CardState rightState = getCard().getState(CardStateName.RightSplit);
-                newCol.addAll(rightState.abilities);
-                rightState.updateSpellAbilities(newCol);
-            }
-        }
-
+    protected final SpellAbility getIntrinsicSpell() {
         // SpellPermanent only for Original State
         switch(getStateName()) {
         case Backside:
             if (!getCard().isModal()) {
-                return;
+                return null;
             }
             break;
         case Original:
@@ -511,32 +509,65 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         case SpecializeW:
             break;
         default:
-            return;
-        }
-        // if card has left or right split, disable intrinsic Spell for original
-        if (getStateName().equals(CardStateName.Original) && (getCard().hasState(CardStateName.LeftSplit) || getCard().hasState(CardStateName.RightSplit))) {
-            return;
+            return null;
         }
 
         CardTypeView type = getTypeWithChanges();
+        if (!type.isPermanent()) {
+            return null;
+        }
+
         if (type.isLand()) {
             if (landAbility == null) {
                 landAbility = new LandAbility(card, this);
             }
-            newCol.add(landAbility);
+            return landAbility;
         } else if (type.isAura()) {
-            newCol.add(getAuraSpell());
-        } else if (type.isPermanent()) {
+            return getAuraSpell();
+        } else {
             if (abilities.anyMatch(s -> (
                     s.isBasicSpell() && s.getSubAbility() == null && (ApiType.PermanentCreature.equals(s.getApi()) || ApiType.PermanentNoncreature.equals(s.getApi())))
                 )) {
-                return;
+                return null;
             }
 
             if (permanentAbility == null) {
                 permanentAbility = new SpellPermanent(card, this);
             }
-            newCol.add(permanentAbility);
+            return permanentAbility;
+        }
+    }
+
+    protected final void updateSpellAbilities(List<SpellAbility> newCol) {
+        // add Split to Original
+        if (getStateName().equals(CardStateName.Original) &&
+                (getCard().hasState(CardStateName.LeftSplit) || getCard().hasState(CardStateName.RightSplit))) {
+            boolean skip = false;
+            // insert right first, so left can be added before
+            if (getCard().hasState(CardStateName.RightSplit)) {
+                skip = true;
+                SpellAbility spRight = getCard().getState(CardStateName.RightSplit).getIntrinsicSpell();
+                if (spRight != null) {
+                    newCol.add(0, spRight);
+                }
+            }
+            if (getCard().hasState(CardStateName.LeftSplit)) {
+                skip = true;
+                SpellAbility spLeft = getCard().getState(CardStateName.LeftSplit).getIntrinsicSpell();
+                if (spLeft != null) {
+                    newCol.add(0, spLeft);
+                }
+            }
+
+            // if card has left or right split, disable intrinsic Spell for original
+            if (skip) {
+                return;
+            }
+        }
+
+        SpellAbility sp = getIntrinsicSpell();
+        if (sp != null) {
+            newCol.add(0, sp);
         }
     }
 
@@ -559,9 +590,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 list.clear();
             }
             CardTypeView type = state.getTypeWithChanges();
-            if (!type.isLand()) {
-                return list;
-            }
+            state.updateSpellAbilities(list);
             for (MagicColor.Color c : MagicColor.Color.values()) {
                if (c.getBasicLandType() == null) {
                    continue;
@@ -620,7 +649,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         if (this.card.getCastSA() != null) {
             return this.card.getCastSA();
         }
-        return Iterables.getFirst(getNonManaAbilities(), null);
+        return getNonManaAbilities().stream().filter(SpellAbility::isSpell).findFirst().orElse(null);
     }
 
     public final SpellAbility getFirstSpellAbilityWithFallback() {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -467,26 +467,12 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         return result;
     }
     public final FCollectionView<SpellAbility> getManaAbilities() {
-        FCollection<SpellAbility> result = new FCollection<>(abilities);
-        if (getStateName().equals(CardStateName.Original)) {
-            if (getCard().hasState(CardStateName.LeftSplit))
-                result.addAll(getCard().getState(CardStateName.LeftSplit).abilities);
-            if (getCard().hasState(CardStateName.RightSplit))
-                result.addAll(getCard().getState(CardStateName.RightSplit).abilities);
-        }
-        card.updateSpellAbilities(result, this);
+        FCollectionView<SpellAbility> result = getSpellAbilities();
         result.removeIf(Predicate.not(SpellAbility::isManaAbility));
         return result;
     }
     public final FCollectionView<SpellAbility> getNonManaAbilities() {
-        FCollection<SpellAbility> result = new FCollection<>(abilities);
-        if (getStateName().equals(CardStateName.Original)) {
-            if (getCard().hasState(CardStateName.LeftSplit))
-                result.addAll(getCard().getState(CardStateName.LeftSplit).abilities);
-            if (getCard().hasState(CardStateName.RightSplit))
-                result.addAll(getCard().getState(CardStateName.RightSplit).abilities);
-        }
-        card.updateSpellAbilities(result, this);
+        FCollectionView<SpellAbility> result = getSpellAbilities();
         result.removeIf(SpellAbility::isManaAbility);
         return result;
     }

--- a/forge-game/src/main/java/forge/game/keyword/KeywordCollection.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordCollection.java
@@ -24,6 +24,9 @@ public class KeywordCollection implements ICardTraitChanges, Iterable<KeywordInt
     public KeywordCollection() {
         super();
     }
+    public KeywordCollection(KeywordCollection other) {
+        this.map.putAll(other.map);
+    }
 
     public boolean contains(Keyword keyword) {
         return map.containsKey(keyword);

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
@@ -169,7 +169,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbility playMerchantSa = c.getSpellAbilities().get(0);
+        SpellAbility playMerchantSa = c.getFirstSpellAbility();
         playMerchantSa.setActivatingPlayer(p);
 
         GameSimulator sim = createSimulator(p);
@@ -224,7 +224,7 @@ public class GameSimulationTest extends SimulationTest {
         GameSimulator sim = createSimulator(p1);
         Game simGame = sim.getSimulatedGameState();
 
-        SpellAbility fractureSa = fractureP1.getSpellAbilities().get(0);
+        SpellAbility fractureSa = fractureP1.getFirstSpellAbility();
         AssertJUnit.assertNotNull(fractureSa);
         fractureSa.getTargets().add(p0);
         sim.simulateSpellAbility(fractureSa);
@@ -320,7 +320,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbility manifestSA = soulSummons.getSpellAbilities().get(0);
+        SpellAbility manifestSA = soulSummons.getFirstSpellAbility();
 
         GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(manifestSA);
@@ -365,7 +365,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbility manifestSA = soulSummons.getSpellAbilities().get(0);
+        SpellAbility manifestSA = soulSummons.getFirstSpellAbility();
 
         GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(manifestSA);
@@ -392,7 +392,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN2, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbility manifestSA = soulSummons.getSpellAbilities().get(0);
+        SpellAbility manifestSA = soulSummons.getFirstSpellAbility();
 
         GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(manifestSA);
@@ -628,7 +628,7 @@ public class GameSimulationTest extends SimulationTest {
 
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
 
-        SpellAbility callTheScionsSA = callTheScionsCard.getSpellAbilities().get(0);
+        SpellAbility callTheScionsSA = callTheScionsCard.getFirstSpellAbility();
 
         GameSimulator sim = createSimulator(p);
         int score = sim.simulateSpellAbility(callTheScionsSA).value;
@@ -1011,7 +1011,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(2, lilianaInPlay.getNetPower());
         AssertJUnit.assertEquals(3, lilianaInPlay.getNetToughness());
 
-        SpellAbility playLiliana = lilianaInHand.getSpellAbilities().get(0);
+        SpellAbility playLiliana = lilianaInHand.getFirstSpellAbility();
         GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(playLiliana);
         Game simGame = sim.getSimulatedGameState();
@@ -1041,7 +1041,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
         AssertJUnit.assertEquals(0, p.getCounters(CounterEnumType.ENERGY));
 
-        SpellAbility playTurtle = turtleCard.getSpellAbilities().get(0);
+        SpellAbility playTurtle = turtleCard.getFirstSpellAbility();
         GameSimulator sim = createSimulator(p);
         sim.simulateSpellAbility(playTurtle);
         Game simGame = sim.getSimulatedGameState();
@@ -1068,7 +1068,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
         AssertJUnit.assertTrue(p1.getManaPool().isEmpty());
 
-        SpellAbility playRitual = darkRitualCard.getSpellAbilities().get(0);
+        SpellAbility playRitual = darkRitualCard.getFirstSpellAbility();
         GameSimulator sim = createSimulator(p1);
         sim.simulateSpellAbility(playRitual);
         Game simGame = sim.getSimulatedGameState();
@@ -1078,7 +1078,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(3, simP1.getManaPool().getAmountOfColor(MagicColor.BLACK));
 
         Card darkConfidantCard2 = (Card) sim.getGameCopier().find(darkConfidantCard);
-        SpellAbility playDarkConfidant2 = darkConfidantCard2.getSpellAbilities().get(0);
+        SpellAbility playDarkConfidant2 = darkConfidantCard2.getFirstSpellAbility();
         Card deathriteCard2 = (Card) sim.getGameCopier().find(deathriteCard);
 
         GameSimulator sim2 = createSimulator(simP1);
@@ -1089,7 +1089,7 @@ public class GameSimulationTest extends SimulationTest {
         AssertJUnit.assertEquals(1, sim2P.getManaPool().getAmountOfColor(MagicColor.BLACK));
 
         Card deathriteCard3 = (Card) sim2.getGameCopier().find(deathriteCard2);
-        SpellAbility playDeathriteCard3 = deathriteCard3.getSpellAbilities().get(0);
+        SpellAbility playDeathriteCard3 = deathriteCard3.getFirstSpellAbility();
 
         GameSimulator sim3 = createSimulator(sim2P);
         sim3.simulateSpellAbility(playDeathriteCard3);
@@ -2120,14 +2120,14 @@ public class GameSimulationTest extends SimulationTest {
         GameSimulator sim = createSimulator(p0);
         Game simGame = sim.getSimulatedGameState();
 
-        SpellAbility actSA = actOfTreason.getSpellAbilities().get(0);
+        SpellAbility actSA = actOfTreason.getFirstSpellAbility();
         AssertJUnit.assertNotNull(actSA);
         actSA.setActivatingPlayer(p0);
         actSA.setTargetCard(serraAngel);
         sim.simulateSpellAbility(actSA);
         simGame.getAction().checkStateEffects(true);
 
-        SpellAbility pathSA = pathToExile.getSpellAbilities().get(0);
+        SpellAbility pathSA = pathToExile.getFirstSpellAbility();
         AssertJUnit.assertNotNull(pathSA);
         pathSA.setActivatingPlayer(p0);
         pathSA.setTargetCard(serraAngel);
@@ -2152,7 +2152,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbility playSa = c.getSpellAbilities().get(0);
+        SpellAbility playSa = c.getFirstSpellAbility();
         playSa.setActivatingPlayer(p);
 
         GameSimulator sim = createSimulator(p);
@@ -2185,7 +2185,7 @@ public class GameSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        SpellAbility playSa = cardEverAfter.getSpellAbilities().get(0);
+        SpellAbility playSa = cardEverAfter.getFirstSpellAbility();
         playSa.setActivatingPlayer(p);
         playSa.getTargets().add(cardWaywardServant);
         playSa.getTargets().add(cardRagingGoblin);
@@ -2677,7 +2677,7 @@ public class GameSimulationTest extends SimulationTest {
         Game simGame = sim.getSimulatedGameState();
 
         for (Card card : cards) {
-            SpellAbility a1 = card.getSpellAbilities().get(0);
+            SpellAbility a1 = card.getFirstSpellAbility();
             a1.setActivatingPlayer(p);
             sim.simulateSpellAbility(a1);
         }


### PR DESCRIPTION
Part of #11409 

kinda cleanup before Cache are added

i try to make each of them "before changes" - "changes" - "after rules" more uniform
See this comment: https://github.com/Card-Forge/forge/issues/11409#issuecomment-5307524964