### PR TITLE
Improve self-sacrificing mana ritual AI

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
@@ -147,6 +147,9 @@ public class ManaAi extends SpellAbilityAi {
 
         CardCollection manaSources = ComputerUtilMana.getAvailableManaSources(ai, true);
         int numManaSrcs = manaSources.size();
+        if (manaSources.contains(host) && ComputerUtilCost.isSacrificeSelfCost(sa.getRootAbility().getPayCosts())) {
+            numManaSrcs--;
+        }
         int manaReceived = sa.hasParam("Amount") ? AbilityUtils.calculateAmount(host, sa.getParam("Amount"), sa) : 1;
         manaReceived *= sa.getParam("Produced").split(" ").length;
 


### PR DESCRIPTION
- Correct the mana-ritual source estimate when activating the ritual sacrifices its own source, so that source is not also counted as remaining mana.
- Local A/B testing reproduced the issue with Black Lotus. The previous logic sacrificed Lotus while still one mana short of Juggernaut, Gilded Lotus, and Triskelion, leaving the payoff stranded in hand.
- With the correction, the AI preserves Lotus in all three unreachable scenarios while still pursuing reachable Juggernaut and Gilded Lotus lines.
- A resolved control scenario confirmed that the previous logic put Black Lotus into the graveyard without casting the intended payoff. Existing automatic-payment and AI safety checks also passed.
- This revision leaves the Fallen Empires sacrifice-land cycle and its AI deck-removal hints unchanged.