### PR TITLE
Let ReplaySpell evaluate responses on the stack

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -255,7 +255,7 @@ public class PumpAi extends PumpAiBase {
             }
         }
 
-        if (!game.getStack().isEmpty() && !sa.isCurse() && !isFight) {
+        if (!game.getStack().isEmpty() && !sa.isCurse() && !isFight && !"ReplaySpell".equals(aiLogic)) {
             return ComputerUtilCard.canPumpAgainstRemoval(ai, sa);
         }
 


### PR DESCRIPTION
PumpAi currently routes ReplaySpell through the generic pump-against-removal check when the stack is nonempty, so Flashback can overlook a playable graveyard response such as No More Lies.

Exempting ReplaySpell lets its existing selector decide while leaving ordinary pump responses unchanged. PlayAi already treats ReplaySpell as the same kind of stack-response exception.

I used Codex to help author this change.