### PR TITLE
Allow sorcery-speed tap pumps before combat

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -89,7 +89,8 @@ public class PumpAi extends PumpAiBase {
         final Game game = ai.getGame();
         boolean main1Preferred = "Main1IfAble".equals(sa.getParam("AILogic")) && ph.is(PhaseType.MAIN1, ai);
         if (game.getStack().isEmpty() && sa.getPayCosts().hasTapCost()) {
-            if (ph.getPhase().isBefore(PhaseType.COMBAT_DECLARE_ATTACKERS) && ph.isPlayerTurn(ai)) {
+            if (ph.getPhase().isBefore(PhaseType.COMBAT_DECLARE_ATTACKERS) && ph.isPlayerTurn(ai)
+                    && !isSorcerySpeed(sa, ai)) {
                 return false;
             }
             if (ph.getPhase().isBefore(PhaseType.COMBAT_BEGIN) && ph.getPlayerTurn().isOpponentOf(ai)) {


### PR DESCRIPTION
`PumpAi` currently rejects every tap-cost Pump during its controller's precombat main phase before reaching the later sorcery-speed allowance. This leaves abilities such as Basilisk Gate unusable in the only window where their combat bonus matters.

This lets sorcery-speed abilities continue through the existing targeting, value, and cost checks. The precombat hold remains unchanged for instant-speed tap abilities, and opponent-turn timing is unchanged.

In a Basilisk Gate exact-lethal state, the current path declined the activation in 30 fresh runs; with this change it activated and won in 30 fresh runs. A one-life-higher control remained unwinnable in 30 fresh runs.

I used Codex to help author this change.
