### PR TITLE
Fix PumpAi creature tap cost timing

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -95,7 +95,9 @@ public class PumpAi extends PumpAiBase {
             boolean isBeforeOppCombat = ph.getPhase().isBefore(PhaseType.COMBAT_BEGIN) && ph.getPlayerTurn().isOpponentOf(ai);
             CostTapType tapType = sa.getPayCosts().getCostPartByType(CostTapType.class);
             if (tapType != null && (tapType.getType().startsWith("Creature") || CardType.isACreatureType(tapType.getType()))) {
-                return isBeforeMyAttack || isBeforeOppCombat;
+                if (isBeforeMyAttack || isBeforeOppCombat) {
+                    return false;
+                }
             }
             Card host = sa.getHostCard();
             // wait until AI has decided if creature should attack/block instead


### PR DESCRIPTION
The `CostTapType` check from #11739 inverted the combat-preservation behavior discussed in #11734, allowing Pump abilities before combat and rejecting them afterward.

Preserve potential attackers and blockers, then use the existing Pump timing once combat is committed.

I used Codex to help author this change.