### PR TITLE
Make Liliana Master Black Wizard deck more focused

### DIFF
--- a/forge-gui/res/adventure/common/decks/standard/blackwizard_hard_liliana.dck
+++ b/forge-gui/res/adventure/common/decks/standard/blackwizard_hard_liliana.dck
@@ -1,50 +1,22 @@
 [metadata]
 Name=black_wiz3
 [Main]
-1 Archfiend's Vessel|M21|1
-1 Arisen Gorgon|M19|1
-1 Carrion Grub|M21|1
-1 Cemetery Recruitment|EMN|1
-1 Cruel Revival|ORI|1
-1 Dark Salvation|EMN|1
-1 Demonic Tutor|DVD|1
+4 Liliana's Devotee|M21|1
+4 Liliana's Elite|EMN|1
+4 Tattered Mummy|AKH|1
 2 Ghastly Gloomhunter|ZNR|1
-2 Goremand|M21|1
-1 Liliana's Devotee|M21|1
-1 Liliana's Elite|EMN|1
-1 Liliana's Mastery|AKH|1
-1 Liliana's Reaver|M14|1
-1 Liliana's Scorn|M21|1
-1 Liliana's Scrounger|M21|1
-1 Liliana's Shade|M13|1
-1 Liliana's Specter|M11|1
-1 Liliana's Standard Bearer|M21|1
-1 Liliana's Steward|M21|1
-1 Liliana, Death Mage|M21|1
-1 Macabre Waltz|SOI|1
-1 Massacre Wurm|M21|1
-1 Persistent Specimen|VOW|1
-1 Professor's Warning|STX|1
-1 Reassembling Skeleton|DDK|1
-1 Rise from the Grave|EMN|1
-1 Sanitarium Skeleton|SOI|1
-1 Settle the Score|DOM|1
-1 Spirit of Malevolence|M21|1
-1 Swamp|AKH|1
-2 Swamp|AKH|2
-1 Swamp|AKH|3
-2 Swamp|DOM|1
-1 Swamp|DOM|2
-1 Swamp|DOM|4
-2 Swamp|ISD|1
-2 Swamp|ISD|3
-1 Swamp|KLD|1
-1 Swamp|KLD|2
-2 Swamp|KLD|3
-2 Swamp|M20|1
-2 Swamp|M21|1
-1 Swamp|STX|1
-3 Swamp|STX|2
-3 Tattered Mummy|AKH|1
-1 Unholy Hunger|UMA|1
+2 Liliana's Standard Bearer|M21|1
+2 Liliana's Reaver|M14|1
+2 Arisen Gorgon|M19|1
+2 Liliana's Steward|M21|1
 1 Walking Corpse|M21|1
+1 Liliana, Death Mage|M21|1
+2 Liliana, Death's Majesty|J22|1
+1 Liliana, Untouched by Death|SCD|1
+1 Liliana, the Last Hope|2X2|1
+2 Liliana's Mastery|AKH|1
+2 Dark Salvation|EMN|1
+2 Liliana's Triumph|TSR|1
+1 Demonic Tutor|DVD|1
+1 Rise from the Grave|EMN|1
+24 Swamp|M21|1


### PR DESCRIPTION
The Master Black Wizard Liliana deck is weak and unfocused. It is not in line with the power levels of the other Master Black Wizard decks. This removes a lot of the singletons, a lot of which did not fit the deck's strategy, and adds more Liliana planeswalkers. 