### PR TITLE
Replace a racy FCollection test with a deterministic one

### DIFF
--- a/forge-gui-desktop/src/test/java/forge/FCollectionTest.java
+++ b/forge-gui-desktop/src/test/java/forge/FCollectionTest.java
@@ -6,7 +6,6 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.testng.Assert.assertEquals;
 
@@ -39,25 +38,27 @@ public class FCollectionTest {
             i++;
         }
         assertEquals(cc.size(), 1);
-    }*/// Commented out since we use synchronized collection and it doesn't support modification while iteration
+    }*/// Commented out since the collection doesn't support modification while iterating over it directly
 
+    /**
+     * {@link forge.util.collect.FCollection#threadSafeIterable()} hands out a snapshot, so removing
+     * from the collection while looping over it neither throws nor skips an element.
+     */
     @Test
-    void testCompletableFuture() {
+    void testRemoveWhileIterating() {
         List<Card> cards = new ArrayList<>();
         for (int i = 1; i < 5; i++)
             cards.add(new Card(i, null));
         CardCollection cc = new CardCollection(cards);
-        List<CompletableFuture<Integer>> futures = new ArrayList<>();
+        int seen = 0;
         for (Card c : cc.threadSafeIterable()) {
-            futures.add(CompletableFuture.supplyAsync(() -> {
-                if (c.getId() % 2 > 0)
-                    cc.remove(c);
-                return 0;
-            }));
+            seen++;
+            if (c.getId() % 2 > 0)
+                cc.remove(c);
         }
-        CompletableFuture<?>[] futuresArray = futures.toArray(new CompletableFuture<?>[0]);
-        CompletableFuture.allOf(futuresArray).join();
-        futures.clear();
+        assertEquals(seen, 4);
         assertEquals(cc.size(), 2);
+        for (Card c : cc)
+            assertEquals(c.getId() % 2, 0);
     }
 }


### PR DESCRIPTION
`FCollectionTest.testCompletableFuture` fails intermittently in CI with `expected [2] but found [3]`.

The test removes from one `CardCollection` on four threads at once and asserts the resulting size. That was correct when it was written in 0854fbb9, where every `FCollection` mutator was guarded by an explicit `synchronized (lock)`. It stopped being correct two weeks later:

| commit | |
|---|---|
| 0854fbb9 | custom implementation, `synchronized (lock)` on every mutator — test added here |
| a0cad5fa (#6657) | lock replaced with `Collections.synchronized{Set,List}` |
| b858b48f | wrappers dropped, after 36f0021c restored `threadSafeIterable` |

`Collections.synchronizedList` makes individual calls atomic, but `remove` is a compound update of two collections, so another thread can interleave between `set.remove` and `list.remove` — and wrapping never stopped iteration throwing `ConcurrentModificationException`. Stressing each version 300k times with the test body of its day: the lock version is clean, 300000/300000; #6657's gives 1261 CMEs and one wrong size. So the guarantee has been gone since #6657, and the wrappers dropped in b858b48f were not providing it.

`threadSafeIterable` fixes iteration, by handing out a copy. It does not make mutation atomic — which is why this assertion kept failing after the CME it originally masked had gone away.

It has also become more visible recently: with four elements the hashed path from #11431 is never built, so `remove` is now a single `ArrayList.remove` and the two threads overlap almost exactly. Measured the same way, 2 bad outcomes per million before that change and 79 after.

This replaces the test with the guarantee that does hold: the snapshot lets a loop remove from the collection it is iterating without throwing or skipping an element. It is single-threaded, so there is no race left to lose — 100k runs give one outcome. Delete the `threadSafeIterable()` call and the same loop throws `ConcurrentModificationException`, so the assertions are load-bearing.

Worth keeping rather than just deleting: 23 call sites depend on that copy, and it was removed once already (5dc84a68, reasoning that the CopyOnWriteArrayList backing made it redundant) two days before that backing was itself replaced.

Suite 357/0/6, checkstyle clean.

Written with Claude Opus 5.
