### PR TITLE
Improve Homarid Spawning Bed AI

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -3253,9 +3253,10 @@ public class ComputerUtil {
             return false; // no use in sacrificing a card in an attempt to regenerate it
         }
         Combat combat = ai.getGame().getCombat();
-        boolean isThreatened = (c.isCreature() && ComputerUtil.predictCreatureWillDieThisTurn(ai, c, sa, false)
+        // The payoff does not save the sacrificed card, so assess the pending threat on its own.
+        boolean isThreatened = (c.isCreature() && ComputerUtil.predictCreatureWillDieThisTurn(ai, c, null, false)
                 && !ComputerUtilCombat.willOpposingCreatureDieInCombat(ai, c, combat) && !ComputerUtilCombat.isDangerousToSacInCombat(ai, c, combat))
-                || (!c.isCreature() && ComputerUtil.predictThreatenedObjects(ai, sa).contains(c));
+                || (!c.isCreature() && ComputerUtil.predictThreatenedObjects(ai, null).contains(c));
         return isThreatened;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
@@ -44,6 +44,10 @@ public class TokenAi extends SpellAbilityAi {
 
     @Override
     protected boolean checkPhaseRestrictions(final Player ai, final SpellAbility sa, final PhaseHandler ph) {
+        if (ComputerUtil.activateForCost(sa, ai)) {
+            return true;
+        }
+
         final Card source = sa.getHostCard();
         // Planeswalker-related flags
         boolean pwMinus = false;
@@ -133,6 +137,10 @@ public class TokenAi extends SpellAbilityAi {
 
     @Override
     protected AiAbilityDecision checkApiLogic(final Player ai, final SpellAbility sa) {
+        if (ComputerUtil.activateForCost(sa, ai)) {
+            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+        }
+
         final Game game = ai.getGame();
         final Player opp = ai.getWeakestOpponent();
 

--- a/forge-gui/res/cardsfolder/h/homarid_spawning_bed.txt
+++ b/forge-gui/res/cardsfolder/h/homarid_spawning_bed.txt
@@ -3,6 +3,5 @@ ManaCost:U U
 Types:Enchantment
 A:AB$ Token | Cost$ 1 U U Sac<1/Creature.Blue/blue creature> | TokenAmount$ X | TokenScript$ u_1_1_camarid | TokenOwner$ You | SpellDescription$ Create X 1/1 blue Camarid creature tokens, where X is the sacrificed creature's mana value.
 SVar:X:Sacrificed$CardManaCost
-AI:RemoveDeck:All
 SVar:NonStackingEffect:True
 Oracle:{1}{U}{U}, Sacrifice a blue creature: Create X 1/1 blue Camarid creature tokens, where X is the sacrificed creature's mana value.


### PR DESCRIPTION
- Reuse the existing threatened-sacrifice cost path so token abilities can cash in a legal permanent that is already predicted to die.
- Keep threat detection independent of the payoff ability, then let the existing `SacCost` preference choose the threatened permanent.
- Keep normal `TokenAi` behavior when no legal sacrifice is threatened.
- Remove Homarid Spawning Bed's AI deck ban without adding card-specific `AILogic` or pre-payment token projection.
- Verified locally that the Bed stays idle without a threat, responds to Doom Blade, and sacrifices the threatened creature instead of another legal choice.
- This intentionally makes the Bed reactive instead of attempting to optimize proactive sacrifice value, avoiding the unresolved pre-payment architecture discussed in #11486.
