### PR TITLE
Update Premodern banlist: add Parallax Tide

### DIFF
--- a/forge-gui/res/formats/Casual/Premodern.txt
+++ b/forge-gui/res/formats/Casual/Premodern.txt
@@ -3,4 +3,4 @@ Name:Premodern
 Order:106
 Type:Casual
 Sets:4ED, ICE, CHR, HML, ALL, MIR, VIS, 5ED, WTH, TMP, STH, EXO, USG, ULG, 6ED, UDS, MMQ, NMS, PCY, INV, PLS, 7ED, APC, ODY, TOR, JUD, ONS, LGN, SCG
-Banned:Amulet of Quoz; Balance; Brainstorm; Bronze Tablet; Channel; Demonic Consultation; Earthcraft; Entomb; Flash; Force of Will; Goblin Recruiter; Grim Monolith; Jeweled Bird; Land Tax; Mana Vault; Memory Jar; Mind Twist; Mind's Desire; Mystical Tutor; Necropotence; Rebirth; Strip Mine; Tempest Efreet; Tendrils of Agony; Time Spiral; Timmerian Fiends; Tolarian Academy; Vampiric Tutor; Windfall; Worldgorger Dragon; Yawgmoth's Bargain; Yawgmoth's Will
+Banned:Amulet of Quoz; Balance; Brainstorm; Bronze Tablet; Channel; Demonic Consultation; Earthcraft; Entomb; Flash; Force of Will; Goblin Recruiter; Grim Monolith; Jeweled Bird; Land Tax; Mana Vault; Memory Jar; Mind Twist; Mind's Desire; Mystical Tutor; Necropotence; Parallax Tide; Rebirth; Strip Mine; Tempest Efreet; Tendrils of Agony; Time Spiral; Timmerian Fiends; Tolarian Academy; Vampiric Tutor; Windfall; Worldgorger Dragon; Yawgmoth's Bargain; Yawgmoth's Will


### PR DESCRIPTION
### Summary

Adds `Parallax Tide` to the Premodern banned list in
`forge-gui/res/formats/Casual/Premodern.txt`.

Parallax Tide was banned in Premodern effective January 2026. 
It's a small PR that's long overdue! 
Glad to be back at contributing! 🚀 

### References for verification

- [Premodern Ban List Update 2026](https://premodernmagic.com/blog/ban-list-update-2026/)
- [Scryfall: banned:premodern](https://scryfall.com/search?q=banned%3Apremodern&order=name&unique=cards)