### PR TITLE
Fix default Bandit Slingshot deck

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
@@ -6374,8 +6374,7 @@
     "name": "Bandit Slingshot",
     "sprite": "sprites/enemy/humanoid/human/bandit/banditslingshot.atlas",
     "deck": [
-      "decks/standard/banditslingshot_flyers.dck",
-      "decks/standard/banditslingshot_vehicles.dck"
+      "decks/standard/banditslingshot_flyers.dck"
     ],
     "ai": "reckless",
     "randomizeDeck": true,

--- a/forge-gui/res/adventure/common/decks/standard/banditslingshot_flyers.dck
+++ b/forge-gui/res/adventure/common/decks/standard/banditslingshot_flyers.dck
@@ -1,47 +1,20 @@
 [metadata]
-Name=Abraham Lincoln 2
+Name=banditslingshot_flyers
 [Main]
-1 Plateau
-1 Flooded Strand
-2 Arid Mesa
-2 Island|M11
-2 Plains|M11
-3 Mountain|M11
-1 Volcanic Island
-2 Scalding Tarn
-4 Mystic Monastery
-2 Clifftop Retreat
-2 Sulfur Falls
-1 Radiant, Archangel
-1 Sky Spirit
-1 Talon Trooper
-3 Skyknight Legionnaire
-1 Archon of Redemption
-1 Ryusei, the Falling Star
-1 Lightning Angel
-1 Pilgrim's Eye
-1 Serra Avenger
-1 Tempest Drake
-1 Highspire Mantis
-1 Firemane Angel
-1 Niv-Mizzet, the Firemind
-1 Azorius First-Wing
-1 Jace's Phantasm
-1 Esper Cormorants
-1 Lantern Kami
-1 Numot, the Devastator
-1 Sage of the Inward Eye
-1 Granite Gargoyle
-1 Pride of the Clouds
-1 Warden of Evos Isle
-1 Tremor
-1 Lightning Helix
-1 Electrolyze
-2 Earthquake
-4 Flamebreak
-1 Concentrate
-1 Swords to Plowshares
-1 Gravitational Shift
-1 Thunder Dragon
-1 Volcanic Spray
-[Sideboard]
+24 Mountain|USG|3
+4 Fireslinger|TMP
+4 Ghitu Slinger|ULG
+2 Slingshot Goblin|PLS
+2 Unerring Sling|MIR
+2 Stone Giant|5ED
+2 Bloodshot Cyclops|UDS
+2 Cinder Wall|WTH
+2 Wall of Razors|STH
+2 Blistering Barrier|MIR
+2 Battle Rampart|MMQ
+2 Ember Shot|JUD
+2 Pinpoint Avalanche|ONS
+2 Volley of Boulders|ODY
+2 Sudden Impact|7ED
+2 Chaos Charm|MIR
+2 Shatter|ICE

--- a/forge-gui/res/adventure/common/world/enemies.json
+++ b/forge-gui/res/adventure/common/world/enemies.json
@@ -2917,8 +2917,7 @@
     "name": "Bandit Slingshot",
     "sprite": "sprites/enemy/humanoid/human/bandit/banditslingshot.atlas",
     "deck": [
-      "decks/standard/banditslingshot_flyers.dck",
-      "decks/standard/banditslingshot_vehicles.dck"
+      "decks/standard/banditslingshot_flyers.dck"
     ],
     "ai": "",
     "randomizeDeck": true,


### PR DESCRIPTION
The Bandit Slingshot enemy in Adventure Mode uses a Jeskai fliers with spirits, gargoyles, and other things that don't fit a Bandit Slingshot at all. It can also use a vehicles deck which might fit the bandit side more but still has nothing to do with slingshots. I replaced the deck contents with another old deck that fits the slingshot theme much better