### PR TITLE
RoL: Fix map crash on plot-critical dungeon

### DIFF
--- a/forge-gui/res/adventure/Realm of Legends/maps/map/cave/Shard_Convergence_Halls.tmx
+++ b/forge-gui/res/adventure/Realm of Legends/maps/map/cave/Shard_Convergence_Halls.tmx
@@ -130,7 +130,7 @@
   <object id="65" template="../../../../common/maps/obj/gold.tx" x="319.75" y="182"/>
   <object id="72" template="../../../../common/maps/obj/enemy.tx" x="208.203" y="125.343">
    <properties>
-    <property name="effect">{&quot;startBattleWithCard&quot;: [&quot;Kaleidostone|CON&quot;, &quot;Manaforce Mace|CON&quot;, &quot;Maelstrom Nexus|ARB&quot;, &quot;Exotic Orchard|CON&quot; 
+    <property name="effect">{&quot;startBattleWithCard&quot;: [&quot;Kaleidostone|CFX&quot;, &quot;Manaforce Mace|CFX&quot;, &quot;Maelstrom Nexus|ARB&quot;, &quot;Exotic Orchard|CFX&quot;
 ]}</property>
     <property name="enemy" value="Child of Alara"/>
     <property name="spawn.Easy" type="bool" value="false"/>
@@ -237,19 +237,19 @@
    <properties>
     <property name="reward">[
   {
-    &quot;editions&quot;: [ &quot;CON&quot; ],
+    &quot;editions&quot;: [ &quot;CFX&quot; ],
     &quot;type&quot;: &quot;card&quot;,
     &quot;count&quot;: 10,
     &quot;rarity&quot;: [ &quot;Common&quot; ]
   },
   {
-    &quot;editions&quot;: [ &quot;CON&quot; ],
+    &quot;editions&quot;: [ &quot;CFX&quot; ],
     &quot;type&quot;: &quot;card&quot;,
     &quot;count&quot;: 3,
     &quot;rarity&quot;: [ &quot;Uncommon&quot; ]
   },
   {
-    &quot;editions&quot;: [ &quot;CON&quot; ],
+    &quot;editions&quot;: [ &quot;CFX&quot; ],
     &quot;type&quot;: &quot;card&quot;,
     &quot;count&quot;: 1,
     &quot;rarity&quot;: [ &quot;Rare&quot;, &quot;Mythic Rare&quot; ]
@@ -312,19 +312,19 @@
    <properties>
     <property name="reward">[
   {
-    &quot;editions&quot;: [ &quot;CON&quot; ],
+    &quot;editions&quot;: [ &quot;CFX&quot; ],
     &quot;type&quot;: &quot;card&quot;,
     &quot;count&quot;: 10,
     &quot;rarity&quot;: [ &quot;Common&quot; ]
   },
   {
-    &quot;editions&quot;: [ &quot;CON&quot; ],
+    &quot;editions&quot;: [ &quot;CFX&quot; ],
     &quot;type&quot;: &quot;card&quot;,
     &quot;count&quot;: 3,
     &quot;rarity&quot;: [ &quot;Uncommon&quot; ]
   },
   {
-    &quot;editions&quot;: [ &quot;CON&quot; ],
+    &quot;editions&quot;: [ &quot;CFX&quot; ],
     &quot;type&quot;: &quot;card&quot;,
     &quot;count&quot;: 1,
     &quot;rarity&quot;: [ &quot;Rare&quot;, &quot;Mythic Rare&quot; ]
@@ -469,7 +469,7 @@ Your manasight stone glows brightly, sensing a truly mighty legend in this place
   </object>
   <object id="99" template="../../../../common/maps/obj/enemy.tx" x="208.667" y="124.667">
    <properties>
-    <property name="effect">{&quot;startBattleWithCard&quot;: [&quot;Kaleidostone|CON&quot;, &quot;Manaforce Mace|CON&quot;, &quot;Maelstrom Nexus|ARB&quot; 
+    <property name="effect">{&quot;startBattleWithCard&quot;: [&quot;Kaleidostone|CFX&quot;, &quot;Manaforce Mace|CFX&quot;, &quot;Maelstrom Nexus|ARB&quot;
 ]}</property>
     <property name="enemy" value="Child of Alara"/>
     <property name="spawn.Hard" type="bool" value="false"/>

--- a/forge-gui/res/adventure/Realm of Legends/maps/map/cave/Shard_Convergence_Halls.tmx
+++ b/forge-gui/res/adventure/Realm of Legends/maps/map/cave/Shard_Convergence_Halls.tmx
@@ -36,7 +36,7 @@
    <property name="spriteLayer" type="bool" value="true"/>
   </properties>
   <data encoding="base64" compression="zlib">
-   eJy9ls9OFEEQxntHE4POzAFiYH0AYAgbEtz4GsLZSDYsj8CRcAUBvam8hm+wIVkfgOVuohwJFxI9alW6v3RRMzV/DPolle70dPevqnu6up1z7iZ1biV37ixzlVqlb0WNvaNxx5kvrTmqdBLGreXtx2i/eCzKNmqK9V+pKtav/Vj/3vNWJ6vP7ot6royV+47I9sheJeU5n7517vy1LzWX+8+CDZNyDFJ6T8bBx6nq/3w7+Em8pS1fSm0mngsxdxTm2quJW2qWlNuW3vgyJV5Glhvcn1T/RXYpYu+iTaP/GfHek31oiDd97G3YkWsp3aF4yfKd8jfmTvqR+RDcj7S/X56V22UbczcGkcn1Llz5X87UPul/p6of+uw/KnPhk8Vlnc7Tfs77+iB84xg2BpF7VDj3g+y68HUti6vXjs8bcy+oXizQGVuwfcWcv5m3FtvhF/qMxTmSXBjyC+Kdy7yxLsQ4zT3M7pdV8U7V/wYmfBqFPMUuW+ss5zwQLIsr8we4t2lkQ4hXrvMk5K8r9V+xvhXRrHhZYPJdtJxHtuZq6faqM8L+yTWRAnMl3NlgW7p7Us29NM6RJebi/lvN7XcCeJDmLq5T3l63ORYXLH0XWny9fi+JOezAZcn7z3qf6HibpP2y9rmNurIhnPMu+flzz9u5ers0+T8Rb4VPvThPG+2q/CFlnS9oTvwjMl9Ybx2tscqXrEm/mSuF9W37xoGmgmPdhXV7x9/0Gw26qckVDy3kV+Sr/y3kK4j9qMuVUrPkftmVK3MUckcX/t8InD+9eZTA
+   eJy9ls1KHEEQx3vHgBhn5qAEXB9AHWERRPIaSc4hsrg+gkfxaj5Mbom+hncPi7B5ANe7YHIUL4IeYxXdf7qsmZqPYPKHopue7v5VdU9Xt3PO3aTOrebOHWWuUmv0raixTzTuY+ZLa44qfQ7j1vP2Y7RfPBZlGzXF+q9UFevPfqxf97zVyeqzs1zPlbFy3yHZLtnrpDznyw/OnbzxpeZy/2mwraQcg5Tek1HwcaL6v3oX/CTe0ltfSm0mngsxdxjm2q2JW2qalNuW3vsyJV5Glhvce6o/kF2I2Lto0+h/RLyvZN8a4k1feNvqyLWUblO8ZPl2+Rtzx/3IfA7ud9rf0/lyu2xj7sYgMrnehSv/y6naJ/3vVPVDn72ZMhc+WVzWlwXazwVfH4RvHMPGIHIPC+d+kf0ufF3L4uq14/PG3HOqF4t0xhZtXzHnH+atx3b4hT4jcY4kF4b8gnjnMm+sczFOcw+yp2VVvBP1v4EJn4YhT7HL1jrLOfcFy+LK/AHubRrZEOKV6zwO+etS/VesqyKaFS8LTL6LVvLI1lwt3V51Rtg/uSZSYK6GOxtsS3ez1dwL4xxZYi7uv7XcfieAB2nu2Yy3tgIXLH0XWny9fl25LHn/We8THa+W5mq/rH1uoya2JZzzLvn5uOftRL1dmvwfi7fCj16cp412VP6Qss4XNCf+EZkvrLeO1kjlS9a438yVwvq2feNAE8Gx7sK6veNv+o0G3dTkiucW8ivy1f8W8hXEftTlSqlp8rTsypU5CrmjC/9vBM4jPUuX9A==
   </data>
  </layer>
  <objectgroup id="4" name="Objects">
@@ -476,15 +476,6 @@ Your manasight stone glows brightly, sensing a truly mighty legend in this place
     <property name="spawn.Insane" type="bool" value="false"/>
     <property name="speedModifier" type="float" value="30"/>
     <property name="threatRange" type="int" value="20"/>
-   </properties>
-  </object>
-  <object id="100" template="../../../../common/maps/obj/shop.tx" x="240.5" y="325">
-   <properties>
-    <property name="commonShopList" value="AlaraBoosters"/>
-    <property name="mythicShopList" value=""/>
-    <property name="rareShopList" value=""/>
-    <property name="signYOffset" type="float" value="-2"/>
-    <property name="uncommonShopList" value=""/>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Realm of Legends/world/shops.json
+++ b/forge-gui/res/adventure/Realm of Legends/world/shops.json
@@ -948,8 +948,8 @@
       {"type": "cardPackShop", "count": 1, "editions": ["ALA"] },
       {"type": "cardPackShop", "count": 1, "editions": ["ARB"] },
       {"type": "cardPackShop", "count": 1, "editions": ["ARB"] },
-      {"type": "cardPackShop", "count": 1, "editions": ["CON"] },
-      {"type": "cardPackShop", "count": 1, "editions": ["CON"] }
+      {"type": "cardPackShop", "count": 1, "editions": ["CFX"] },
+      {"type": "cardPackShop", "count": 1, "editions": ["CFX"] }
     ]
   },
   {


### PR DESCRIPTION
Remove alara pack shop which suddenly broke, preventing this plot-critical map from loading