### PR TITLE
Prefer card printings in the selected language in Adventure Mode

### DIFF
--- a/forge-core/src/main/java/forge/StaticData.java
+++ b/forge-core/src/main/java/forge/StaticData.java
@@ -67,6 +67,11 @@ public class StaticData {
         this(cardReader, null, customCardReader, null, editionFolder, customEditionsFolder, blockDataFolder, "", cardArtPreference, enableUnknownCards, loadNonLegalCards, false, false);
     }
     public StaticData(CardStorageReader cardReader, CardStorageReader tokenReader, CardStorageReader customCardReader, CardStorageReader customTokenReader, String editionFolder, String customEditionsFolder, String blockDataFolder, String setLookupFolder, String cardArtPreference, boolean enableUnknownCards, boolean loadNonLegalCards, boolean allowCustomCardsInDecksConformance, boolean enableSmartCardArtSelection) {
+        this(cardReader, tokenReader, customCardReader, customTokenReader, editionFolder, customEditionsFolder,
+                blockDataFolder, setLookupFolder, cardArtPreference, "en-US", enableUnknownCards, loadNonLegalCards,
+                allowCustomCardsInDecksConformance, enableSmartCardArtSelection);
+    }
+    public StaticData(CardStorageReader cardReader, CardStorageReader tokenReader, CardStorageReader customCardReader, CardStorageReader customTokenReader, String editionFolder, String customEditionsFolder, String blockDataFolder, String setLookupFolder, String cardArtPreference, String preferredCardLanguage, boolean enableUnknownCards, boolean loadNonLegalCards, boolean allowCustomCardsInDecksConformance, boolean enableSmartCardArtSelection) {
         this.cardReader = cardReader;
         this.tokenReader = tokenReader;
         this.editions = new CardEdition.Collection(new CardEdition.Reader(new File(editionFolder)));
@@ -129,6 +134,8 @@ public class StaticData {
             commonCards = new CardDb(regularCards, editions, filtered);
             variantCards = new CardDb(variantsCards, editions, filtered);
 
+            commonCards.setPreferredCardLanguage(preferredCardLanguage);
+            variantCards.setPreferredCardLanguage(preferredCardLanguage);
             commonCards.setCardArtPreference(cardArtPreference);
             variantCards.setCardArtPreference(cardArtPreference);
 

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -98,6 +98,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     // Placeholder to setup default art Preference - to be moved from Static Data!
     private CardArtPreference defaultCardArtPreference;
+    private String preferredCardLanguage = "en";
 
     public static class CardRequest {
         public String cardName;
@@ -581,11 +582,53 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     }
 
     private PaperCard getBestUniquePrint(final Collection<PaperCard> cards) {
-        return cards.stream()
+        List<PaperCard> candidates = cards.stream()
                 .filter(pc -> !pc.getRarity().equals(CardRarity.Special))
+                .collect(Collectors.toList());
+        candidates = preferPrintingLanguage(candidates);
+        return candidates.stream()
                 .min(Comparator.comparing((PaperCard pc) -> editions.get(pc.getEdition()), defaultCardArtPreference)
                         .thenComparing(PaperCard::getCollectorNumber))
                 .orElseGet(() -> cards.iterator().next());
+    }
+
+    private List<PaperCard> preferPrintingLanguage(final List<PaperCard> cards) {
+        List<PaperCard> preferredCards = cards.stream()
+                .filter(card -> isPrintingLanguage(card, preferredCardLanguage))
+                .collect(Collectors.toList());
+        if (!preferredCards.isEmpty()) {
+            return preferredCards;
+        }
+        if (!"en".equals(preferredCardLanguage)) {
+            List<PaperCard> englishCards = cards.stream()
+                    .filter(card -> isPrintingLanguage(card, "en"))
+                    .collect(Collectors.toList());
+            if (!englishCards.isEmpty()) {
+                return englishCards;
+            }
+        }
+        return cards;
+    }
+
+    private boolean isPrintingLanguage(final PaperCard card, final String language) {
+        CardEdition edition = editions.get(card.getEdition());
+        return edition != null && !CardEdition.UNKNOWN.equals(edition)
+                && language.equalsIgnoreCase(edition.getCardsLangCode());
+    }
+
+    public void setPreferredCardLanguage(final String locale) {
+        String normalizedLocale = StringUtils.defaultIfBlank(locale, "en-US").trim().replace('_', '-').toLowerCase(Locale.ROOT);
+        if (normalizedLocale.startsWith("zh-hk") || normalizedLocale.startsWith("zh-mo") || normalizedLocale.startsWith("zh-tw")) {
+            preferredCardLanguage = "zht";
+        } else if (normalizedLocale.startsWith("zh")) {
+            preferredCardLanguage = "zhs";
+        } else {
+            int separatorIndex = normalizedLocale.indexOf('-');
+            preferredCardLanguage = separatorIndex < 0 ? normalizedLocale : normalizedLocale.substring(0, separatorIndex);
+        }
+        if (!allCardsByRules.isEmpty()) {
+            reIndex();
+        }
     }
 
     public boolean setPreferredArt(String cardName, String setCode, int artIndex) {
@@ -855,6 +898,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
         if (cards.isEmpty())
             return null;
+        cards = preferPrintingLanguage(cards);
         if (cards.size() == 1)  // if only one candidate, there's not much else we should do
             return cr.isFoil ? cards.get(0).getFoiled() : cards.get(0);
 

--- a/forge-gui-desktop/src/test/java/forge/card/CardDbLanguagePreferenceTest.java
+++ b/forge-gui-desktop/src/test/java/forge/card/CardDbLanguagePreferenceTest.java
@@ -1,0 +1,100 @@
+package forge.card;
+
+import forge.CardStorageReader;
+import forge.ImageKeys;
+import forge.StaticData;
+import forge.item.PaperCard;
+import forge.util.Localizer;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class CardDbLanguagePreferenceTest {
+    private StaticData staticData;
+    private CardDb cardDb;
+
+    @BeforeClass
+    public void setUp() {
+        Localizer.getInstance().initialize("en-US", "../forge-gui/res/languages");
+        ImageKeys.initializeDirs("target/test-images/cards", Collections.emptyMap(),
+                "target/test-images/tokens", "target/test-images/icons", "target/test-images/boosters",
+                "target/test-images/fatpacks", "target/test-images/boosterboxes",
+                "target/test-images/precons", "target/test-images/tournamentpacks");
+        CardStorageReader reader = new CardStorageReader("../forge-gui/res/cardsfolder", null, true);
+        staticData = new StaticData(reader, null,
+                "../forge-gui/res/editions", "target/nonexistent-custom-editions",
+                "../forge-gui/res/blockdata", "Latest Art All Editions", true, false);
+        cardDb = staticData.getCommonCards();
+    }
+
+    @BeforeMethod
+    public void resetLanguagePreference() {
+        cardDb.setPreferredCardLanguage("en-US");
+    }
+
+    @Test
+    public void automaticPrintingPrefersSelectedLanguage() {
+        String cardName = "Earthquake";
+
+        staticData.attemptToLoadCard(cardName);
+        cardDb.setPreferredCardLanguage("ja-JP");
+
+        PaperCard automaticCard = cardDb.getCard(cardName);
+        assertNotNull(automaticCard);
+        assertEquals(staticData.getCardEdition(automaticCard.getEdition()).getCardsLangCode(), "ja");
+
+        PaperCard uniqueCard = cardDb.getUniqueByNameNoAlt(cardName);
+        assertNotNull(uniqueCard);
+        assertEquals(staticData.getCardEdition(uniqueCard.getEdition()).getCardsLangCode(), "ja");
+    }
+
+    @Test
+    public void automaticPrintingFallsBackToEnglish() {
+        String cardName = "Earthquake";
+
+        staticData.attemptToLoadCard(cardName);
+        cardDb.setPreferredCardLanguage("fr-FR");
+
+        PaperCard automaticCard = cardDb.getCard(cardName);
+        assertNotNull(automaticCard);
+        assertEquals(staticData.getCardEdition(automaticCard.getEdition()).getCardsLangCode(), "en");
+
+        PaperCard uniqueCard = cardDb.getUniqueByNameNoAlt(cardName);
+        assertNotNull(uniqueCard);
+        assertEquals(staticData.getCardEdition(uniqueCard.getEdition()).getCardsLangCode(), "en");
+    }
+
+    @Test
+    public void automaticPrintingFallsBackToAnyAvailableLanguage() {
+        String cardName = "Earthquake";
+        String japaneseEdition = "PMDA";
+
+        staticData.attemptToLoadCard(cardName);
+        cardDb.setPreferredCardLanguage("fr-FR");
+
+        PaperCard fallbackCard = cardDb.getCardFromEditions(cardName, cardDb.getCardArtPreference(), 1,
+                card -> japaneseEdition.equals(card.getEdition()));
+        assertNotNull(fallbackCard);
+        assertEquals(fallbackCard.getEdition(), japaneseEdition);
+        assertEquals(staticData.getCardEdition(fallbackCard.getEdition()).getCardsLangCode(), "ja");
+    }
+
+    @Test
+    public void explicitEditionIsPreserved() {
+        String cardName = "Earthquake";
+        String japaneseEdition = "PMDA";
+
+        staticData.attemptToLoadCard(cardName);
+        cardDb.setPreferredCardLanguage("fr-FR");
+
+        PaperCard explicitJapaneseCard = cardDb.getCard(cardName, japaneseEdition);
+        assertNotNull(explicitJapaneseCard);
+        assertEquals(explicitJapaneseCard.getEdition(), japaneseEdition);
+        assertEquals(staticData.getCardEdition(explicitJapaneseCard.getEdition()).getCardsLangCode(), "ja");
+    }
+}

--- a/forge-gui/src/main/java/forge/model/FModel.java
+++ b/forge-gui/src/main/java/forge/model/FModel.java
@@ -82,6 +82,7 @@ public final class FModel {
         new StaticData(reader, tokenReader, customReader, customTokenReader, ForgeConstants.EDITIONS_DIR,
             ForgeConstants.USER_CUSTOM_EDITIONS_DIR, ForgeConstants.BLOCK_DATA_DIR, ForgeConstants.SETLOOKUP_DIR,
             getPreferences().getPref(FPref.UI_PREFERRED_ART),
+            getPreferences().getPref(FPref.UI_LANGUAGE),
             getPreferences().getPrefBoolean(FPref.UI_LOAD_UNKNOWN_CARDS),
             getPreferences().getPrefBoolean(FPref.UI_LOAD_NONLEGAL_CARDS),
             getPreferences().getPrefBoolean(FPref.ALLOW_CUSTOM_CARDS_IN_DECKS_CONFORMANCE),


### PR DESCRIPTION
I noticed that in Adventure mode I would sometimes encounter cards that are in Japanese. This is especially an issue since no raw card text is available in this UI so I have no way of knowing what the card does. 

To fix this I made it so automatic card selection now prefers printings matching Forge’s selected UI language if available, then English, then any available language. Explicit edition requests remain authoritative.

Adds regression coverage for selected-language preference, English fallback, any-language fallback, and explicit editions. Just let me know if you think the added regression tests are excessive and I can remove them.

Sol assisted in development.