### PR TITLE
Desktop: default the screen scale when headless

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
+++ b/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
@@ -350,6 +350,11 @@ public class GuiDesktop implements IGuiBase {
     }
 
     private static float initializeScreenScale() {
+        // Main installs GuiDesktop before it reads the mode argument, so `sim` and `parse` load
+        // this class with no display.
+        if (GraphicsEnvironment.isHeadless()) {
+            return 1.0f;
+        }
         GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
         AffineTransform at = gc.getDefaultTransform();
         double scaleX = at.getScaleX();


### PR DESCRIPTION
Fixes #11754.

`GraphicsEnvironment.isHeadless()` returns false whenever a display exists, so the GUI path is
unchanged; verified `isHeadless=false` and the real scale on a headful JVM.

Verified with no `DISPLAY`, stock jar, no other changes:

```
$ java -Dsentry.dsn= -jar forge-gui-desktop-*-jar-with-dependencies.jar sim -d a.dck b.dck -n 2
Simulation mode
Match Result: Ai(1)-A: 1 Ai(2)-B: 0
Match Result: Ai(1)-A: 1 Ai(2)-B: 1
```

Before: `ExceptionInInitializerError` at `Main.java:57`, no games.

Nothing else in the `sim` path needed a display, which was the open question in the issue.

Written with Claude Code, per CONTRIBUTING.md. No tests added.
