### PR TITLE
Fix Greensleeves ability definition

### DIFF
--- a/forge-gui/res/cardsfolder/g/greensleeves.txt
+++ b/forge-gui/res/cardsfolder/g/greensleeves.txt
@@ -3,7 +3,7 @@ ManaCost:4 G G
 Types:Legendary Planeswalker Greensleeves
 Loyalty:5
 A:AB$ CopyPermanent | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | DefinedName$ Giant Badger | SpellDescription$ Create a Giant Badger token. (It's a {1}{G}{G} 2/2 Badger creature with "Whenever this token blocks, it gets +2/+2 until end of turn.")
-A:AB$ Mill | Cost$ SubCounter<3/LOYALTY> | NumCards$ 3 | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill three cards. Put all permanent cards from among them into your hand.
+A:AB$ Mill | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | NumCards$ 3 | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill three cards. Put all permanent cards from among them into your hand.
 SVar:DBChangeZone:DB$ ChangeZoneAll | ChangeType$ Permanent.IsRemembered | Origin$ Graveyard,Exile | Destination$ Hand | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ AnimateAll | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Creature.YouCtrl | Power$ 8 | Toughness$ 8 | Keywords$ Trample | AILogic$ CreatureAdvantage | SpellDescription$ Until end of turn, creatures you control have base power and toughness 8/8 and gain trample.


### PR DESCRIPTION
The minus 3 ability for Greensleeves is not defined as a planeswalker ability, and as such can be activated multiple times per turn.