### PR TITLE
Count all lands when evaluating land sacrifice costs

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -375,7 +375,7 @@ public class ComputerUtil {
                 final CardCollection nonLandsInHand = CardLists.getNotType(ai.getCardsIn(ZoneType.Hand), "Land");
                 nonLandsInHand.addAll(ai.getCardsIn(ZoneType.Library));
                 final int highestCMC = Math.max(6, Aggregates.max(nonLandsInHand, Card::getCMC));
-                if (landsInPlay.size() + landsInHand >= highestCMC) {
+                if (ai.getLandsInPlay().size() + landsInHand >= highestCMC) {
                     // Don't need more land.
                     return ComputerUtilCard.getWorstLand(landsInPlay);
                 }


### PR DESCRIPTION
Typed land-sacrifice costs currently use only eligible payment choices when deciding whether the AI can spare a land, so Hashep Oasis can treat a six-land board with two Deserts as two lands.\n\nCount all controlled lands for scarcity while retaining the eligible list for the actual sacrifice.\n\nI used Codex to help author this change.