### PR TITLE
Sentry: skip obvious custom script error

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/IllegalAbilityException.java
+++ b/forge-game/src/main/java/forge/game/ability/IllegalAbilityException.java
@@ -5,17 +5,23 @@ import forge.util.TextUtil;
 
 public class IllegalAbilityException extends RuntimeException {
     private static final long serialVersionUID = -8638474348184716635L;
+    private boolean fromCustom = false;
 
     public IllegalAbilityException(final SpellAbility sa) {
-        this(sa.toString());
+        super(sa.toString());
     }
 
     public IllegalAbilityException(final SpellAbility sa, final SpellAbilityEffect effect) {
-        this(TextUtil.concatWithSpace(sa.toString(), "(effect "+effect.getClass().getName()+")"));
+        super(TextUtil.concatWithSpace(sa.toString(), "(effect "+effect.getClass().getName()+")"));
     }
 
-    private IllegalAbilityException(final String message) {
-        super(message);
+    public IllegalAbilityException(final String message, final Throwable t, final boolean isCustom) {
+        super(message, t);
+        fromCustom = isCustom;
+    }
+
+    public boolean isCustom() {
+        return fromCustom;
     }
 
 }

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -29,6 +29,7 @@ import forge.game.GameLogEntryType;
 import forge.game.ability.AbilityFactory;
 import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
+import forge.game.ability.IllegalAbilityException;
 import forge.game.cost.*;
 import forge.game.event.GameEventAddLog;
 import forge.game.event.GameEventCardForetold;
@@ -480,7 +481,7 @@ public class CardFactoryUtil {
                 Sentry.addBreadcrumb(bread);
 
                 // rethrow the exception with card Name for the user
-                throw new RuntimeException("crash in raw Ability, check card script of " + card.getName(), e);
+                throw new IllegalAbilityException("crash in raw Ability, check card script of " + card.getName(), e, card.getRules() != null && card.getRules().isCustom());
             }
         }
     }

--- a/forge-gui/src/main/java/forge/gui/error/BugReporter.java
+++ b/forge-gui/src/main/java/forge/gui/error/BugReporter.java
@@ -17,6 +17,7 @@
  */
 package forge.gui.error;
 
+import forge.game.ability.IllegalAbilityException;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.util.SOptionPane;
@@ -79,7 +80,7 @@ public class BugReporter {
         else {
             sb.append(swStr);
         }
-        if (isSentryEnabled()) {
+        if ((!(exception instanceof IllegalAbilityException iae) || !iae.isCustom()) && isSentryEnabled()) {
             sendSentry();
         } else {
             GuiBase.getInterface().showBugReportDialog(Localizer.getInstance().getMessageorUseDefault("lblReportCrash", "Report a Crash"), sb.toString(), true);


### PR DESCRIPTION
Still looking for a way to detect all these custom LLM builds popping up but this is a start to reduce some noise.