### PR TITLE
Add AI targeting logic for Metamorphic Alteration

### DIFF
--- a/forge-gui/res/cardsfolder/m/metamorphic_alteration.txt
+++ b/forge-gui/res/cardsfolder/m/metamorphic_alteration.txt
@@ -2,6 +2,7 @@ Name:Metamorphic Alteration
 ManaCost:1 U
 Types:Enchantment Aura
 K:Enchant:Creature
+SVar:AttachAILogic:HighestEvaluation
 K:ETBReplacement:Other:ChooseCreature
 SVar:ChooseCreature:DB$ ChooseCard | Defined$ You | Mandatory$ True | Choices$ Creature.Other | SpellDescription$ As CARDNAME enters, choose a creature.
 T:Mode$ Attached | ValidSource$ Card.Self | Static$ True | Execute$ DBClone | TriggerDescription$ Enchanted creature is a copy of the chosen creature.


### PR DESCRIPTION
Metamorphic Alteration has no `AttachAILogic`, so the AI rejects the optional Aura before choosing a target. `HighestEvaluation` matches the existing copy-Aura scripts and lets it choose the best legal creature.

I used Codex to help author this change.