### PR TITLE
Fix/11167: Revamped input handling Android fix

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/stage/Console.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/Console.java
@@ -18,11 +18,13 @@ public class Console extends Window {
 
     public void toggle() {
         if (isVisible()) {
+            Forge.advFreezePlayerControls = false;
             setVisible(false);
             getStage().unfocus(input);
             Gdx.input.setOnscreenKeyboardVisible(false);
         } else {
             if (!Forge.advFreezePlayerControls) {
+                Forge.advFreezePlayerControls = true;
                 setVisible(true);
                 getStage().setKeyboardFocus(input);
             }
@@ -58,7 +60,6 @@ public class Console extends Window {
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 } else {
                                     index = 0;
-                                    textField.setText(commands.get(index));
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 }
                             } else if (!commands.isEmpty()) {
@@ -78,7 +79,7 @@ public class Console extends Window {
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 } else {
                                     index = commands.size - 1;
-                                    textField.setText(commands.get(index));
+                                    textField.setText("");
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 }
                             } else if (!commands.isEmpty()) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
@@ -137,13 +137,11 @@ public class GameHUD extends Stage {
                 if (MapStage.getInstance().isInMap()) {
                     if (MapStage.getInstance().isPaused())
                         return;
-                    MapStage.getInstance().getPlayerSprite().getMovementDirection().x += ((Touchpad) actor).getKnobPercentX();
-                    MapStage.getInstance().getPlayerSprite().getMovementDirection().y += ((Touchpad) actor).getKnobPercentY();
+                    MapStage.getInstance().setTouchKnobInput(((Touchpad) actor).getKnobPercentX(), ((Touchpad) actor).getKnobPercentY());
                 } else {
                     if (WorldStage.getInstance().isPaused())
                         return;
-                    WorldStage.getInstance().getPlayerSprite().getMovementDirection().x += ((Touchpad) actor).getKnobPercentX();
-                    WorldStage.getInstance().getPlayerSprite().getMovementDirection().y += ((Touchpad) actor).getKnobPercentY();
+                    WorldStage.getInstance().setTouchKnobInput(((Touchpad) actor).getKnobPercentX(), ((Touchpad) actor).getKnobPercentY());
                 }
             }
         });
@@ -280,6 +278,8 @@ public class GameHUD extends Stage {
     @Override
     public boolean touchUp(int screenX, int screenY, int pointer, int button) {
         touchpad.setVisible(false);
+        MapStage.getInstance().setTouchKnobInput(0, 0);
+        WorldStage.getInstance().setTouchKnobInput(0, 0);
         MapStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
         WorldStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
         return super.touchUp(screenX, screenY, pointer, button);

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -1,6 +1,5 @@
 package forge.adventure.stage;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.files.FileHandle;
@@ -387,29 +386,20 @@ public abstract class GameStage extends Stage {
             player.stop();
         } else {
             keyboardInput.setZero();
-            for (int key : KeyBinding.Left.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.x = -1;
-                    break;
-                }
+            if (KeyBinding.Left.isPressed()) {
+                keyboardInput.x -= 1;
             }
-            for (int key : KeyBinding.Right.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.x = 1;
-                    break;
-                }
+
+            if (KeyBinding.Right.isPressed()) {
+                keyboardInput.x += 1;
             }
-            for (int key : KeyBinding.Up.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.y = 1;
-                    break;
-                }
+
+            if (KeyBinding.Up.isPressed()) {
+                keyboardInput.y += 1;
             }
-            for (int key : KeyBinding.Down.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.y = -1;
-                    break;
-                }
+
+            if (KeyBinding.Down.isPressed()) {
+                keyboardInput.y -= 1;
             }
 
             // Input priority: touch > controller > keyboard

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -256,7 +256,6 @@ public abstract class GameStage extends Stage {
         showDialog();
     }
 
-
     public boolean axisMoved(Controller controller, int axisIndex, float value) {
         if (MapStage.getInstance().isDialogOnlyInput() || isPaused()) {
             return true;
@@ -271,7 +270,6 @@ public abstract class GameStage extends Stage {
         Fly
 
     }
-
 
     HashMap<PlayerModification, Float> currentModifications = new HashMap<>();
 
@@ -359,28 +357,24 @@ public abstract class GameStage extends Stage {
     @Override
     public final void act(float delta) {
         keyboardInput.setZero();
-
         for (int key : KeyBinding.Left.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.x = -1;
                 break;
             }
         }
-
         for (int key : KeyBinding.Right.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.x = 1;
                 break;
             }
         }
-
         for (int key : KeyBinding.Up.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.y = 1;
                 break;
             }
         }
-
         for (int key : KeyBinding.Down.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.y = -1;
@@ -388,9 +382,8 @@ public abstract class GameStage extends Stage {
             }
         }
 
-        Vector2 dir = new Vector2();
-
         // Input priority: touch > controller > keyboard
+        Vector2 dir = new Vector2();
         if (touchX >= 0 && touchInput.len() > 0.2f) {
             dir.set(touchInput);
 
@@ -466,7 +459,6 @@ public abstract class GameStage extends Stage {
     }
 
     abstract protected void onActing(float delta);
-
 
     @Override
     public boolean keyDown(int keycode) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -262,9 +262,6 @@ public abstract class GameStage extends Stage {
             return true;
         }
         controllerInput.set(controller.getAxis(0), -controller.getAxis(1));
-        if (player.getMovementDirection().len() < 0.2) {
-            player.stop();
-        }
         return true;
     }
 
@@ -390,7 +387,6 @@ public abstract class GameStage extends Stage {
                 break;
             }
         }
-
 
         Vector2 dir = new Vector2();
 

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -1,5 +1,6 @@
 package forge.adventure.stage;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.files.FileHandle;
@@ -76,6 +77,9 @@ public abstract class GameStage extends Stage {
     private float animationTimeout = 0;
     public static float maximumScrollDistance = 1.5f;
     public static float minimumScrollDistance = 0.3f;
+    private final Vector2 keyboardInput = new Vector2();
+    private final Vector2 controllerInput = new Vector2();
+    private final Vector2 touchInput = new Vector2();
 
     private String extraAnnouncement = "";
 
@@ -257,8 +261,7 @@ public abstract class GameStage extends Stage {
         if (MapStage.getInstance().isDialogOnlyInput() || isPaused()) {
             return true;
         }
-        player.getMovementDirection().x = controller.getAxis(0);
-        player.getMovementDirection().y = -controller.getAxis(1);
+        controllerInput.set(controller.getAxis(0), -controller.getAxis(1));
         if (player.getMovementDirection().len() < 0.2) {
             player.stop();
         }
@@ -358,6 +361,55 @@ public abstract class GameStage extends Stage {
 
     @Override
     public final void act(float delta) {
+        keyboardInput.setZero();
+
+        for (int key : KeyBinding.Left.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.x = -1;
+                break;
+            }
+        }
+
+        for (int key : KeyBinding.Right.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.x = 1;
+                break;
+            }
+        }
+
+        for (int key : KeyBinding.Up.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.y = 1;
+                break;
+            }
+        }
+
+        for (int key : KeyBinding.Down.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.y = -1;
+                break;
+            }
+        }
+
+
+        Vector2 dir = new Vector2();
+
+        // Input priority: touch > controller > keyboard
+        if (touchX >= 0 && touchInput.len() > 0.2f) {
+            dir.set(touchInput);
+
+        } else if (controllerInput.len() > 0.2f) {
+            dir.set(controllerInput);
+
+        } else {
+            dir.set(keyboardInput);
+        }
+        if (dir.len() < 0.01f) {
+            player.stop();
+        } else {
+            player.getMovementDirection().set(dir);
+        }
+
         super.act(delta);
 
         if (animationTimeout >= 0) {
@@ -379,7 +431,6 @@ public abstract class GameStage extends Stage {
             return;
         }
 
-
         if (onEndAction != null) {
 
             onEndAction.run();
@@ -388,14 +439,15 @@ public abstract class GameStage extends Stage {
 
         if (touchX >= 0) {
             Vector2 target = this.screenToStageCoordinates(new Vector2(touchX, touchY));
+
             target.x -= player.getWidth() / 2f;
             Vector2 diff = target.sub(player.pos());
 
             if (diff.len() < 2) {
-                diff.setZero();
-                player.stop();
+                touchInput.setZero();
+            } else {
+                touchInput.set(diff);
             }
-            player.setMovementDirection(diff);
         }
         camera.position.x = Math.min(Math.max(Scene.getIntendedWidth() / 2f, player.pos().x), getViewport().getWorldWidth() - Scene.getIntendedWidth() / 2f);
         camera.position.y = Math.min(Math.max(Scene.getIntendedHeight() / 2f, player.pos().y), getViewport().getWorldHeight() - Scene.getIntendedHeight() / 2f);
@@ -426,16 +478,16 @@ public abstract class GameStage extends Stage {
         if (isPaused())
             return true;
         if (KeyBinding.Left.isPressed(keycode)) {
-            player.getMovementDirection().x = -1;
+            keyboardInput.x = -1;
         }
         if (KeyBinding.Right.isPressed(keycode)) {
-            player.getMovementDirection().x = +1;
+            keyboardInput.x = +1;
         }
         if (KeyBinding.Up.isPressed(keycode)) {
-            player.getMovementDirection().y = +1;
+            keyboardInput.y = +1;
         }
         if (KeyBinding.Down.isPressed(keycode)) {
-            player.getMovementDirection().y = -1;
+            keyboardInput.y = -1;
         }
         if (keycode == Input.Keys.F5)//todo config
         {
@@ -562,12 +614,10 @@ public abstract class GameStage extends Stage {
         if (isPaused())
             return true;
         if (KeyBinding.Left.isPressed(keycode) || KeyBinding.Right.isPressed(keycode)) {
-            player.getMovementDirection().x = 0;
             if (!player.isMoving())
                 stop();
         }
         if (KeyBinding.Down.isPressed(keycode) || KeyBinding.Up.isPressed(keycode)) {
-            player.getMovementDirection().y = 0;
             if (!player.isMoving())
                 stop();
         }

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -79,6 +79,7 @@ public abstract class GameStage extends Stage {
     private final Vector2 keyboardInput = new Vector2();
     private final Vector2 controllerInput = new Vector2();
     private final Vector2 touchInput = new Vector2();
+    protected final Vector2 touchKnobInput = new Vector2();
 
     private String extraAnnouncement = "";
 
@@ -263,6 +264,10 @@ public abstract class GameStage extends Stage {
         return true;
     }
 
+    public void setTouchKnobInput(float x, float y) {
+        touchKnobInput.set(x, y);
+    }
+
     enum PlayerModification {
         Sprint,
         Hide,
@@ -382,6 +387,7 @@ public abstract class GameStage extends Stage {
             keyboardInput.setZero();
             controllerInput.setZero();
             touchInput.setZero();
+            touchKnobInput.setZero();
             player.getMovementDirection().setZero();
             player.stop();
         } else {
@@ -406,10 +412,10 @@ public abstract class GameStage extends Stage {
             Vector2 dir = new Vector2();
             if (touchX >= 0 && touchInput.len() > 0.2f) {
                 dir.set(touchInput);
-
             } else if (controllerInput.len() > 0.2f) {
                 dir.set(controllerInput);
-
+            } else if (touchKnobInput.len() > 0.2f) {
+                dir.set(touchKnobInput);
             } else {
                 dir.set(keyboardInput);
             }
@@ -582,6 +588,7 @@ public abstract class GameStage extends Stage {
         WorldStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
         MapStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
         touchInput.setZero();
+        touchKnobInput.setZero();
         keyboardInput.setZero();
         controllerInput.setZero();
         touchX = -1;

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -356,55 +356,13 @@ public abstract class GameStage extends Stage {
 
     @Override
     public final void act(float delta) {
-        keyboardInput.setZero();
-        for (int key : KeyBinding.Left.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.x = -1;
-                break;
-            }
-        }
-        for (int key : KeyBinding.Right.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.x = 1;
-                break;
-            }
-        }
-        for (int key : KeyBinding.Up.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.y = 1;
-                break;
-            }
-        }
-        for (int key : KeyBinding.Down.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.y = -1;
-                break;
-            }
-        }
-
-        // Input priority: touch > controller > keyboard
-        Vector2 dir = new Vector2();
-        if (touchX >= 0 && touchInput.len() > 0.2f) {
-            dir.set(touchInput);
-
-        } else if (controllerInput.len() > 0.2f) {
-            dir.set(controllerInput);
-
-        } else {
-            dir.set(keyboardInput);
-        }
-        if (dir.len() < 0.01f) {
-            player.stop();
-        } else {
-            player.getMovementDirection().set(dir);
-        }
-
         super.act(delta);
 
         if (animationTimeout >= 0) {
             animationTimeout -= delta;
             return;
         }
+
         Array<PlayerModification> modsToRemove = new Array<>();
         for (Map.Entry<PlayerModification, Float> mod : currentModifications.entrySet()) {
             mod.setValue(mod.getValue() - delta);
@@ -416,28 +374,75 @@ public abstract class GameStage extends Stage {
             onRemoveEffect(mod);
         }
 
-        if (isPaused()) {
-            return;
-        }
-
         if (onEndAction != null) {
-
             onEndAction.run();
             onEndAction = null;
         }
 
-        if (touchX >= 0) {
-            Vector2 target = this.screenToStageCoordinates(new Vector2(touchX, touchY));
+        if (isPaused() || isDialogOnlyInput() || Forge.advFreezePlayerControls) {
+            keyboardInput.setZero();
+            controllerInput.setZero();
+            touchInput.setZero();
+            player.getMovementDirection().setZero();
+            player.stop();
+        } else {
+            keyboardInput.setZero();
+            for (int key : KeyBinding.Left.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.x = -1;
+                    break;
+                }
+            }
+            for (int key : KeyBinding.Right.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.x = 1;
+                    break;
+                }
+            }
+            for (int key : KeyBinding.Up.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.y = 1;
+                    break;
+                }
+            }
+            for (int key : KeyBinding.Down.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.y = -1;
+                    break;
+                }
+            }
 
-            target.x -= player.getWidth() / 2f;
-            Vector2 diff = target.sub(player.pos());
+            // Input priority: touch > controller > keyboard
+            Vector2 dir = new Vector2();
+            if (touchX >= 0 && touchInput.len() > 0.2f) {
+                dir.set(touchInput);
 
-            if (diff.len() < 2) {
-                touchInput.setZero();
+            } else if (controllerInput.len() > 0.2f) {
+                dir.set(controllerInput);
+
             } else {
-                touchInput.set(diff);
+                dir.set(keyboardInput);
+            }
+            if (dir.len() < 0.01f) {
+                player.stop();
+            } else {
+                player.getMovementDirection().set(dir);
+            }
+
+            if (touchX >= 0) {
+                Vector2 target = this.screenToStageCoordinates(new Vector2(touchX, touchY));
+                target.x -= player.getWidth() / 2f;
+                Vector2 diff = target.sub(player.pos());
+
+                if (diff.len() < 2) {
+                    touchInput.setZero();
+                    player.stop();
+                } else {
+                    touchInput.set(diff);
+                }
             }
         }
+
         camera.position.x = Math.min(Math.max(Scene.getIntendedWidth() / 2f, player.pos().x), getViewport().getWorldWidth() - Scene.getIntendedWidth() / 2f);
         camera.position.y = Math.min(Math.max(Scene.getIntendedHeight() / 2f, player.pos().y), getViewport().getWorldHeight() - Scene.getIntendedHeight() / 2f);
 
@@ -586,6 +591,9 @@ public abstract class GameStage extends Stage {
     public void stop() {
         WorldStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
         MapStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
+        touchInput.setZero();
+        keyboardInput.setZero();
+        controllerInput.setZero();
         touchX = -1;
         touchY = -1;
         player.stop();
@@ -602,10 +610,12 @@ public abstract class GameStage extends Stage {
         if (isPaused())
             return true;
         if (KeyBinding.Left.isPressed(keycode) || KeyBinding.Right.isPressed(keycode)) {
+            player.getMovementDirection().x = 0;
             if (!player.isMoving())
                 stop();
         }
         if (KeyBinding.Down.isPressed(keycode) || KeyBinding.Up.isPressed(keycode)) {
+            player.getMovementDirection().y = 0;
             if (!player.isMoving())
                 stop();
         }

--- a/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
@@ -230,8 +230,8 @@ public class WorldStage extends GameStage implements SaveFileContent {
 
     public void loadPOI(PointOfInterest poi) {
         try {
-            TileMapScene.instance().load(poi);
             stop();
+            TileMapScene.instance().load(poi);
             TileMapScene.instance().setFromWorldMap(true);
             Forge.switchScene(TileMapScene.instance());
         } catch (Exception e) {
@@ -266,7 +266,7 @@ public class WorldStage extends GameStage implements SaveFileContent {
         }
 
         World world = WorldSave.getCurrentSave().getWorld();
-        int currentBiome = World.highestBiome(world.getBiome((int) player.getX() / world.getTileSize(), (int) player.getY() / world.getTileSize()));
+        int currentBiome = World.highestBiome(world.getBiome((int) ((player.getX() + player.getWidth() / 2f) / world.getTileSize()), (int) (player.getY() / world.getTileSize())));
         List<BiomeData> biomeData = WorldSave.getCurrentSave().getWorld().getData().GetBiomes();
         float sprintingMod = currentModifications.containsKey(PlayerModification.Sprint) ? 2 : 1;
         if (biomeData.size() <= currentBiome) {// "if isOnRoad

--- a/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
+++ b/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
@@ -49,6 +49,10 @@ public enum KeyBinding {
         return false;
     }
 
+    public int[] getBindings() {
+        return bindings;
+    }
+
     // The controller binding always has index 1.
     final static String controllerPrefix = "XBox_";
 

--- a/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
+++ b/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
@@ -1,5 +1,6 @@
 package forge.adventure.util;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerMapping;
@@ -34,6 +35,15 @@ public enum KeyBinding {
         this.bindings = bindings;
     }
 
+    public boolean isPressed() {
+        for (int key : bindings) {
+            if (Gdx.input.isKeyPressed(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean isPressed(int key) {
         return isPressed(key, null);
     }
@@ -47,10 +57,6 @@ public enum KeyBinding {
             }
         }
         return false;
-    }
-
-    public int[] getBindings() {
-        return bindings;
     }
 
     // The controller binding always has index 1.


### PR DESCRIPTION
Split off from: [Archipelago PR](https://github.com/Card-Forge/forge/pull/11167)
Builds further on the groundwork laid in [this PR](https://github.com/Card-Forge/forge/pull/11170)
Fixes an issue found in [this PR](https://github.com/Card-Forge/forge/pull/11168) which was reverted.

An issue was found with my previous PR (linked above) that was causing players not to be able to move correctly, enter POIs or enter battles on Android. At the time, I was not able to build the Android version of the app locally so I couldn't test the platform, that's now been resolved and I was able to reproduce the observed issue as well as fix it.

It turns out Android movement input is handled by a different mechanism compared to desktops, namely the `touchPad` and more accurately its `knob` member. 

In this PR I have fixed the issues described above as well as re-staged the commits reverted earlier that improve input handling. Only the changes made from 22327ec7 on out should be reviewed as everything before that has already been looked at in the abovementioned PR.

### Android input bugfix
- Added a `touchKnobInput` input vector to `GameStage.java`
- Changed the `GameHUD.java`'s touchpad listener so it reports player input to the new `touchKnobInput` vector in `GameStage.java`
- Added `touchKnobInput` to the input priority ranking created in the reverted PR above such that the priority is: mouse/touch > controller > touchKnob > keyboard.