### PR TITLE
Improve High Tide AI usage

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -173,6 +173,11 @@ public class EffectAi extends SpellAbilityAi {
                 randomReturn = saCreature != null;
             } else if (logic.equals("Always")) {
                 randomReturn = true;
+            } else if (logic.equals("HighTide")) {
+                if (!phase.is(PhaseType.MAIN1, ai) && !phase.is(PhaseType.MAIN2, ai)) {
+                    return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                }
+                randomReturn = ManaAi.doManaRitualLogic(ai, sa, false);
             } else if (logic.equals("Main1")) {
                 if (phase.getPhase().isBefore(PhaseType.MAIN1)) {
                     return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);

--- a/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
@@ -127,7 +127,7 @@ public class ManaAi extends SpellAbilityAi {
         return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
     }
     
-    // Dark Ritual and other similar instants/sorceries that add mana to mana pool
+    // Dark Ritual, High Tide, and other similar spells that increase available mana
     public static boolean doManaRitualLogic(Player ai, SpellAbility sa, boolean fromTrigger) {
         final Card host = sa.getHostCard();
         final String logic = sa.getParamOrDefault("AILogic", "");
@@ -147,12 +147,15 @@ public class ManaAi extends SpellAbilityAi {
         
         CardCollection manaSources = ComputerUtilMana.getAvailableManaSources(ai, true);
         int numManaSrcs = manaSources.size();
-        int manaReceived = sa.hasParam("Amount") ? AbilityUtils.calculateAmount(host, sa.getParam("Amount"), sa) : 1;
-        manaReceived *= sa.getParam("Produced").split(" ").length;
+        final boolean highTide = "HighTide".equals(logic);
+        int manaReceived = highTide
+                ? CardLists.count(ai.getCardsIn(ZoneType.Battlefield), CardPredicates.UNTAPPED.and(CardPredicates.isType("Island"))) - 1
+                : (sa.hasParam("Amount") ? AbilityUtils.calculateAmount(host, sa.getParam("Amount"), sa) : 1)
+                        * sa.getParam("Produced").split(" ").length;
 
         int selfCost = sa.getRootAbility().getPayCosts().getCostMana() != null ? sa.getRootAbility().getPayCosts().getCostMana().getMana().getCMC() : 0;
 
-        String produced = sa.getParam("Produced");
+        String produced = highTide ? "U" : sa.getParam("Produced");
         byte producedColor = produced.equals("Any") ? MagicColor.ALL_COLORS : MagicColor.fromName(produced);
 
         int numCounters = 0;

--- a/forge-gui/res/cardsfolder/h/high_tide.txt
+++ b/forge-gui/res/cardsfolder/h/high_tide.txt
@@ -1,8 +1,8 @@
 Name:High Tide
 ManaCost:U
 Types:Instant
-A:SP$ Effect | Triggers$ IslandTrigger | SpellDescription$ Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.
+A:SP$ Effect | Triggers$ IslandTrigger | AILogic$ HighTide | AINoRecursiveCheck$ True | SpellDescription$ Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.
 SVar:IslandTrigger:Mode$ TapsForMana | ValidCard$ Island | Execute$ TrigMana | Static$ True | TriggerDescription$ Whenever a player taps an Island for mana, that player adds an additional {U}.
 SVar:TrigMana:DB$ Mana | Produced$ U | Amount$ 1 | Defined$ TriggeredActivator
-AI:RemoveDeck:All
+AI:RemoveDeck:Random
 Oracle:Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.


### PR DESCRIPTION
- We are preparing Fallen Empires Adventure dungeons whose authored AI decks use High Tide, which is currently excluded by `AI:RemoveDeck:All`.
- Add dedicated `HighTide` handling for its effect-based spell during the AI controller main phases, delegating payoff selection to the existing mana-ritual heuristic.
- Keep the card script schema-truthful. The AI derives the estimated net gain directly as the number of untapped Island lands minus the Island used to cast High Tide. This includes nonbasic lands with the Island subtype.
- Replace `AI:RemoveDeck:All` with `AI:RemoveDeck:Random`, allowing authored AI decks to use High Tide while keeping it out of generated decks that may lack sufficient Islands or worthwhile fixed-cost payoffs. This is especially important because High Tide also benefits opposing Islands.
- The existing ritual heuristic holds High Tide without a useful fixed-cost payoff and casts it when the additional mana unlocks one. X-cost spell planning remains outside this change.
- Verified with normal AI scenarios: with three Islands, Tundra, and Time Spiral, High Tide is selected first; without a payoff it is held; during an opponent main phase it is held. Existing Dark Ritual selection and mana-resolution scenarios also pass.