### PR TITLE
Fix iOS crash when importing decks from clipboard

### DIFF
--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * <p>
@@ -41,6 +42,9 @@ import java.util.regex.Pattern;
  * 
  */
 public class DeckRecognizer {
+    private static final Map<Pattern, Map<String, Integer>> PORTABLE_PATTERN_GROUPS =
+            Collections.synchronizedMap(new IdentityHashMap<>());
+
     /**
      * The Enum TokenType.
      */
@@ -403,12 +407,78 @@ public class DeckRecognizer {
     private static final String LINE_COMMENT_DELIMITER_OR_MD_HEADER = "#";
     private static final String ASTERISK = "* ";  // Note the blank space after asterisk!
 
+    private static Pattern compilePattern(String regex, int flags) {
+        try {
+            return Pattern.compile(regex, flags);
+        } catch (PatternSyntaxException ignored) {
+            // RoboVM's regex implementation does not support Java named capture groups.
+            return compilePortablePattern(regex, flags);
+        }
+    }
+
+    static Pattern compilePortablePattern(String regex, int flags) {
+        PortablePattern portablePattern = makePortablePattern(regex);
+        Pattern pattern = Pattern.compile(portablePattern.regex, flags);
+        PORTABLE_PATTERN_GROUPS.put(pattern, portablePattern.groupIndexes);
+        return pattern;
+    }
+
+    private static PortablePattern makePortablePattern(String regex) {
+        StringBuilder portableRegex = new StringBuilder(regex.length());
+        Map<String, Integer> groupIndexes = new HashMap<>();
+        int groupIndex = 0;
+        boolean inCharacterClass = false;
+
+        for (int i = 0; i < regex.length(); i++) {
+            char current = regex.charAt(i);
+            if (current == '\\' && i + 1 < regex.length()) {
+                portableRegex.append(current).append(regex.charAt(++i));
+                continue;
+            }
+            if (current == '[') {
+                inCharacterClass = true;
+            } else if (current == ']') {
+                inCharacterClass = false;
+            } else if (current == '(' && !inCharacterClass) {
+                boolean isSpecialGroup = i + 1 < regex.length() && regex.charAt(i + 1) == '?';
+                boolean isNamedGroup = isSpecialGroup && i + 3 < regex.length()
+                        && regex.charAt(i + 2) == '<'
+                        && regex.charAt(i + 3) != '=' && regex.charAt(i + 3) != '!';
+                if (isNamedGroup) {
+                    int nameEnd = regex.indexOf('>', i + 3);
+                    if (nameEnd < 0) {
+                        throw new PatternSyntaxException("Unclosed named capture group", regex, i);
+                    }
+                    groupIndexes.put(regex.substring(i + 3, nameEnd), ++groupIndex);
+                    portableRegex.append('(');
+                    i = nameEnd;
+                    continue;
+                }
+                if (!isSpecialGroup) {
+                    groupIndex++;
+                }
+            }
+            portableRegex.append(current);
+        }
+        return new PortablePattern(portableRegex.toString(), groupIndexes);
+    }
+
+    private static final class PortablePattern {
+        private final String regex;
+        private final Map<String, Integer> groupIndexes;
+
+        private PortablePattern(String regex, Map<String, Integer> groupIndexes) {
+            this.regex = regex;
+            this.groupIndexes = groupIndexes;
+        }
+    }
+
     // Core Matching Patterns (initialised in Constructor)
     public static final String REGRP_DECKNAME = "deckName";
     public static final String REX_DECK_NAME =
             String.format("^(\\/\\/\\s*)?(?<pre>(deck|name(\\s)?))(\\:|=)\\s*(?<%s>([a-zA-Z0-9',\\/\\-\\s\\)\\]\\(\\[\\#]+))\\s*(.*)$",
                     REGRP_DECKNAME);
-    public static final Pattern DECK_NAME_PATTERN = Pattern.compile(REX_DECK_NAME, Pattern.CASE_INSENSITIVE);
+    public static final Pattern DECK_NAME_PATTERN = compilePattern(REX_DECK_NAME, Pattern.CASE_INSENSITIVE);
 
     public static final String REGRP_TOKEN = "token";
     public static final String REGRP_COLR1 = "colr1";
@@ -422,11 +492,11 @@ public class DeckRecognizer {
     public static final String REX_MANA_COLOURS = String.format("(\\{(%s)\\})|(white|blue|black|red|green|colo(u)?rless|multicolo(u)?r)", MANA_SYMBOLS);
     public static final String REX_MANA = String.format("^(?<pre>[^a-zA-Z]*)\\s*(?<%s>(%s))((\\s|-|\\|)(?<%s>(%s)))?(?<post>[^a-zA-Z]*)?$",
             REGRP_COLR1, REX_MANA_COLOURS, REGRP_COLR2, REX_MANA_COLOURS);
-    public static final Pattern NONCARD_PATTERN = Pattern.compile(REX_NOCARD, Pattern.CASE_INSENSITIVE);
-    public static final Pattern CMC_PATTERN = Pattern.compile(REX_CMC, Pattern.CASE_INSENSITIVE);
-    public static final Pattern CARD_RARITY_PATTERN = Pattern.compile(REX_RARITY, Pattern.CASE_INSENSITIVE);
-    public static final Pattern MANA_PATTERN = Pattern.compile(REX_MANA, Pattern.CASE_INSENSITIVE);
-    public static final Pattern MANA_SYMBOL_PATTERN = Pattern.compile(REX_MANA_SYMBOLS, Pattern.CASE_INSENSITIVE);
+    public static final Pattern NONCARD_PATTERN = compilePattern(REX_NOCARD, Pattern.CASE_INSENSITIVE);
+    public static final Pattern CMC_PATTERN = compilePattern(REX_CMC, Pattern.CASE_INSENSITIVE);
+    public static final Pattern CARD_RARITY_PATTERN = compilePattern(REX_RARITY, Pattern.CASE_INSENSITIVE);
+    public static final Pattern MANA_PATTERN = compilePattern(REX_MANA, Pattern.CASE_INSENSITIVE);
+    public static final Pattern MANA_SYMBOL_PATTERN = compilePattern(REX_MANA_SYMBOLS, Pattern.CASE_INSENSITIVE);
 
     public static final String REGRP_SET = "setcode";
     public static final String REGRP_COLLNR = "collnr";
@@ -451,36 +521,36 @@ public class DeckRecognizer {
     public static final String REX_CARD_SET_REQUEST = String.format(
             "(%s\\s*:\\s*)?(%s\\s)?\\s*%s\\s*(\\s|\\||\\(|\\[|\\{)\\s?%s(\\s|\\)|\\]|\\})?\\s*%s",
             REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_CARD_NAME, REX_SET_CODE, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern CARD_SET_PATTERN = Pattern.compile(REX_CARD_SET_REQUEST);
+    public static final Pattern CARD_SET_PATTERN = compilePattern(REX_CARD_SET_REQUEST, 0);
     // 2. Set-Card Request (Amount?, Set, CardName)
     public static final String REX_SET_CARD_REQUEST = String.format(
             "(%s\\s*:\\s*)?(%s\\s)?\\s*(\\(|\\[|\\{)?%s(\\s+|\\)|\\]|\\}|\\|)\\s*%s\\s*%s\\s*",
             REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_SET_CODE, REX_CARD_NAME, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern SET_CARD_PATTERN = Pattern.compile(REX_SET_CARD_REQUEST);
+    public static final Pattern SET_CARD_PATTERN = compilePattern(REX_SET_CARD_REQUEST, 0);
     // 3. Full-Request (Amount?, CardName, Set, Collector Number|Art Index) - MTGArena Format
     public static final String REX_FULL_REQUEST_CARD_SET = String.format(
             "(%s\\s*:\\s*)?(%s\\s)?\\s*%s\\s*(\\||\\(|\\[|\\{|\\s)%s(\\s|\\)|\\]|\\})?(\\s+|\\|\\s*)%s\\s*%s\\s*",
             REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_CARD_NAME, REX_SET_CODE, REX_COLL_NUMBER, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern CARD_SET_COLLNO_PATTERN = Pattern.compile(REX_FULL_REQUEST_CARD_SET);
+    public static final Pattern CARD_SET_COLLNO_PATTERN = compilePattern(REX_FULL_REQUEST_CARD_SET, 0);
     // 4. Full-Request (Amount?, Set, CardName, Collector Number|Art Index) - Alternative for flexibility
     public static final String REX_FULL_REQUEST_SET_CARD = String.format(
             "^(%s\\s*:\\s*)?(%s\\s)?\\s*(\\(|\\[|\\{)?%s(\\s+|\\)|\\]|\\}|\\|)\\s*%s(\\s+|\\|\\s*)%s\\s*%s$",
             REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_SET_CODE, REX_CARD_NAME, REX_COLL_NUMBER, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern SET_CARD_COLLNO_PATTERN = Pattern.compile(REX_FULL_REQUEST_SET_CARD);
+    public static final Pattern SET_CARD_COLLNO_PATTERN = compilePattern(REX_FULL_REQUEST_SET_CARD, 0);
     // 5. (MTGGoldfish mostly) (Amount?, Card Name, <Collector Number>, Set)
     public static final String REX_FULL_REQUEST_CARD_COLLNO_SET = String.format(
             "^(%s\\s*:\\s*)?(%s\\s)?\\s*%s\\s+(\\<%s\\>)\\s*(\\(|\\[|\\{)?%s(\\s+|\\)|\\]|\\}|\\|)\\s*%s$",
             REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_CARD_NAME, REX_COLL_NUMBER, REX_SET_CODE, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern CARD_COLLNO_SET_PATTERN = Pattern.compile(REX_FULL_REQUEST_CARD_COLLNO_SET);
+    public static final Pattern CARD_COLLNO_SET_PATTERN = compilePattern(REX_FULL_REQUEST_CARD_COLLNO_SET, 0);
     // 6. XMage format (Amount?, [Set:Collector Number] Card Name)
     public static final String REX_FULL_REQUEST_XMAGE = String.format(
             "^(%s\\s*:\\s*)?(%s\\s)?\\s*(\\[)?%s:%s(\\])\\s+%s\\s*%s$",
             REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_SET_CODE, REX_COLL_NUMBER, REX_CARD_NAME, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern SET_COLLNO_CARD_XMAGE_PATTERN = Pattern.compile(REX_FULL_REQUEST_XMAGE);
+    public static final Pattern SET_COLLNO_CARD_XMAGE_PATTERN = compilePattern(REX_FULL_REQUEST_XMAGE, 0);
     // 7. Card-Only Request (Amount?)
     public static final String REX_CARDONLY = String.format(
             "(%s\\s*:\\s*)?(%s\\s)?\\s*%s\\s*%s", REX_DECKSEC_XMAGE, REX_CARD_COUNT, REX_CARD_NAME, REX_FOIL_MTGGOLDFISH);
-    public static final Pattern CARD_ONLY_PATTERN = Pattern.compile(REX_CARDONLY);
+    public static final Pattern CARD_ONLY_PATTERN = compilePattern(REX_CARDONLY, 0);
 
     // CoreTypes (to recognise Tokens of type CardType
     private static final CharSequence[] CARD_TYPES = allCardTypes();
@@ -622,7 +692,7 @@ public class DeckRecognizer {
     }
 
     public static String purgeAllLinks(String line){
-        String urlPattern = "(?<protocol>((https|ftp|file|http):))(?<sep>((//|\\\\)+))(?<url>([\\w\\d:#@%/;$~_?+-=\\\\.&]*))";
+        String urlPattern = "(?:(?:https|ftp|file|http):)(?:(?://|\\\\)+)(?:[\\w\\d:#@%/;$~_?+-=\\\\.&]*)";
         Pattern p = Pattern.compile(urlPattern, Pattern.CASE_INSENSITIVE);
         Matcher m = p.matcher(line);
 
@@ -793,14 +863,17 @@ public class DeckRecognizer {
                 (this.gameFormatRestrictedCards != null && !this.gameFormatRestrictedCards.isEmpty());
     }
 
-    private String getRexGroup(Matcher matcher, String groupName){
-        String rexGroup;
-        try{
-            rexGroup = matcher.group(groupName);
-        } catch (IllegalArgumentException ex) {
-            rexGroup = null;
+    static String getRexGroup(Matcher matcher, String groupName){
+        Map<String, Integer> groupIndexes = PORTABLE_PATTERN_GROUPS.get(matcher.pattern());
+        if (groupIndexes != null) {
+            Integer groupIndex = groupIndexes.get(groupName);
+            return groupIndex == null ? null : matcher.group(groupIndex);
         }
-        return rexGroup;
+        try{
+            return matcher.group(groupName);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     private boolean isBannedInFormat(PaperCard pc) {
@@ -916,7 +989,7 @@ public class DeckRecognizer {
         Matcher noncardMatcher = NONCARD_PATTERN.matcher(line);
         if (!noncardMatcher.matches())
             return null;
-        return noncardMatcher.group(REGRP_TOKEN);
+        return getRexGroup(noncardMatcher, REGRP_TOKEN);
     }
 
     private static String cardRarityTokenMatch(final String lineAsIs){
@@ -926,7 +999,7 @@ public class DeckRecognizer {
         Matcher cardRarityMatcher = CARD_RARITY_PATTERN.matcher(line);
         if (!cardRarityMatcher.matches())
             return null;
-        return cardRarityMatcher.group(REGRP_TOKEN);
+        return getRexGroup(cardRarityMatcher, REGRP_TOKEN);
     }
 
     private static String cardCMCTokenMatch(final String lineAsIs){
@@ -936,7 +1009,7 @@ public class DeckRecognizer {
         Matcher cardCMCmatcher = CMC_PATTERN.matcher(line);
         if (!cardCMCmatcher.matches())
             return null;
-        return cardCMCmatcher.group(REGRP_TOKEN);
+        return getRexGroup(cardCMCmatcher, REGRP_TOKEN);
     }
 
     private String getCardCMCMatch(String lineAsIs) {
@@ -956,8 +1029,8 @@ public class DeckRecognizer {
         Matcher manaMatcher = MANA_PATTERN.matcher(line);
         if (!manaMatcher.matches())
             return null;
-        String firstMana = manaMatcher.group(REGRP_COLR1);
-        String secondMana = manaMatcher.group(REGRP_COLR2);
+        String firstMana = getRexGroup(manaMatcher, REGRP_COLR1);
+        String secondMana = getRexGroup(manaMatcher, REGRP_COLR2);
         firstMana = matchAnyManaSymbolIn(firstMana);
         secondMana = matchAnyManaSymbolIn(secondMana);
         return Pair.of(firstMana, secondMana);
@@ -968,7 +1041,7 @@ public class DeckRecognizer {
             return null;
         Matcher matchManaSymbol = MANA_SYMBOL_PATTERN.matcher(manaToken);
         if (matchManaSymbol.matches())
-            return matchManaSymbol.group(REGRP_MANA);
+            return getRexGroup(matchManaSymbol, REGRP_MANA);
         return manaToken;
     }
 
@@ -1028,7 +1101,7 @@ public class DeckRecognizer {
         String line = text.trim();
         final Matcher deckNamePattern = DECK_NAME_PATTERN.matcher(line);
         if (deckNamePattern.matches())
-            return deckNamePattern.group(REGRP_DECKNAME);  // Deck name is at match 7
+            return getRexGroup(deckNamePattern, REGRP_DECKNAME);
         return "";
     }
 

--- a/forge-gui-desktop/src/test/java/forge/deck/DeckRecognizerPortablePatternTest.java
+++ b/forge-gui-desktop/src/test/java/forge/deck/DeckRecognizerPortablePatternTest.java
@@ -1,0 +1,51 @@
+package forge.deck;
+
+import org.testng.annotations.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class DeckRecognizerPortablePatternTest {
+    @Test
+    public void testPortablePatternFallback() {
+        String[] importerPatterns = {
+                DeckRecognizer.REX_DECK_NAME,
+                DeckRecognizer.REX_NOCARD,
+                DeckRecognizer.REX_CMC,
+                DeckRecognizer.REX_RARITY,
+                DeckRecognizer.REX_MANA,
+                DeckRecognizer.REX_MANA_SYMBOLS,
+                DeckRecognizer.REX_CARD_SET_REQUEST,
+                DeckRecognizer.REX_SET_CARD_REQUEST,
+                DeckRecognizer.REX_FULL_REQUEST_CARD_SET,
+                DeckRecognizer.REX_FULL_REQUEST_SET_CARD,
+                DeckRecognizer.REX_FULL_REQUEST_CARD_COLLNO_SET,
+                DeckRecognizer.REX_FULL_REQUEST_XMAGE,
+                DeckRecognizer.REX_CARDONLY
+        };
+        for (String regex : importerPatterns) {
+            DeckRecognizer.compilePortablePattern(regex, Pattern.CASE_INSENSITIVE);
+        }
+
+        Pattern deckNamePattern = DeckRecognizer.compilePortablePattern(
+                DeckRecognizer.REX_DECK_NAME, Pattern.CASE_INSENSITIVE);
+        Matcher deckNameMatcher = deckNamePattern.matcher("Deck: Red Green Aggro");
+        assertTrue(deckNameMatcher.matches());
+        assertEquals(DeckRecognizer.getRexGroup(deckNameMatcher, DeckRecognizer.REGRP_DECKNAME),
+                "Red Green Aggro");
+
+        Pattern cardPattern = DeckRecognizer.compilePortablePattern(
+                DeckRecognizer.REX_FULL_REQUEST_CARD_SET, 0);
+        Matcher cardMatcher = cardPattern.matcher("SB:4x Power Sink+ (TMP) 78 *F*");
+        assertTrue(cardMatcher.matches());
+        assertEquals(DeckRecognizer.getRexGroup(cardMatcher, DeckRecognizer.REGRP_DECK_SEC_XMAGE_STYLE), "SB");
+        assertEquals(DeckRecognizer.getRexGroup(cardMatcher, DeckRecognizer.REGRP_CARDNO), "4");
+        assertEquals(DeckRecognizer.getRexGroup(cardMatcher, DeckRecognizer.REGRP_CARD), "Power Sink+ ");
+        assertEquals(DeckRecognizer.getRexGroup(cardMatcher, DeckRecognizer.REGRP_SET), "TMP");
+        assertEquals(DeckRecognizer.getRexGroup(cardMatcher, DeckRecognizer.REGRP_COLLNR), "78");
+        assertEquals(DeckRecognizer.getRexGroup(cardMatcher, DeckRecognizer.REGRP_FOIL_GFISH), "*F*");
+    }
+}


### PR DESCRIPTION
## Summary

- avoid the iOS/RoboVM crash caused by named capture groups in the deck import regexes
- preserve named-group behavior on standard JVMs while falling back to indexed capture groups on regex engines that reject the syntax
- cover every importer pattern and a representative sideboard/card line with a portability regression test

## Root cause

Opening **Import from Clipboard** initializes `DeckRecognizer`. RoboVM's regex implementation rejects Java named capture syntax such as `(?<pre>...)`, which raised a `PatternSyntaxException` during static initialization and terminated the iOS app with an `ExceptionInInitializerError`.

## Testing

- focused Maven regression test passed for `DeckRecognizerPortablePatternTest`
- iOS IPA built successfully in GitHub Actions
- installed and verified on a physical iPad running iPadOS 18.7.3
- confirmed the original clipboard import crashed before the change and imports successfully afterward

## Contribution note

The issue was reproduced and the fix was validated on-device by the contributor. OpenAI Codex assisted with diagnosis, implementation, test creation, and PR preparation.