### PR TITLE
Improve AI evaluation of permanent animations

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/AnimateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AnimateAi.java
@@ -196,6 +196,13 @@ public class AnimateAi extends SpellAbilityAi {
                         bFlag = true;
                     }
                 }
+                if (!bFlag && "Permanent".equals(sa.getParam("Duration"))) {
+                    // Account for improvements represented by other animation changes, such as
+                    // removing defender or adding an unblockable static ability.
+                    final Card animatedCopy = becomeAnimated(c, sa);
+                    bFlag = ComputerUtilCard.evaluateCreature(animatedCopy)
+                            > ComputerUtilCard.evaluateCreature(c);
+                }
             }
 
             if (!isSorcerySpeed(sa, aiPlayer) && !"Permanent".equals(sa.getParam("Duration"))) {


### PR DESCRIPTION
The AI does not use creature abilities that cause permanent changes to the creature except for specific changes like increasing power and toughness. One example is that the AI will never use the first ability on Surge Engine even if it has the mana to do so. This change makes it so that if the creature's ability permanently increases the evaluation value of the creature, then the ability will be considered for use.