### PR TITLE
Warm the deck's card images at match start

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
+++ b/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
@@ -308,6 +308,11 @@ public class GuiDesktop implements IGuiBase {
     }
 
     @Override
+    public void preloadCardImages(final Collection<PaperCard> cards) {
+        ImageCache.preloadOriginals(cards);
+    }
+
+    @Override
     public void showSpellShop() {
         Singletons.getControl().setCurrentScreen(FScreen.QUEST_CARD_SHOP);
         CDeckEditorUI.SINGLETON_INSTANCE.setEditorController(

--- a/forge-gui-desktop/src/main/java/forge/ImageCache.java
+++ b/forge-gui-desktop/src/main/java/forge/ImageCache.java
@@ -25,8 +25,11 @@ import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +53,7 @@ import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.item.IPaperCard;
 import forge.item.InventoryItem;
+import forge.item.PaperCard;
 import forge.localinstance.properties.ForgeConstants;
 import forge.util.SleeveArt;
 import forge.localinstance.properties.ForgePreferences;
@@ -85,6 +89,7 @@ public class ImageCache {
     // default as unset; any other value is one somebody chose.
     private static final int LEGACY_DEFAULT_CACHE_SIZE = 400;
     private static final int DEFAULT_CACHE_SIZE = 1500;
+    private static int preloadGeneration = 0;
     private static final LoadingCache<String, BufferedImage> _CACHE = CacheBuilder.newBuilder()
             .maximumSize(cacheSize())
             // soft values so memory pressure, not entry count, is what ultimately evicts
@@ -146,7 +151,31 @@ public class ImageCache {
         }
     }
 
+    /**
+     * Decode the originals for these cards one per EDT event, so a view that later shows many
+     * cards at once does not decode them all at the moment it opens. Only what is already on
+     * disk: useDefaultIfNotFound is false, so a card with no local image costs a failed file
+     * lookup and is skipped rather than rendered or downloaded.
+     * <p>
+     * Originals only. They are what the decode cost buys and they do not depend on the size the
+     * view eventually asks for, so this needs no advance knowledge of that size.
+     */
+    public static void preloadOriginals(final Collection<PaperCard> cards) {
+        FThreads.assertExecutedByEdt(true);
+        preloadNext(new ArrayList<>(cards).iterator(), ++preloadGeneration);
+    }
+
+    private static void preloadNext(final Iterator<PaperCard> cards, final int generation) {
+        // a cleared cache means the warmed originals are gone and the screen has moved on
+        if (generation != preloadGeneration || !cards.hasNext()) {
+            return;
+        }
+        getOriginalImage(cards.next().getCardImageKey(), false, null);
+        SwingUtilities.invokeLater(() -> preloadNext(cards, generation));
+    }
+
     public static void clear() {
+        preloadGeneration++;
         _CACHE.invalidateAll();
         _missingIconKeys.clear();
         ImageKeys.clearMissingCards();

--- a/forge-gui-desktop/src/main/java/forge/ImageCache.java
+++ b/forge-gui-desktop/src/main/java/forge/ImageCache.java
@@ -80,10 +80,22 @@ public class ImageCache {
     // short prefixes to save memory
 
     private static final Set<String> _missingIconKeys = new HashSet<>();
+    // A single large zone view needs two entries per card - the decoded original and the
+    // scaled copy the panel paints - so 400 cannot hold even one. Treat that long-standing
+    // default as unset; any other value is one somebody chose.
+    private static final int LEGACY_DEFAULT_CACHE_SIZE = 400;
+    private static final int DEFAULT_CACHE_SIZE = 1500;
     private static final LoadingCache<String, BufferedImage> _CACHE = CacheBuilder.newBuilder()
-            .maximumSize(FModel.getPreferences().getPrefInt(FPref.UI_IMAGE_CACHE_MAXIMUM))
+            .maximumSize(cacheSize())
+            // soft values so memory pressure, not entry count, is what ultimately evicts
+            .softValues()
             .expireAfterAccess(15, TimeUnit.MINUTES)
             .build(new ImageLoader());
+
+    private static int cacheSize() {
+        final int configured = FModel.getPreferences().getPrefInt(FPref.UI_IMAGE_CACHE_MAXIMUM);
+        return configured == LEGACY_DEFAULT_CACHE_SIZE ? DEFAULT_CACHE_SIZE : configured;
+    }
     private static final BufferedImage _defaultImage;
     private static final BufferedImage _stars;
     private static final BufferedImage _inv_stars;

--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -9,6 +9,7 @@ import com.google.common.eventbus.Subscribe;
 import forge.LobbyPlayer;
 import forge.StaticData;
 import forge.ai.AiProfileUtil;
+import forge.deck.Deck;
 import forge.game.*;
 import forge.game.event.GameEvent;
 import forge.game.event.GameEventSubgameEnd;
@@ -21,6 +22,7 @@ import forge.game.player.RegisteredPlayer;
 import forge.gamemodes.net.NetworkGameEventListener;
 import forge.gamemodes.net.server.FServerManager;
 import forge.gamemodes.quest.QuestController;
+import forge.item.PaperCard;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.control.FControlGameEventHandler;
@@ -260,6 +262,20 @@ public class HostedMatch {
         for (final Entry<IGuiGame, Collection<PlayerView>> e : playersPerGui.asMap().entrySet()) {
             e.getKey().openView(new TrackableCollection<>(e.getValue()));
         }
+
+        // Decode the deck images now rather than when a view first shows them all at once.
+        // Queued behind the views opening above: the desktop clears the image cache when
+        // switching to the match screen, which would discard anything warmed earlier.
+        final Set<PaperCard> deckCards = new LinkedHashSet<>();
+        for (final RegisteredPlayer rp : match.getPlayers()) {
+            final Deck deck = rp.getDeck();
+            if (deck != null) {
+                for (final Entry<PaperCard, Integer> entry : deck.getAllCardsInASinglePool()) {
+                    deckCards.add(entry.getKey());
+                }
+            }
+        }
+        GuiBase.getInterface().invokeInEdtLater(() -> GuiBase.getInterface().preloadCardImages(deckCards));
 
         if (humanCount == 0) { //watch game but do not participate
             final IGuiGame gui = GuiBase.getInterface().getNewGuiGame();

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiBase.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiBase.java
@@ -39,6 +39,8 @@ public interface IGuiBase {
     ISkinImage createLayeredImage(PaperCard card, FSkinProp background, String overlayFilename, float opacity);
 
     void clearImageCache();
+    /** Optionally warms the platform's image cache for the given cards. */
+    default void preloadCardImages(Collection<PaperCard> cards) { }
     String encodeSymbols(String str, boolean formatReminderText);
 
     int getAvatarCount();


### PR DESCRIPTION
Opening a zone view that shows a whole library - a tutor search, most visibly - decodes every card
image at the moment it opens. On a 525-card highlander deck with the art already downloaded that is
5.5 seconds of JPEG decode on the EDT, and the player waits for all of it.

Decode them at match start instead, one card per EDT event, once the match views are up.

| 525-card deck, art present | before | after |
| --- | --- | --- |
| first library open | 5,470 ms | **2,180 ms** |
| reopen | 3 ms | 3 ms |

The warm itself is ~10 ms per event. Measured in a real match rather than a harness: 550 cards
(both decks) warmed in 5,356 ms of spread-out EDT work, during which the game played normally with
no perceptible stutter. A 60-card deck is the same work scaled down, so no cap seemed worth adding.

**Two scope cuts keep it small.** It warms *originals* only - they carry the decode cost and do not
depend on the size the view eventually asks for, so this needs no advance knowledge of that size.
And it passes `useDefaultIfNotFound=false`, so a card with no local image costs a failed file lookup
and is skipped: nothing is rendered, and the online fetcher is not involved. That avoids
`FCardImageRenderer`'s non-thread-safe statics without needing a worker thread, which is why this is
~50 lines and touches no threading.

It starts after the match views open, because the desktop clears the image cache when switching
screens and would otherwise discard the work, and it cancels whenever the cache is cleared. Exposed
as a default no-op on `IGuiBase`; only the desktop GUI opts in.

**Depends on #11295.** Without the larger image cache this does almost nothing: on plain master a
500-card warm went 8,451 ms -> 8,068 ms, because a 400-entry cache evicts the warmed originals
faster than they are stored. The two are complementary - #11295 makes a large view stay cached,
this makes its first open cheap.

**Memory.** Warming allocates the decoded originals early rather than additionally. Opening a
525-card library costs +589 MB of heap on master; warming first and then opening costs +593 MB - the
same peak, paid at match start instead of mid-tutor. What is genuinely new is the player who never
opens a large zone view: they hold ~506 MB (525-card deck), or proportionally less (~60 MB for 60
cards), that they would not otherwise have allocated. The cache holds soft values, so it is
reclaimed under memory pressure, and a screen switch clears it entirely.

**No test.** Every test in this repo drives `PlayerControllerAi`, so none of them reach this code
path; a test here would assert nothing. It was verified by instrumenting both ends of the hook and
playing a real match, and by the measurements above.

Full desktop suite: 360 tests, 0 failures, 6 skipped. Checkstyle clean.

Written with Claude Opus 5 (also recorded in the commit co-authors).
