### PR TITLE
Architecture to skip GUI updates when simulating

### DIFF
--- a/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
@@ -83,6 +83,7 @@ public class GameCopier {
         GameRules currentRules = origGame.getRules();
         Match newMatch = new Match(currentRules, newPlayers, origGame.getView().getTitle());
         Game newGame = new Game(newPlayers, currentRules, newMatch);
+        newGame.setNoGUIUser();
         newGame.dangerouslySetTimestamp(origGame.getTimestamp());
 
         for (int i = 0; i < origGame.getPlayers().size(); i++) {

--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -67,6 +67,8 @@ public class Game {
     private static int maxId = 0;
     private static int nextId() { return ++maxId; }
 
+    private boolean noGUIUser;
+
     /** The ID. */
     private int id;
     private final GameRules rules;
@@ -265,7 +267,7 @@ public class Game {
     }
 
     public Player getPlayer(int id) {
-        for(Player p : allPlayers) {
+        for (Player p : allPlayers) {
             if (p.getId() == id) {
                 return p;
             }
@@ -1427,5 +1429,12 @@ public class Game {
     }
     public boolean canUseTimeout() {
         return AI_CAN_USE_TIMEOUT;
+    }
+
+    public boolean isNoGUIUser() {
+        return noGUIUser;
+    }
+    public void setNoGUIUser() {
+        noGUIUser = true;
     }
 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -407,7 +407,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
         game = game0;
         paperCard = paperCard0;
-        view = new CardView(id0, tracker0);
+        view = game0 != null && game0.isNoGUIUser() ? new DummyCardView(id0, tracker0) : new CardView(id0, tracker0);
         currentState = new CardState(view.getCurrentState(), this);
         states.put(CardStateName.Original, currentState);
         view.updateChangedColorWords(this);

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -552,7 +552,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
 
     public List<LandTraitChanges> getLandTraitChanges() { return this.landTraitChanges; }
 
-    public record LandTraitChanges(CardState state) implements ICardTraitChanges, IKeywordsChange
+    record LandTraitChanges(CardState state) implements ICardTraitChanges, IKeywordsChange
     {
         public List<SpellAbility> applySpellAbility(List<SpellAbility> list) {
             if (state.getCard().hasRemoveIntrinsic()) {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -552,7 +552,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
 
     public List<LandTraitChanges> getLandTraitChanges() { return this.landTraitChanges; }
 
-    record LandTraitChanges(CardState state) implements ICardTraitChanges, IKeywordsChange
+    public record LandTraitChanges(CardState state) implements ICardTraitChanges, IKeywordsChange
     {
         public List<SpellAbility> applySpellAbility(List<SpellAbility> list) {
             if (state.getCard().hasRemoveIntrinsic()) {

--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -91,11 +91,11 @@ public class CardView extends GameEntityView {
 
     public CardView(final int id0, final Tracker tracker) {
         super(id0, tracker);
-        set(TrackableProperty.CurrentState, new CardStateView(id0, CardStateName.Original, tracker));
+        set(TrackableProperty.CurrentState, createAlternateState(CardStateName.Original));
     }
     public CardView(final int id0, final Tracker tracker, final String name0, final String description, final Object object) {
         super(id0, tracker);
-        set(TrackableProperty.CurrentState, new CardStateView(id0, CardStateName.Original, tracker));
+        set(TrackableProperty.CurrentState, createAlternateState(CardStateName.Original));
         getCurrentState().setName(name0);
         getCurrentState().setOracleText(description);
         set(TrackableProperty.Name, name0);

--- a/forge-game/src/main/java/forge/game/card/DummyCardView.java
+++ b/forge-game/src/main/java/forge/game/card/DummyCardView.java
@@ -1,0 +1,27 @@
+package forge.game.card;
+
+import forge.card.CardStateName;
+import forge.trackable.Tracker;
+
+// this class should be used in games without GUI
+public class DummyCardView extends CardView {
+
+    public DummyCardView(final int id0, final Tracker tracker) {
+        super(id0, tracker);
+    }
+
+    @Override
+    public CardStateView createAlternateState(final CardStateName state0) {
+        return new DummyCardStateView(getId(), state0, tracker);
+    }
+
+    public class DummyCardStateView extends CardStateView {
+
+        public DummyCardStateView(final int id0, final CardStateName state0, final Tracker tracker) {
+            super(id0, state0, tracker);
+        }
+
+        @Override
+        void updateAbilityText(Card c, CardState state) {}
+    }
+}

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -83,8 +83,8 @@ public class ReplacementHandler {
 
             // CR 614.12 ETB replacements look at what the card would be on the battlefield
             affectedCard = (Card) runParams.get(AbilityKey.Affected);
-            // must force cache these ETB replacements so the LKI copies them
-            affectedCard.getCurrentState().getLandTraitChanges().get(0).applyReplacementEffect(Lists.newArrayList());
+            // must force cache the CardState ETB replacements so the LKI copies them
+            affectedCard.getReplacementEffects();
             affectedLKI = CardCopyService.getLKICopy(affectedCard);
             affectedLKI.setLastKnownZone(affectedCard.getController().getZone(ZoneType.Battlefield));
 

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -83,6 +83,8 @@ public class ReplacementHandler {
 
             // CR 614.12 ETB replacements look at what the card would be on the battlefield
             affectedCard = (Card) runParams.get(AbilityKey.Affected);
+            // must force cache these ETB replacements so the LKI copies them
+            affectedCard.getCurrentState().getLandTraitChanges().get(0).applyReplacementEffect(Lists.newArrayList());
             affectedLKI = CardCopyService.getLKICopy(affectedCard);
             affectedLKI.setLastKnownZone(affectedCard.getController().getZone(ZoneType.Battlefield));
 

--- a/forge-game/src/main/java/forge/game/trigger/TriggerLifeLost.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerLifeLost.java
@@ -61,7 +61,7 @@ public class TriggerLifeLost extends Trigger {
 
         // A source dealing exactly 1 damage to you will cause Sahir's last ability to trigger only once, even though you also lose exactly 1 life.
         // This is because the source dealing you damage isn't what's causing you to lose life. (That's a job for the rules!)
-        if (!matchesValidParam("ValidCause", runParams.get(AbilityKey.Player))) {
+        if (!matchesValidParam("ValidCause", runParams.get(AbilityKey.SpellAbility))) {
             return false;
         }
 

--- a/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
+++ b/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
@@ -165,7 +165,7 @@ public class SimulateMatch {
             sb.append(" seed ").append(seed);
         }
 
-        System.out.println(sb.toString());
+        System.out.println(sb);
 
         Match mc = new Match(rules, pp, "Test");
 
@@ -207,6 +207,7 @@ public class SimulateMatch {
         sw.start();
 
         final Game g1 = mc.createGame();
+        g1.setNoGUIUser();
         // will run match in the same thread
         try {
             TimeLimitedCodeBlock.runWithTimeout(() -> {


### PR DESCRIPTION
This skips one of the more expensive methods when there is no point in calculating it.
Since View classes might still be useful to interface with the engine in some cases this can be restricted further for developers as needed.

---

First commit also made me discover a nasty engine racing crash:
- when *Spark Double* copies a Planeswalker `loyaltyRep` is null at first
- `ReplacementHandler` now creates another LKI copy for the lookahead and only that will produce a new ETB counter replacement
- this leads to an endless loop (since the real Affected has none it's a new ID each round)

The only reason it didn't fail on master was because `getAbilityText()` was randomly calling `getReplacementEffects()` first to force the caching!