### PR TITLE
AI hybrid simulation: don't simulate a subability

### DIFF
--- a/forge-ai/src/main/java/forge/ai/simulation/OnePlaySafetyChecker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/OnePlaySafetyChecker.java
@@ -3,6 +3,7 @@ package forge.ai.simulation;
 import forge.ai.simulation.GameStateEvaluator.Score;
 import forge.game.card.Card;
 import forge.game.player.Player;
+import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
@@ -13,7 +14,8 @@ public final class OnePlaySafetyChecker {
         // Forge keeps the parent ability on the stack while it resolves. Score actions offered
         // during that resolution incrementally; priority responses need two full stack-resolution
         // branches and are not supported yet.
-        if (sa == null || CHECKING.get()
+        // A subability is never played on its own, so there is nothing here to rule unsafe.
+        if (sa == null || sa instanceof AbilitySub || CHECKING.get()
                 || (!player.getGame().getStack().isEmpty() && !player.getGame().getStack().isResolving())) {
             return true;
         }


### PR DESCRIPTION
## Bug

`CharmAi.chooseOptionsAi` calls `canPlaySa()` on each mode to score it
([CharmAi.java:124](https://github.com/Card-Forge/forge/blob/master/forge-ai/src/main/java/forge/ai/ability/CharmAi.java#L124)),
and `canPlaySa` ends at `saSideEffects`, which in hybrid mode calls
`OnePlaySafetyChecker.isAcceptable`. `GameSimulator.findSaInSimGame` matches by description against
the host card's abilities, and a mode is in neither list, so it returns null:

```
Simulation: SA not found! Pinecone Strike deals 3 damage to target creature. / class forge.game.spellability.AbilitySub
```

6 hybrid-sim games, deck with 2x `Pinecone Strike`: **121 misses, 100% `AbilitySub`.**

## Fix

Skip subabilities in `isAcceptable`. `DelayedTriggerAi.java:28` already guards its own call the
same way.

**The AI decision is unchanged**: a miss scores `Integer.MIN_VALUE`, which `isAcceptable` already
returns `true` for. This drops a wasted full game copy per mode, and the stderr noise. 121 -> 0 on
the same seed.

Hybrid only — full simulation routes modes through `SpellAbilityPicker.chooseModeForAbility` and
never passes one to `simulateSpellAbility`.

## Not fixed here

`isAcceptable` returning `true` on `MIN_VALUE` means any line the simulator cannot reproduce
passes the safety check silently. Happy to look at that separately if it is worth an issue.

Written with Claude Code, per CONTRIBUTING.md. No tests added.
