### PR TITLE
Initialize stack item views before tracking

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/StackItemView.java
+++ b/forge-game/src/main/java/forge/game/spellability/StackItemView.java
@@ -28,7 +28,7 @@ public class StackItemView extends TrackableObject implements IHasCardView {
     }
 
     public StackItemView(SpellAbilityStackInstance si) {
-        super(si.getId(), si.getSourceCard().getGame().getTracker());
+        super(si.getId(), null);
         updateKey(si);
         updateSourceTrigger(si);
         updateText(si);
@@ -40,6 +40,7 @@ public class StackItemView extends TrackableObject implements IHasCardView {
         updateOptionalTrigger(si);
         updateSubInstance(si);
         updateOptionalCost(si);
+        setTracker(si.getSourceCard().getGame().getTracker());
     }
 
     /**

--- a/forge-game/src/test/java/forge/game/spellability/StackItemViewTest.java
+++ b/forge-game/src/test/java/forge/game/spellability/StackItemViewTest.java
@@ -1,0 +1,63 @@
+package forge.game.spellability;
+
+import forge.game.Game;
+import forge.game.GameRules;
+import forge.game.GameType;
+import forge.game.Match;
+import forge.game.card.Card;
+import forge.game.cost.Cost;
+import forge.game.player.Player;
+import forge.util.Localizer;
+import forge.util.Lang;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class StackItemViewTest {
+    @BeforeClass
+    public void initializeLocalizer() {
+        Localizer.getInstance().initialize(
+                "en-US",
+                Path.of("..", "forge-gui", "res", "languages").toAbsolutePath().toString());
+        Lang.createInstance("en-US");
+    }
+
+    @Test
+    public void constructorInitializesViewWhileTrackerIsFrozen() {
+        GameRules rules = new GameRules(GameType.Constructed);
+        Game game = new Game(Collections.emptyList(), rules, new Match(rules, Collections.emptyList(), "Test"));
+        Card card = new Card(1, game);
+        Player player = new Player("Test player", game, 1);
+        SpellAbility ability = new AbilityActivated(card, Cost.Zero, null) {
+            @Override
+            public void resolve() {
+            }
+        };
+        ability.setStackDescription("Test ability");
+        ability.setActivatingPlayer(player);
+
+        game.getTracker().freeze();
+        SpellAbilityStackInstance instance = new SpellAbilityStackInstance(ability);
+        game.getTracker().clearDelayed();
+        game.getTracker().unfreeze();
+
+        Assert.assertSame(instance.getView().getSourceCard(), card.getView());
+        Assert.assertSame(instance.getView().getActivatingPlayer(), player.getView());
+        Assert.assertTrue(instance.getView().isAbility());
+        Assert.assertEquals(instance.getView().getText(), "Test ability");
+        Assert.assertSame(instance.getView().getTracker(), game.getTracker());
+
+        Player newPlayer = new Player("New player", game, 2);
+        game.getTracker().freeze();
+        instance.setActivatingPlayer(newPlayer);
+
+        Assert.assertSame(instance.getView().getActivatingPlayer(), player.getView());
+
+        game.getTracker().unfreeze();
+
+        Assert.assertSame(instance.getView().getActivatingPlayer(), newPlayer.getView());
+    }
+}


### PR DESCRIPTION
`StackItemView` attaches its tracker before setting constructor properties. When the tracker is frozen, those initial values are deferred. A later `clearDelayed()` can leave the new view empty and make stack-event consumers fail while reading fields such as the activating player.

Initialize the view before attaching the tracker. Later updates retain normal freeze behavior.

I used Codex to help diagnose and author this change.