### PR TITLE
Make sim mode run without a display

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
+++ b/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
@@ -4,6 +4,7 @@ import java.awt.Desktop;
 import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.geom.AffineTransform;
@@ -39,6 +40,7 @@ import forge.gui.framework.FScreen;
 import forge.gui.interfaces.IGuiBase;
 import forge.gui.interfaces.IGuiGame;
 import forge.item.PaperCard;
+import forge.localinstance.properties.ForgeConstants;
 import forge.localinstance.skin.FSkinProp;
 import forge.localinstance.skin.ISkinImage;
 import forge.model.FModel;
@@ -162,18 +164,50 @@ public class GuiDesktop implements IGuiBase {
         return new FSkin.UnskinnedIcon(image, opacity);
     }
 
+    /** What {@link FOptionPane} returns when a dialog is closed without choosing an option. */
+    private static final int DIALOG_DISMISSED = -1;
+
+    /**
+     * Report a prompt that can't be shown because there's no display, so command line runs get the
+     * text on stderr instead of a {@link HeadlessException} thrown from inside the dialog.
+     */
+    private static void logSuppressedDialog(final String title, final String message, final String outcome) {
+        System.err.printf("[headless] %s: %s (%s)%n", title, message, outcome);
+    }
+
     @Override
     public void showImageDialog(final ISkinImage image, final String message, final String title) {
+        if (GraphicsEnvironment.isHeadless()) {
+            logSuppressedDialog(title, message, "dismissed");
+            return;
+        }
         FOptionPane.showMessageDialog(message, title, (SkinImage)image);
     }
 
     @Override
     public int showOptionDialog(final String message, final String title, final FSkinProp icon, final List<String> options, final int defaultOption) {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Deliberately NOT defaultOption. SOptionPane.showConfirmDialog is built on this method with
+            // the Yes button at index 0 and defaultYes=true, so returning the default would silently
+            // approve every confirmation — including destructive ones like overwriting a file or
+            // restarting the app. DIALOG_DISMISSED is what FOptionPane already returns when a user
+            // closes a dialog without choosing, so callers must handle it.
+            logSuppressedDialog(title, message, "dismissed, no option chosen");
+            return DIALOG_DISMISSED;
+        }
         return FOptionPane.showOptionDialog(message, title, icon == null ? null : FSkin.getImage(icon), options, defaultOption);
     }
 
     @Override
     public String showInputDialog(final String message, final String title, final FSkinProp icon, final String initialInput, final List<String> inputOptions, boolean isNumeric) {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Never null — matches the convention in HeadlessGuiDesktop, which subclasses this class.
+            final String fallback = initialInput != null ? initialInput
+                    : inputOptions != null && !inputOptions.isEmpty() ? inputOptions.get(0)
+                    : isNumeric ? "0" : "";
+            logSuppressedDialog(title, message, "using initial input: " + fallback);
+            return fallback;
+        }
         return FOptionPane.showInputDialog(message, title, icon == null ? null : FSkin.getImage(icon), initialInput, inputOptions);
     }
 
@@ -238,6 +272,10 @@ public class GuiDesktop implements IGuiBase {
 
     @Override
     public String showFileDialog(final String title, final String defaultDir) {
+        if (GraphicsEnvironment.isHeadless()) {
+            logSuppressedDialog(title, "file chooser", "cancelled");
+            return null;
+        }
         final JFileChooser fc = new JFileChooser(defaultDir);
         final int rc = fc.showDialog(null, title);
         if (rc != JFileChooser.APPROVE_OPTION) {
@@ -253,6 +291,27 @@ public class GuiDesktop implements IGuiBase {
 
     @Override
     public File getSaveFile(final File defaultFile) {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Callers fall back to the default path rather than prompting. A relative default is
+            // resolved against USER_DIR rather than the process working directory, keeping any
+            // sub-path it carries — but it is NOT contained: a default containing ".." still
+            // escapes, and a nested one can name a directory that does not exist, which
+            // BugReporter.saveToFile would fail to create. Callers passing anything but a bare
+            // filename should resolve it themselves.
+            //
+            // Null in, null out; every other input returns non-null, which is what
+            // BugReporter.saveToFile needs since it writes the result without a null check.
+            //
+            // Neither caller reaches this headless: BugReporter.saveToFile runs from the Swing Save
+            // button this class suppresses, and PlayerControllerHuman.dumpGameState from dev mode,
+            // passing an absolute path it then null-checks. So this is a guard for future callers
+            // rather than a fix for a live path.
+            if (defaultFile == null) {
+                return null;
+            }
+            return defaultFile.isAbsolute() ? defaultFile
+                    : new File(ForgeConstants.USER_DIR, defaultFile.getPath());
+        }
         final JFileChooser fc = new JFileChooser();
         fc.setSelectedFile(defaultFile);
         int result = fc.showSaveDialog(null);
@@ -266,6 +325,9 @@ public class GuiDesktop implements IGuiBase {
 
     @Override
     public void copyToClipboard(final String text) {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // no system clipboard without a display
+        }
         final StringSelection ss = new StringSelection(text);
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ss, null);
     }
@@ -349,14 +411,41 @@ public class GuiDesktop implements IGuiBase {
         OperatingSystem.preventSystemSleep(preventSleep);
     }
 
+    private static final float DEFAULT_SCREEN_SCALE = 1.0f;
+
     private static float initializeScreenScale() {
-        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
-        AffineTransform at = gc.getDefaultTransform();
-        double scaleX = at.getScaleX();
-        double scaleY = at.getScaleY();
-        return (float) Math.min(scaleX, scaleY);
+        if (GraphicsEnvironment.isHeadless()) {
+            // No display to measure — command line modes (sim, parse) run here.
+            return DEFAULT_SCREEN_SCALE;
+        }
+        try {
+            GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
+            AffineTransform at = gc.getDefaultTransform();
+            double scaleX = at.getScaleX();
+            double scaleY = at.getScaleY();
+            return (float) Math.min(scaleX, scaleY);
+        } catch (final Throwable t) {
+            // isHeadless() said otherwise, but the display is unusable anyway — a stale DISPLAY over
+            // ssh, or an X server that died. That throws AWTError, not HeadlessException, so
+            // catching only the latter would never fire for the situation this guard exists for.
+            // Throwable rather than the two named types because a JRE without the AWT natives
+            // raises UnsatisfiedLinkError here: anything escaping would poison ScreenScaleHolder
+            // and make every later read throw NoClassDefFoundError on the paint path. There is a
+            // safe default, so nothing is gained by letting any of it propagate.
+            return DEFAULT_SCREEN_SCALE;
+        }
     }
-    static float screenScale = initializeScreenScale();
+
+    /**
+     * Resolved on first use rather than in a static initializer: loading {@link GuiDesktop} must
+     * never touch the display, or command line modes die before they can parse their own arguments.
+     * The holder keeps that laziness without putting a lock on {@link #getScreenScale()}, which is
+     * called per-paint. {@link #initializeScreenScale()} never throws, so this cannot fail to
+     * initialize and leave every later read throwing NoClassDefFoundError.
+     */
+    private static final class ScreenScaleHolder {
+        static final float VALUE = initializeScreenScale();
+    }
 
     @Override
     public boolean hasNetGame() {
@@ -368,6 +457,6 @@ public class GuiDesktop implements IGuiBase {
 
     @Override
     public float getScreenScale() {
-        return screenScale;
+        return ScreenScaleHolder.VALUE;
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/error/BugReportDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/error/BugReportDialog.java
@@ -19,6 +19,7 @@ package forge.error;
 
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -55,6 +56,22 @@ public class BugReportDialog {
 
     public static void show(String title, String text, boolean showExitAppBtn) {
         if (dialogShown) { return; }
+
+        if (GraphicsEnvironment.isHeadless()) {
+            // Building the dialog would throw HeadlessException, and that secondary exception would
+            // replace the crash we were asked to report. Print instead.
+            //
+            // This repeats what BugReporter.reportException already wrote to stderr, so a crash is
+            // reported twice. That is deliberate: the alternative is inferring whether the caller
+            // already printed, and the only available signal (showExitAppBtn) means something else
+            // entirely, so a future caller would silently lose its whole report. De-duplicating
+            // properly means changing who prints in BugReporter, which is shared with the mobile
+            // ports and belongs in its own change. Duplicated output beats discarded output.
+            System.err.println("== " + title + " ==");
+            System.err.println(text);
+            System.err.flush();
+            return;
+        }
 
         JTextArea area = new JTextArea(text);
         area.setFont(new Font("Monospaced", Font.PLAIN, 10));

--- a/forge-gui-desktop/src/main/java/forge/view/Main.java
+++ b/forge-gui-desktop/src/main/java/forge/view/Main.java
@@ -33,6 +33,29 @@ public final class Main {
      * Main entry point for Forge
      */
     public static void main(final String[] args) {
+        // Command line modes must never touch the display: they run on servers, in CI, and over ssh.
+        // This has to happen before any AWT class loads, so it also has to happen before Sentry.init.
+        final String mode = args.length > 0 ? args[0].toLowerCase() : "";
+        if (isCommandLineMode(mode) && System.getProperty("java.awt.headless") == null) {
+            // Only when the user hasn't decided: setting this here would otherwise beat an explicit
+            // -Djava.awt.headless=false on the command line, since it runs before GraphicsEnvironment
+            // caches its answer.
+            System.setProperty("java.awt.headless", "true");
+        }
+
+        // Sentry chains to whatever default handler is already installed, but if none is, an uncaught
+        // exception is reported and then discarded without ever reaching stderr. Install a printing
+        // handler first so failures during the startup below are visible rather than a bare exit code.
+        //
+        // Scope: ExceptionHandler.registerErrorHandling() replaces the default handler outright, so
+        // this one only covers the window up to that call — which is where GuiBase.setInterface runs.
+        // After it, visibility depends on BugReporter, which prints before it reports.
+        Thread.setDefaultUncaughtExceptionHandler((t, ex) -> {
+            System.err.println("Uncaught exception in thread " + t.getName() + ":");
+            ex.printStackTrace();
+            System.err.flush();
+        });
+
         Sentry.init(options -> {
             options.setEnableExternalConfiguration(true);
             options.setRelease(BuildInfo.getVersionString());
@@ -70,8 +93,6 @@ public final class Main {
         }
 
         // command line startup here
-        String mode = args[0].toLowerCase();
-
         switch (mode) {
             case "sim":
                 SimulateMatch.simulate(args);
@@ -86,11 +107,21 @@ public final class Main {
                 break;
 
             default:
-                System.out.println("Unknown mode.\nKnown mode is 'sim', 'parse' ");
+                System.out.println("Unknown mode.\nKnown modes are 'sim', 'parse', 'server'");
                 break;
         }
 
         System.exit(0);
+    }
+
+    /**
+     * Modes that run to completion on the console and never open a window, and so should force
+     * headless AWT. Keep in sync with the named cases of the switch in {@link #main(String[])}.
+     * The switch's {@code default} arm also stays on the console, but an unrecognised argument is
+     * not a mode and only prints usage, so it is deliberately not listed here.
+     */
+    public static boolean isCommandLineMode(final String mode) {
+        return "sim".equals(mode) || "parse".equals(mode) || "server".equals(mode);
     }
 
     @SuppressWarnings("deprecation")

--- a/forge-gui-desktop/src/main/java/forge/view/Main.java
+++ b/forge-gui-desktop/src/main/java/forge/view/Main.java
@@ -47,9 +47,15 @@ public final class Main {
         // exception is reported and then discarded without ever reaching stderr. Install a printing
         // handler first so failures during the startup below are visible rather than a bare exit code.
         //
-        // Scope: ExceptionHandler.registerErrorHandling() replaces the default handler outright, so
-        // this one only covers the window up to that call — which is where GuiBase.setInterface runs.
-        // After it, visibility depends on BugReporter, which prints before it reports.
+        // This cannot just be registerErrorHandling() moved up: that reads ForgeConstants.LOG_FILE,
+        // whose class initializer resolves ASSETS_DIR through GuiBase.getInterface() and so needs the
+        // GUI interface already set. The window we need covered includes setting it, which is where
+        // the headless crash this fix is about used to happen — so the real handler cannot be
+        // installed early enough to see it, and something simpler has to cover the gap.
+        //
+        // Scope: registerErrorHandling() then replaces the default handler outright, so this one
+        // covers only the window up to that call. After it, visibility depends on BugReporter, which
+        // prints before it reports.
         Thread.setDefaultUncaughtExceptionHandler((t, ex) -> {
             System.err.println("Uncaught exception in thread " + t.getName() + ":");
             ex.printStackTrace();

--- a/forge-gui-desktop/src/test/java/forge/HeadlessStartupTest.java
+++ b/forge-gui-desktop/src/test/java/forge/HeadlessStartupTest.java
@@ -1,0 +1,282 @@
+package forge;
+
+import forge.view.Main;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Guards the command line modes ({@code sim}, {@code parse}, {@code server}) against regaining a
+ * hard dependency on a display.
+ *
+ * <p>The display checks have to run in a forked JVM. {@link java.awt.GraphicsEnvironment} decides
+ * whether it is headless once, on first use, and CI runs the suite under Xvfb with a real
+ * {@code DISPLAY} — so a check made inside the test JVM would exercise the headful path and prove
+ * nothing.
+ *
+ * <p>The regression being guarded: {@code GuiDesktop} once resolved the screen scale from a static
+ * initializer, so merely loading the class threw {@link java.awt.HeadlessException}. Since
+ * {@code Main} installs the GUI interface before it parses argv, {@code sim} died before it could
+ * read its own arguments.
+ *
+ * <p>{@code Main} forces {@code java.awt.headless} for console modes so that a desktop run takes the
+ * same path a server does, and leaves it alone when the user has set it explicitly. Both are
+ * asserted by reading the property back out of the forked JVM
+ * ({@link #mainForcesHeadlessUnlessUserSaysOtherwise()}) rather than by observing
+ * {@code isHeadless()}, which would be true anyway on a machine with no display and so would prove
+ * nothing there.
+ */
+// The per-method budget has to clear the probe budget below times the most forks any one method
+// runs (two), so a hung fork trips its own timeout and reports what it had printed so far, rather
+// than TestNG killing the method first with nothing to show.
+@Test(timeOut = 240000, enabled = true)
+public class HeadlessStartupTest {
+
+    /** Forks take ~2s in practice; this is a hang guard, not a deadline. */
+    private static final long PROBE_TIMEOUT_SECONDS = 90;
+
+    /** Loading GuiDesktop and reading the screen scale must work with no display available. */
+    public void guiDesktopLoadsHeadless() throws Exception {
+        ProbeResult result = runHeadless(ScreenScaleProbe.class.getName(), true);
+        assertEquals("probe failed, output was:\n" + result.output, 0, result.exitCode);
+        assertTrue("expected a usable screen scale, got:\n" + result.output,
+                result.output.contains("screenScale=1.0"));
+    }
+
+    /**
+     * Dialog entry points must degrade to a return value instead of throwing HeadlessException, and
+     * must not answer a confirmation on the user's behalf — {@code SOptionPane.showConfirmDialog}
+     * treats index 0 as "Yes", so returning the default option would approve destructive prompts.
+     */
+    public void dialogsDegradeHeadless() throws Exception {
+        ProbeResult result = runHeadless(DialogProbe.class.getName(), true);
+        assertEquals("probe failed, output was:\n" + result.output, 0, result.exitCode);
+        assertTrue("expected the dialog to report itself dismissed, got:\n" + result.output,
+                result.output.contains("optionDialog=-1"));
+        assertTrue("expected the initial input back, got:\n" + result.output,
+                result.output.contains("inputDialog=keep-me"));
+        assertTrue("expected a non-null fallback for a null initial input, got:\n" + result.output,
+                result.output.contains("inputDialogNullInitial="));
+        assertFalse("showInputDialog must never return null headless:\n" + result.output,
+                result.output.contains("inputDialogNullInitial=null"));
+    }
+
+    /**
+     * The whole of {@code Main}'s startup — including {@code GuiBase.setInterface(new GuiDesktop())},
+     * which is where the original bug struck — must survive with no display. {@code server} is used
+     * because it is the one console mode that returns without loading the card database.
+     */
+    public void mainStartsHeadless() throws Exception {
+        ProbeResult result = runInThrowawayHome(Main.class.getName(), List.of(), "server");
+        assertEquals("Main failed to start headless, output was:\n" + result.output, 0, result.exitCode);
+        assertFalse("Main hit a display dependency during startup:\n" + result.output,
+                result.output.contains("HeadlessException"));
+        assertTrue("expected the server mode banner, got:\n" + result.output,
+                result.output.contains("Dedicated server mode"));
+    }
+
+    /**
+     * Runs a class that starts {@code Main}, with the Forge profile pointed at a throwaway home so a
+     * test run leaves nothing in the developer's (or CI user's) real one. {@code user.home} covers
+     * Linux and macOS; Windows resolves its profile from APPDATA/LOCALAPPDATA instead, so those are
+     * overridden too.
+     */
+    private static ProbeResult runInThrowawayHome(final String mainClass, final List<String> jvmArgs,
+                                                  final String... args) throws Exception {
+        File fakeHome = Files.createTempDirectory("headless-probe-home").toFile();
+        // Backstop for the JVM being killed outright, matching the deleteOnExit on the temp files.
+        // Both calls throw IllegalStateException once shutdown has begun, so each is guarded, for a
+        // different reason: unguarded, the add would abandon the method before it ran at all and
+        // strand the directory it had just created, while the remove sits in a finally where it
+        // would replace the result or failure this method was about to report. An unregistered hook
+        // costs nothing more than the backstop — the finally below does the actual cleanup.
+        Thread cleanup = new Thread(() -> deleteRecursively(fakeHome));
+        try {
+            Runtime.getRuntime().addShutdownHook(cleanup);
+        } catch (final IllegalStateException alreadyShuttingDown) {
+            cleanup = null;
+        }
+        try {
+            List<String> withHome = new ArrayList<>(jvmArgs);
+            withHome.add("-Duser.home=" + fakeHome.getAbsolutePath());
+            return runHeadless(mainClass, false, withHome, fakeHome, args);
+        } finally {
+            deleteRecursively(fakeHome);
+            if (cleanup != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(cleanup);
+                } catch (final IllegalStateException alreadyShuttingDown) {
+                    // The hook will run during shutdown and find nothing left to delete.
+                }
+            }
+        }
+    }
+
+    private static void deleteRecursively(final File file) {
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+
+    /**
+     * A console mode must run headless even where a display exists, so a desktop run reproduces what
+     * a server does — but an explicit {@code -Djava.awt.headless=false} must still win.
+     */
+    public void mainForcesHeadlessUnlessUserSaysOtherwise() throws Exception {
+        ProbeResult forced = runInThrowawayHome(HeadlessPropertyProbe.class.getName(), List.of());
+        assertEquals("probe failed, output was:\n" + forced.output, 0, forced.exitCode);
+        assertTrue("Main must force headless for a console mode, got:\n" + forced.output,
+                forced.output.contains("java.awt.headless=true"));
+
+        ProbeResult explicit = runInThrowawayHome(HeadlessPropertyProbe.class.getName(),
+                List.of("-Djava.awt.headless=false"));
+        assertEquals("probe failed, output was:\n" + explicit.output, 0, explicit.exitCode);
+        assertTrue("an explicit -Djava.awt.headless=false must not be overridden, got:\n"
+                + explicit.output, explicit.output.contains("java.awt.headless=false"));
+    }
+
+    /** The console-mode list must stay in sync with the switch in {@code Main.main}. */
+    public void commandLineModesAreRecognized() {
+        assertTrue("sim must be a console mode", Main.isCommandLineMode("sim"));
+        assertTrue("parse must be a console mode", Main.isCommandLineMode("parse"));
+        assertTrue("server must be a console mode", Main.isCommandLineMode("server"));
+        assertFalse("the zero-argument GUI launch must not be a console mode",
+                Main.isCommandLineMode(""));
+        assertFalse("an unknown mode must not be a console mode", Main.isCommandLineMode("garbage"));
+    }
+
+    /**
+     * Runs a class in a forked JVM and returns its exit code and combined output.
+     *
+     * @param forceHeadless pass {@code -Djava.awt.headless=true}; {@code Main} sets it itself, so
+     *                      forcing it there would hide whether {@code Main} still does so
+     */
+    private static ProbeResult runHeadless(final String mainClass, final boolean forceHeadless,
+                                           final String... args) throws Exception {
+        return runHeadless(mainClass, forceHeadless, List.of(), null, args);
+    }
+
+    private static ProbeResult runHeadless(final String mainClass, final boolean forceHeadless,
+                                           final List<String> jvmArgs, final File homeOverride,
+                                           final String... args) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+        if (forceHeadless) {
+            command.add("-Djava.awt.headless=true");
+        }
+        command.addAll(jvmArgs);
+        command.add("-cp");
+        command.add(classPath());
+        command.add(mainClass);
+        command.addAll(List.of(args));
+
+        // Output goes to a file rather than a pipe this test reads. Draining a pipe to EOF before
+        // waiting would make the timeout below unreachable — EOF only arrives when the child exits —
+        // and would instead block here forever on a child that hangs holding stdout open.
+        File outputFile = File.createTempFile("headless-probe", ".log");
+        outputFile.deleteOnExit();
+        // An empty file as stdin gives the child immediate EOF, so a probe that ever reads the
+        // console can't wedge waiting for input nobody will type. Portable, unlike /dev/null.
+        File emptyStdin = File.createTempFile("headless-probe-stdin", "");
+        emptyStdin.deleteOnExit();
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        if (homeOverride != null) {
+            // ForgeProfileProperties reads these rather than user.home on Windows.
+            pb.environment().put("APPDATA", homeOverride.getAbsolutePath());
+            pb.environment().put("LOCALAPPDATA", homeOverride.getAbsolutePath());
+        }
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(outputFile);
+        pb.redirectInput(emptyStdin);
+
+        Process process = pb.start();
+        try {
+            if (!process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new AssertionError("headless probe timed out after " + PROBE_TIMEOUT_SECONDS
+                        + "s, output so far:\n" + read(outputFile));
+            }
+            return new ProbeResult(process.exitValue(), read(outputFile));
+        } finally {
+            // Covers the timeout above and a TestNG timeout unwinding this thread; without it a
+            // hung child is reparented to init and leaks for the life of the machine.
+            // Wait for it to actually die: the caller may be about to delete a directory the child
+            // is still writing into.
+            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
+            outputFile.delete();
+            emptyStdin.delete();
+        }
+    }
+
+    /**
+     * Surefire launches the test JVM from a manifest-only booter jar, then replaces
+     * {@code java.class.path} with the expanded test classpath and stashes the original booter jar
+     * in {@code surefire.real.class.path} — that property is the one-entry jar, not the real path,
+     * despite its name. So {@code java.class.path} is what the child wants.
+     */
+    private static String classPath() {
+        return System.getProperty("java.class.path");
+    }
+
+    private static String read(final File file) throws IOException {
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+
+    private static final class ProbeResult {
+        private final int exitCode;
+        private final String output;
+
+        private ProbeResult(final int exitCode, final String output) {
+            this.exitCode = exitCode;
+            this.output = output;
+        }
+    }
+
+    /** Runs in the forked JVM: loads GuiDesktop and reports the screen scale. */
+    public static final class ScreenScaleProbe {
+        public static void main(final String[] args) {
+            System.out.println("screenScale=" + new GuiDesktop().getScreenScale());
+        }
+    }
+
+    /**
+     * Runs in the forked JVM: lets {@code Main} start a console mode, then reports what
+     * {@code java.awt.headless} ended up as. The read happens in a shutdown hook because
+     * {@code Main.main} ends in {@code System.exit}, and the property is what matters rather than
+     * {@code isHeadless()} — the latter is true on a display-less machine no matter what Main does.
+     */
+    public static final class HeadlessPropertyProbe {
+        public static void main(final String[] args) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() ->
+                    System.out.println("java.awt.headless=" + System.getProperty("java.awt.headless"))));
+            // "server" returns immediately; every other console mode loads the card database first.
+            Main.main(new String[] {"server"});
+        }
+    }
+
+    /** Runs in the forked JVM: checks the dialog entry points return instead of throwing. */
+    public static final class DialogProbe {
+        public static void main(final String[] args) {
+            GuiDesktop gui = new GuiDesktop();
+            System.out.println("optionDialog=" + gui.showOptionDialog("msg", "title", null, null, 0));
+            System.out.println("inputDialog="
+                    + gui.showInputDialog("msg", "title", null, "keep-me", null, false));
+            System.out.println("inputDialogNullInitial="
+                    + gui.showInputDialog("msg", "title", null, null, null, false));
+        }
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/net/HeadlessGuiDesktop.java
+++ b/forge-gui-desktop/src/test/java/forge/net/HeadlessGuiDesktop.java
@@ -61,15 +61,23 @@ public class HeadlessGuiDesktop extends GuiDesktop implements IHasForgeLog {
     @Override
     public void showBazaar() { }
 
+    // The overrides below duplicate GuiDesktop's headless guards on purpose. Those guards key off
+    // GraphicsEnvironment.isHeadless(), which is false when the suite runs under Xvfb with a real
+    // DISPLAY — as CI does — so without these a test could open a genuine modal dialog and hang.
+    // Keep their return values in step with GuiDesktop's, or tests exercise semantics production
+    // no longer has.
+
     @Override
     public int showOptionDialog(final String message, final String title,
                                 final FSkinProp icon, final List<String> options,
                                 final int defaultOption) {
         System.err.println("[HeadlessGuiDesktop] " + title + ": " + message);
         if (options != null && !options.isEmpty()) {
-            System.err.println("[HeadlessGuiDesktop] Options: " + options + ", returning: " + defaultOption);
+            System.err.println("[HeadlessGuiDesktop] Options: " + options + ", dismissed without choosing");
         }
-        return defaultOption;
+        // Not defaultOption: SOptionPane.showConfirmDialog reads index 0 as "Yes", so returning the
+        // default would auto-approve every confirmation, including destructive ones.
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
## The problem

`sim` is documented as the way to run AI matches on headless servers, but it has been unable to start without a display since 48f3ae13154 (2022-04-16) — and it failed with **no output at all**:

```console
$ DISPLAY= java -jar forge.jar sim -d deck1 deck2 -n 1 -q
$ echo $?
1
# nothing on stdout, nothing on stderr
```

## Root cause

Two defects compound:

**1. An eager display touch during class load.** `GuiDesktop` resolved the screen scale from a static initializer, so merely *loading* the class called `GraphicsEnvironment.getDefaultScreenDevice()` and threw `HeadlessException`. `Main` installs the GUI interface before it parses argv, so `sim` died before it could read its own arguments.

**2. The crash was invisible.** Sentry's uncaught-exception handler chains to whatever default handler is already installed — and nothing installed one this early, so the exception was reported and then discarded without ever reaching stderr.

## The fix

- **`GuiDesktop`** — the screen scale is resolved on first use (via a holder, so the read stays lock-free on the paint path) and falls back to `1.0` when there is no display. Loading the class no longer touches the display.
- **`Main`** — sets `java.awt.headless` for the console modes before any AWT class loads, *unless the user set it explicitly*, so a desktop `sim` run exercises the same path a server does. Installs a printing uncaught-exception handler before `Sentry.init`, covering the startup window up to `ExceptionHandler.registerErrorHandling()` (which replaces the default handler; past that point `BugReporter` prints before it reports).
- **Dialog entry points** — degrade to a return value instead of throwing. This matters most for `BugReportDialog`: a crash mid-run built a dialog that itself threw, and that secondary exception *replaced* the crash being reported, so a failed batch run lost the actual bug.

One behavioural note worth flagging: `showOptionDialog` returns `-1` ("closed without choosing", which `FOptionPane` already returns) rather than the default option. `SOptionPane.showConfirmDialog` reads index 0 as *Yes* with `defaultYes=true` in all four overloads, so returning the default would have silently approved every confirmation — including destructive ones such as overwriting a saved game state.

## Testing

Verified on a host with no `DISPLAY`: a full game completes and exits 0, as do 2-player, 3-player, best-of-N (`-m`), Commander, Planechase, and a 4-player bracket tournament. A `-verbose:class` trace of a complete `sim` run shows no display-dependent AWT class is ever initialised. Under Xvfb the GUI is unchanged — output is byte-identical before and after apart from timestamps — and HiDPI still reports `2.0` with `-Dsun.java2d.uiScale=2`.

Full suite: 365 tests, 0 failures.

## On the new test

`CONTRIBUTING.md` asks contributors to avoid adding unnecessary tests, so let me make the case explicitly rather than leave it implied. This regression survived ~18k commits without anyone noticing, which is the "future integration regression" case that guidance carves out. `HeadlessStartupTest` forks a JVM with `-Djava.awt.headless=true`, because `GraphicsEnvironment` caches headlessness on first use and CI runs the suite under Xvfb with a real `DISPLAY` — so an in-process check would exercise the headful path and prove nothing.

It has five methods. Four fork a JVM and assert real behaviour. The fifth, `commandLineModesAreRecognized`, is a plain change-detector over a three-literal list — **I'm happy to drop it if you'd rather keep the suite lean.**

## Not addressed

Pre-existing and out of scope, but found while working here and worth separate issues:

- All 10 shipped `forge-gui/res/defaults/gauntlet/*.dat` files fail to deserialize (`GauntletIO.loadGauntlet` returns null with a `ConversionException`, surfacing at `CSubmenuGauntletContests.initialize`).
- `parse` mode is non-functional: it never initialises `Lang`, so `CardFace` NPEs. It is display-independent — it fails identically under Xvfb.

---

🤖 Written with [Claude Code](https://claude.com/claude-code) (Claude Opus 5), per the AI-agent disclosure in `CONTRIBUTING.md`. Also recorded as a `Co-Authored-By` trailer on the commit.
