### PR TITLE
Fix UnsupportedCharsetException: IBM437 crash on iOS during Zip extraction

### DIFF
--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadZipService.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadZipService.java
@@ -171,13 +171,21 @@ public class GuiDownloadZipService extends GuiDownloadService {
                 }
             }
 
-            final Charset charset = Charset.forName("IBM437");
+            Charset charset;
+            try {
+                charset = Charset.forName("IBM437");
+            } catch (java.nio.charset.UnsupportedCharsetException e) {
+                // Fallback for environments like iOS/RoboVM that lack legacy charsets
+                charset = java.nio.charset.StandardCharsets.UTF_8;
+            }
+
             ZipFile zipFile;
             try {
                 zipFile = new ZipFile(zipFilename, charset);
             } catch (Throwable e) { //some older Android versions need the old method
                 zipFile = new ZipFile(zipFilename);
             }
+
             final Enumeration<? extends ZipEntry> entries = zipFile.entries();
 
             if (progressBar != null) {


### PR DESCRIPTION

### Summary
Fixes an unhandled `java.nio.charset.UnsupportedCharsetException: IBM437` crash on iOS (RoboVM) when downloading and unzipping Net Decks in `GuiDownloadZipService`.

### Problem
RoboVM strips legacy DOS charsets (such as `IBM437`) on iOS to reduce binary size. Calling `Charset.forName("IBM437")` during ZIP extraction throws an unhandled `UnsupportedCharsetException`, causing Net Deck downloads to fail instantly:

```
java.nio.charset.UnsupportedCharsetException: IBM437
	at java.nio.charset.Charset.forName(Charset.java:313)
	at forge.gui.download.GuiDownloadZipService.extract(GuiDownloadZipService.java:174)
	at forge.gui.download.GuiDownloadZipService.downloadAndUnzip(GuiDownloadZipService.java:76)
```

### Fix
- Wrap `Charset.forName("IBM437")` in a `try-catch` block targeting `UnsupportedCharsetException`.
- Fall back gracefully to `StandardCharsets.UTF_8` on environments lacking legacy charset tables (e.g., iOS).
- Retain existing desktop & legacy Android behavior without regressions.

> [!NOTE]
> *Co-authored with assistance from Antigravity AI agent.*
