### PR TITLE
Include previously missing shards when fetching land

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiCardMemory.java
+++ b/forge-ai/src/main/java/forge/ai/AiCardMemory.java
@@ -190,14 +190,14 @@ public class AiCardMemory {
      * @param set the memory set to inspect.
      * @return true, if the given memory set contains no remembered cards.
      */
-    public boolean isMemorySetEmpty(MemorySet set) {
+    public boolean isMemorySetEmpty(MemoryType set) {
         return set == null || getMemorySet(set).isEmpty();
     }
     
     /**
      * Clears the given memory set.
      */
-    public void clearMemorySet(MemorySet set) {
+    public void clearMemorySet(MemoryType set) {
         if (set != null) {
             getMemorySet(set).clear();
         }
@@ -207,7 +207,7 @@ public class AiCardMemory {
      * Clears all memory sets stored in this card memory for the given player.
      */
     public void clearAllRemembered() {
-        for (MemorySet memSet : MemorySet.values()) {
+        for (MemoryType memSet : memoryMap.get().keySet()) {
             clearMemorySet(memSet);
         }
     }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -801,6 +801,9 @@ public class ComputerUtilMana {
             manapool.refundMana(manaSpentToPay);
             if (test) {
                 resetPayment(paymentList);
+                // TODO should probably only record when canPlayAndPayFor
+                // TODO doesn't count multiple copies filtered by dedupeCards
+                AiCardMemory.getMemorySet(ai, AiCardMemory.MemorySetMana.UNPAID_COSTS).add(cost);
             } else {
                 System.out.println("ComputerUtilMana: payManaCost() cost was not paid for " + sa + " (" +  sa.getHostCard().getName() + "). Didn't find what to pay for " + toPay);
                 sa.setSkip(true);

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -2,11 +2,13 @@ package forge.ai.ability;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
 
 import forge.ai.*;
 import forge.card.CardType;
 import forge.card.MagicColor;
+import forge.card.mana.ManaCostShard;
 import forge.game.Game;
 import forge.game.GameEntity;
 import forge.game.GameObject;
@@ -17,6 +19,7 @@ import forge.game.card.*;
 import forge.game.combat.Combat;
 import forge.game.cost.*;
 import forge.game.keyword.Keyword;
+import forge.game.mana.ManaCostBeingPaid;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -548,13 +551,33 @@ public class ChangeZoneAi extends SpellAbilityAi {
             }
         }
 
+        // check if any SA we wanted to pay for had missing shards
+        Set<ManaCostBeingPaid> unpaid = AiCardMemory.getMemorySet(ai, AiCardMemory.MemorySetMana.UNPAID_COSTS);
+        Map<String, Integer> basicTypes = Maps.newHashMap();
+        if (unpaid != null) {
+            for (ManaCostBeingPaid cost : unpaid) {
+                for (ManaCostShard shard : cost.getUnpaidShards()) {
+                    for (MagicColor.Color col : shard.getColor()) {
+                        if (col == MagicColor.Color.COLORLESS) {
+                            continue;
+                        }
+                        basicTypes.merge(col.getBasicLandType(), 1, Integer::sum);
+                    }
+                }
+            }
+        }
+
         // Which basic land is least available from hand and play, that I still
         // have in my deck
         int minSize = Integer.MAX_VALUE;
         String minType = null;
 
         for (String b : basics) {
-            final int num = CardLists.getType(combined, b).size();
+            // average between well rounded mana base and shards that were missing
+            int num = CardLists.getType(combined, b).size();
+            if (!basicTypes.isEmpty()) {
+                num /= basicTypes.getOrDefault(b, 0) + 1;
+            }
             if (num < minSize) {
                 minType = b;
                 minSize = num;

--- a/forge-core/src/main/java/forge/card/mana/ManaCostShard.java
+++ b/forge-core/src/main/java/forge/card/mana/ManaCostShard.java
@@ -311,7 +311,7 @@ public enum ManaCostShard {
     }
 
     public boolean isGeneric() {
-    	return isOfKind(ManaAtom.GENERIC)|| isOfKind(ManaAtom.IS_X) || this.isSnow() || this.isOr2Generic();
+    	return isOfKind(ManaAtom.GENERIC) || isOfKind(ManaAtom.IS_X) || this.isSnow() || this.isOr2Generic();
     }
     public boolean isOr2Generic() {
         return isOfKind(ManaAtom.OR_2_GENERIC);

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -699,11 +699,11 @@ public class GameAction {
             stAb.setActiveZone(EnumSet.of(ZoneType.Command));
             // needed for ETB lookahead like Bronzehide Lion
             stAb.putParam("AffectedZone", "All");
-            SpellAbilityEffect.addForgetOnMovedTrigger(eff, "Battlefield");
             eff.getOwner().getZone(ZoneType.Command).add(eff);
         }
 
         eff.addRemembered(copied);
+        copied.addLeavesPlayCommand(() -> cleanStaticEffect(eff, copied));
         // refresh needed for canEnchant checks
         checkStaticAbilities(false, Sets.newHashSet(copied), new CardCollection(copied));
         return eff;

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -522,7 +522,7 @@ public abstract class SpellAbilityEffect {
     public static void addForgetOnMovedTrigger(final Card card, final String zone) {
         String trig = "Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ " + zone + " | ExcludedDestinations$ Stack,Exile | Destination$ Any | TriggerZones$ Command | Static$ True";
         // CR 400.8 Exiled card becomes new object when it's exiled
-        String trig2 = "Mode$ Exiled | ValidCard$ Card.IsRemembered | ValidCause$ SpellAbility.!EffectSource | TriggerZones$ Command | Static$ True";
+        String trig2 = "Mode$ Exiled | ValidCard$ Card.IsRemembered | ValidCause$ SpellAbility.!EffectSourceAbility | TriggerZones$ Command | Static$ True";
 
         final Trigger parsedTrigger = TriggerHandler.parseTrigger(trig, card, true);
         final Trigger parsedTrigger2 = TriggerHandler.parseTrigger(trig2, card, true);

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -1415,6 +1415,11 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                     movedCard = game.getAction().exile(c, sa, moveParams);
 
                     handleExiledWith(movedCard, sa);
+                    final CardCollectionView lastStateBattlefield = triggerList.getLastStateBattlefield();
+                    if (destination.equals(ZoneType.Exile) && lastStateBattlefield.contains(c) && source.equals(c)) {
+                        // support Wormfang Newt returning itself
+                        handleExiledWith(movedCard, sa, lastStateBattlefield.get(c));
+                    }
 
                     if (sa.hasParam("ExileFaceDown")) {
                         movedCard.turnFaceDown(true);

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityProperty.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityProperty.java
@@ -153,7 +153,8 @@ public class SpellAbilityProperty {
             if (source.getEffectSourceAbility() == null) {
                 return false;
             }
-            if (!sa.equals(source.getEffectSourceAbility().getRootAbility().getOriginalAbility())) {
+            SpellAbility root = source.getEffectSourceAbility().getRootAbility();
+            if (!sa.equals(Objects.requireNonNullElse(root.getOriginalAbility(), root))) {
                 return false;
             }
         } else if (property.equals("LastChapter")) {

--- a/forge-gui/res/cardsfolder/w/wormfang_newt.txt
+++ b/forge-gui/res/cardsfolder/w/wormfang_newt.txt
@@ -4,7 +4,6 @@ Types:Creature Nightmare Salamander Beast
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile a land you control.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME leaves the battlefield, return the exiled card to the battlefield under its owner's control.
-SVar:TrigExile:DB$ ChooseCard | Choices$ Land.YouCtrl | Mandatory$ True | Amount$ 1 | ChoiceTitle$ Choose a land to exile | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ ChosenCard | RememberChanged$ True
-SVar:TrigReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield
+SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Hidden$ True | Mandatory$ True | ChangeType$ Land.YouCtrl
+SVar:TrigReturn:DB$ ChangeZone | Defined$ ExiledWith | Origin$ Exile | Destination$ Battlefield
 Oracle:When Wormfang Newt enters, exile a land you control.\nWhen Wormfang Newt leaves the battlefield, return the exiled card to the battlefield under its owner's control.

--- a/forge-gui/res/cardsfolder/w/wormfang_turtle.txt
+++ b/forge-gui/res/cardsfolder/w/wormfang_turtle.txt
@@ -2,10 +2,8 @@ Name:Wormfang Turtle
 ManaCost:2 U
 Types:Creature Nightmare Turtle Beast
 PT:2/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChooseExile | TriggerDescription$ When CARDNAME enters, exile a land you control.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile a land you control.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME leaves the battlefield, return the exiled card to the battlefield under its owner's control.
-SVar:TrigChooseExile:DB$ ChooseCard | Choices$ Land.YouCtrl | Mandatory$ True | Amount$ 1 | ChoiceTitle$ Choose a land to exile | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ ChosenCard | RememberChanged$ True
-SVar:TrigReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Hidden$ True | Mandatory$ True | ChangeType$ Land.YouCtrl
+SVar:TrigReturn:DB$ ChangeZone | Defined$ ExiledWith | Origin$ Exile | Destination$ Battlefield
 Oracle:When Wormfang Turtle enters, exile a land you control.\nWhen Wormfang Turtle leaves the battlefield, return the exiled card to the battlefield under its owner's control.


### PR DESCRIPTION
When AI fails to pay a cost we already know it wanted to play its SA, so it's cheap to remember and try to fetch for one of the unavailable colors.

The overall weighting may eventually need further tweaking, this focuses more on getting the connecting parts right.

Closes #11655