### PR TITLE
Warn when selecting undersized Adventure decks

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
@@ -11,8 +11,11 @@ import com.github.tommyettinger.textra.TextraLabel;
 import forge.Forge;
 import forge.adventure.player.AdventurePlayer;
 import forge.adventure.stage.GameHUD;
+import forge.adventure.util.Config;
 import forge.adventure.util.Controls;
 import forge.adventure.util.Current;
+import forge.deck.Deck;
+import forge.deck.DeckFormat;
 
 public class DeckSelectScene extends UIScene {
     private final IntMap<TextraButton> buttons = new IntMap<>();
@@ -241,5 +244,39 @@ public class DeckSelectScene extends UIScene {
         DeckEditScene editScene = DeckEditScene.getInstance();
         editScene.loadEvent(null);
         Forge.switchScene(editScene);
+    }
+
+    @Override
+    public boolean back() {
+        Deck deck = Current.player().getSelectedDeck();
+        int minimumDeckSize = Current.player().isCommanderMode()
+                ? DeckFormat.Commander.getMainRange().getMinimum()
+                : Config.instance().getConfigData().minDeckSize;
+        int mainDeckSize = deck.getMain().countAll();
+
+        if (Current.player().isCommanderMode()) {
+            mainDeckSize += Math.max(0, deck.getCommanders().size() - 1);
+        }
+
+        if (mainDeckSize < minimumDeckSize) {
+            Dialog warningDialog = createGenericDialog(
+                    null,
+                    null,
+                    Forge.getLocalizer().getMessage("lblContinue"),
+                    Forge.getLocalizer().getMessage("lblCancel"),
+                    () -> {
+                        removeDialog();
+                        super.back();
+                    },
+                    this::removeDialog);
+            TextraLabel warningLabel = Controls.newTextraLabel(
+                    Forge.getLocalizer().getMessage("lblAdventureDeckSelectionWarning", minimumDeckSize));
+            warningLabel.setWrap(true);
+            warningDialog.getContentTable().add(warningLabel).width(Math.min(400f, getIntendedWidth() - 40f));
+            showDialog(warningDialog);
+            return true;
+        }
+
+        return super.back();
     }
 }

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -3887,6 +3887,7 @@ lblEffectDialogDescription=An diesem Ort fließen seltsame magische Energien...
 lblEffectDataHeader=Alle Gegner erhalten:
 lblDefeatedDescription=Sie sind besiegt und können nicht weitermachen. Mit letzter Kraft versuchen Sie, aus dem Gebiet zu entkommen.
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Umgekehrte Eingabeaufforderungsschaltflächen
 nlReversePromptButton=Wenn diese Option aktiviert ist, sind die Schaltflächen „OK“ und „Cancel“ vertauscht.
 lblPrepareDatabase=Datenbank vorbereiten...

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -3578,6 +3578,7 @@ lblEffectDialogDescription=Strange magical energies flow within this place...
 lblEffectDataHeader=All opponents get:
 lblDefeatedDescription=Defeated and unable to continue, you use the last of your power to escape the area.
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Reversed Prompt Buttons
 nlReversePromptButton=If enabled, the OK and Cancel Prompt buttons are reversed.
 lblPrepareDatabase=Preparing database...

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -3880,6 +3880,7 @@ lblEffectDialogDescription=Extrañas energías mágicas fluyen dentro de este lu
 lblEffectDataHeader=Todos los oponentes obtienen:
 lblDefeatedDescription=Derrotado e incapaz de continuar, utilizas lo último de tu poder para escapar del área.
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Botones de aviso invertidos
 nlReversePromptButton=Si esta opción está habilitada, los botones Aceptar y Cancelar solicitud se invierten.
 lblPrepareDatabase=Preparando la base de datos...

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -3886,6 +3886,7 @@ lblEffectDialogDescription=D'étranges énergies magiques circulent dans ce lieu
 lblEffectDataHeader=Tous les adversaires obtiennent:
 lblDefeatedDescription=Vaincu et incapable de continuer, vous utilisez le reste de votre pouvoir pour vous échapper de la zone.
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Boutons d'invite inversés
 nlReversePromptButton=Si cette option est activée, les boutons OK et Annuler sont inversés.
 lblPrepareDatabase=Préparation de la base de données...

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -3883,6 +3883,7 @@ lblEffectDialogDescription=In questo luogo fluiscono strane energie magiche...
 lblEffectDataHeader=Tutti gli avversari ottengono:
 lblDefeatedDescription=Sconfitto e impossibilitato a proseguire, usi le ultime energie che ti restano per fuggire dalla zona.
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Pulsanti di richiesta invertiti
 nlReversePromptButton=Se abilitati, i pulsanti OK e Annulla richiesta sono invertiti.
 lblPrepareDatabase=Preparazione del database...

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -3880,6 +3880,7 @@ lblEffectDialogDescription=この場所には不思議な魔力が流れてい�
 lblEffectDataHeader=対戦相手全員が得るもの:
 lblDefeatedDescription=敗北し、続行不可能となったあなたは、最後の力を振り絞ってそのエリアから脱出します。
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=逆プロンプトボタン
 nlReversePromptButton=有効にすると、[OK] ボタンと [Cancel] ボタンが逆になります。
 lblPrepareDatabase=データベースを準備しています

--- a/forge-gui/res/languages/ko-KR.properties
+++ b/forge-gui/res/languages/ko-KR.properties
@@ -3583,6 +3583,7 @@ lblEffectDialogDescription=이곳에는 신비한 마력이 흐르고 있다...
 lblEffectDataHeader=모든 상대가 얻는 것:
 lblDefeatedDescription=패배하여 더 이상 진행할 수 없게 된 당신은 마지막 힘을 짜내 그 지역에서 탈출합니다.
 lblAdventureDeckError=덱 {0}\n불완전한 덱으로 게임을 시작하면 예상치 못한 결과가 발생할 수 있습니다. 계속하시겠습니까?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=역 프롬프트 버튼
 nlReversePromptButton=활성화하면 [확인] 버튼과 [취소] 버튼이 반대로 바뀝니다.
 lblPrepareDatabase=데이터베이스 준비 중

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -3968,6 +3968,7 @@ lblEffectDialogDescription=Estranhas energias mágicas fluem dentro deste lugar.
 lblEffectDataHeader=Todos os oponentes recebem:
 lblDefeatedDescription=Derrotado e incapaz de continuar, você usa o que resta de seu poder para escapar da área.
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Botões de prompt invertidos
 nlReversePromptButton=Se ativados, os botões OK e Cancelar prompt serão invertidos.
 lblPrepareDatabase=Preparando banco de dados...

--- a/forge-gui/res/languages/ru-RU.properties
+++ b/forge-gui/res/languages/ru-RU.properties
@@ -3578,6 +3578,7 @@ lblEffectDialogDescription=В этом месте текут странные м
 lblEffectDataHeader=Все оппоненты получают:
 lblDefeatedDescription=Побеждённый и неспособный продолжать, вы используете последние силы, чтобы сбежать из этой местности.
 lblAdventureDeckError=Колода {0}\nНачало игры с неполной колодой может привести к неожиданным результатам. Продолжить?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=Поменять местами кнопки запроса
 nlReversePromptButton=Если включено, кнопки "ОК" и "Отмена" в запросах меняются местами.
 lblPrepareDatabase=Подготовка базы данных...

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -3862,6 +3862,7 @@ lblEffectDialogDescription=奇怪的魔法能量在这个地方流动。。。
 lblEffectDataHeader=所有对手获得:
 lblDefeatedDescription=你被击败了，无法继续前进，你用尽最后的力量逃离了该区域。
 lblAdventureDeckError=Deck {0}\nStarting a game with an incomplete deck may have unexpected results. Continue?
+lblAdventureDeckSelectionWarning=Warning: The currently selected deck has too few cards (minimum {0}). The deck will be filled with Wastes in order to meet the minimum during battle.
 lblReversePromptButton=反转提示按钮
 nlReversePromptButton=如果启用，则“确定”和“取消提示”按钮将会反转。
 lblPrepareDatabase=准备数据库


### PR DESCRIPTION
## Description

Several times when I have been playing in Adventure Mode I have opened up my deck list to update an incomplete deck and then accidentally left the incomplete deck selected. This has caused me to bring an unusable deck into combat several times, resulting in a loss. I think it is very unlikely someone would want to bring an incomplete deck into combat on purpose, so I added a warning when leaving the Adventure Mode deck-selection screen with an undersized deck selected.

The warning explains that Wastes will be added during battle to meet the minimum deck size. Players can continue leaving the screen or cancel and select/edit another deck.

The check:

- Includes empty decks.
- Uses Adventure Mode's configured minimum deck size.
- Accounts for Commander Mode deck sizing.
- Automatically wraps the warning text for portrait and landscape layouts.

## Testing

- Confirmed the warning appears for empty and undersized decks.
- Confirmed Cancel remains on the deck-selection screen.
- Confirmed Continue leaves the screen.
- Compiled `forge-gui-mobile` and its dependencies successfully.
- Checkstyle passed with zero violations.

AI assisted in development