### PR TITLE
Resolve CardForge#11705 - Misaligned scrolling labels on New Adventure menu

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/Controls.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Controls.java
@@ -153,6 +153,7 @@ public class Controls {
             minScrollDuration = MIN_SCROLL_DURATION_DEFAULT;
             this.clip(true);
             this.getTextraLabel().setWrap(false);
+            this.align(Align.left);
             this.manageAnimation();
         }
 
@@ -245,19 +246,19 @@ public class Controls {
         @Override
         public void setTextraLabel(TextraLabel label) {
             super.setTextraLabel(label);
-            this.manageAnimation();
+            this.invalidate();
         }
 
         @Override
         public void setText(@Null String text) {
             super.setText(text);
-            this.manageAnimation();
+            this.invalidate();
         }
 
         @Override
         public void setStyle(Button.ButtonStyle style, boolean makeGridGlyphs) {
             super.setStyle(style, makeGridGlyphs);
-            this.manageAnimation();
+            this.invalidate();
         }
 
         @Override


### PR DESCRIPTION
Resolves #11705 by properly invalidating the layout from the MarqueeButton text/style setters and setting the label alignment in the constructor to get things lined up.

Only place that uses this button is the New Game menu so it shouldn't break anything else.

Fixed behavior: https://github.com/user-attachments/assets/dc82a02b-07a0-4dbd-b742-7b054813d527

