### PR TITLE
Allow shared fetches when other players have no cards to retrieve

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -333,6 +333,11 @@ public class ChangeZoneAi extends SpellAbilityAi {
             ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger());
         }
 
+        final boolean allowEmptyDefinedPlayers = isMandatoryCreatureGraveyardReturn(sa, origin, type);
+        boolean emptyDefinedPlayer = false;
+        boolean nonEmptyDefinedPlayer = false;
+        boolean ownCanReturn = false;
+
         for (final Player p : pDefined) {
             CardCollectionView list = p.getCardsIn(origin);
 
@@ -358,7 +363,23 @@ public class ChangeZoneAi extends SpellAbilityAi {
             }
 
             if (!activateForCost && list.isEmpty()) {
-                return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                if (allowEmptyDefinedPlayers && p != ai) {
+                    emptyDefinedPlayer = true;
+                } else {
+                    return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                }
+            }
+            if (allowEmptyDefinedPlayers) {
+                if (p == ai) {
+                    for (final Card card : list) {
+                        if (!ComputerUtil.isETBprevented(card)) {
+                            ownCanReturn = true;
+                            break;
+                        }
+                    }
+                } else if (!list.isEmpty()) {
+                    nonEmptyDefinedPlayer = true;
+                }
             }
             if ("Atarka's Command".equals(sourceName)
                     && (list.size() < 2 || ai.getLandsPlayedThisTurn() < 1)) {
@@ -402,6 +423,11 @@ public class ChangeZoneAi extends SpellAbilityAi {
             }
         }
 
+        if (!activateForCost && allowEmptyDefinedPlayers && emptyDefinedPlayer
+                && (nonEmptyDefinedPlayer || !ownCanReturn)) {
+            return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+        }
+
         if (ComputerUtil.playImmediately(ai, sa)) {
             return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
         }
@@ -424,6 +450,15 @@ public class ChangeZoneAi extends SpellAbilityAi {
         }
 
         return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+    }
+
+    private static boolean isMandatoryCreatureGraveyardReturn(final SpellAbility sa,
+            final List<ZoneType> origin, final String type) {
+        return sa.hasParam("Mandatory") && !sa.usesTargeting() && sa.hasParam("DefinedPlayer")
+                && "Player".equals(sa.getParam("DefinedPlayer")) && "Creature".equals(type)
+                && "1".equals(sa.getParamOrDefault("ChangeNum", "1"))
+                && ZoneType.Battlefield.equals(ZoneType.smartValueOf(sa.getParam("Destination")))
+                && origin != null && origin.size() == 1 && ZoneType.Graveyard.equals(origin.get(0));
     }
 
     /**

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -333,11 +333,6 @@ public class ChangeZoneAi extends SpellAbilityAi {
             ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger());
         }
 
-        final boolean allowEmptyDefinedPlayers = canIgnoreEmptyDefinedPlayers(ai, sa, origin,
-                destination, pDefined);
-        boolean emptyDefinedPlayer = false;
-        CardCollectionView ownCards = null;
-
         for (final Player p : pDefined) {
             CardCollectionView list = p.getCardsIn(origin);
 
@@ -357,21 +352,17 @@ public class ChangeZoneAi extends SpellAbilityAi {
                 });
             }
             // TODO: prevent ai searching its own library when Ob Nixilis, Unshackled is in play
-            if (origin != null && origin.size() == 1 && origin.get(0).isKnown()) {
+            else if (origin != null && origin.size() == 1 && origin.get(0).isKnown()) {
                 // FIXME: make this properly interact with several origin zones
                 list = CardLists.getValidCards(list, type, source.getController(), source, sa);
             }
 
-            if (allowEmptyDefinedPlayers && !activateForCost && p != ai && list.isEmpty()) {
-                emptyDefinedPlayer = true;
-                continue;
-            }
-            if (!activateForCost && list.isEmpty()) {
+            if (!activateForCost &&
+                    (p == ai || !canIgnoreEmptyDefinedPlayers(ai, sa, origin, destination, pDefined)) &&
+                    (list.isEmpty() || ("Battlefield".equals(destination) && Iterables.any(list, card -> ComputerUtil.isETBprevented(card))))) {
                 return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
             }
-            if (allowEmptyDefinedPlayers && p == ai) {
-                ownCards = list;
-            }
+
             if ("Atarka's Command".equals(sourceName)
                     && (list.size() < 2 || ai.getLandsPlayedThisTurn() < 1)) {
                 // be strict on playing lands off charms
@@ -412,11 +403,6 @@ public class ChangeZoneAi extends SpellAbilityAi {
                 }
                 return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
             }
-        }
-
-        if (!activateForCost && emptyDefinedPlayer && "Battlefield".equals(destination)
-                && (ownCards == null || !Iterables.any(ownCards, card -> !ComputerUtil.isETBprevented(card)))) {
-            return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
 
         if (ComputerUtil.playImmediately(ai, sa)) {
@@ -491,9 +477,6 @@ public class ChangeZoneAi extends SpellAbilityAi {
      * @return a boolean.
      */
     private static AiAbilityDecision hiddenTriggerAI(final Player ai, final SpellAbility sa, final boolean mandatory) {
-        // Fetching should occur fairly often as it helps cast more spells, and
-        // have access to more mana
-
         List<ZoneType> origin = new ArrayList<>();
         if (sa.hasParam("Origin")) {
             origin = ZoneType.listValueOf(sa.getParam("Origin"));

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -333,10 +333,10 @@ public class ChangeZoneAi extends SpellAbilityAi {
             ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger());
         }
 
-        final boolean allowEmptyDefinedPlayers = isMandatoryCreatureGraveyardReturn(sa, origin, type);
+        final boolean allowEmptyDefinedPlayers = canIgnoreEmptyDefinedPlayers(ai, sa, origin,
+                destination, pDefined);
         boolean emptyDefinedPlayer = false;
-        boolean nonEmptyDefinedPlayer = false;
-        boolean ownCanReturn = false;
+        CardCollectionView ownCards = null;
 
         for (final Player p : pDefined) {
             CardCollectionView list = p.getCardsIn(origin);
@@ -362,24 +362,15 @@ public class ChangeZoneAi extends SpellAbilityAi {
                 list = CardLists.getValidCards(list, type, source.getController(), source, sa);
             }
 
-            if (!activateForCost && list.isEmpty()) {
-                if (allowEmptyDefinedPlayers && p != ai) {
-                    emptyDefinedPlayer = true;
-                } else {
-                    return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
-                }
+            if (allowEmptyDefinedPlayers && !activateForCost && p != ai && list.isEmpty()) {
+                emptyDefinedPlayer = true;
+                continue;
             }
-            if (allowEmptyDefinedPlayers) {
-                if (p == ai) {
-                    for (final Card card : list) {
-                        if (!ComputerUtil.isETBprevented(card)) {
-                            ownCanReturn = true;
-                            break;
-                        }
-                    }
-                } else if (!list.isEmpty()) {
-                    nonEmptyDefinedPlayer = true;
-                }
+            if (!activateForCost && list.isEmpty()) {
+                return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+            }
+            if (allowEmptyDefinedPlayers && p == ai) {
+                ownCards = list;
             }
             if ("Atarka's Command".equals(sourceName)
                     && (list.size() < 2 || ai.getLandsPlayedThisTurn() < 1)) {
@@ -423,8 +414,8 @@ public class ChangeZoneAi extends SpellAbilityAi {
             }
         }
 
-        if (!activateForCost && allowEmptyDefinedPlayers && emptyDefinedPlayer
-                && (nonEmptyDefinedPlayer || !ownCanReturn)) {
+        if (!activateForCost && emptyDefinedPlayer && "Battlefield".equals(destination)
+                && (ownCards == null || !Iterables.any(ownCards, card -> !ComputerUtil.isETBprevented(card)))) {
             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
 
@@ -452,13 +443,12 @@ public class ChangeZoneAi extends SpellAbilityAi {
         return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
     }
 
-    private static boolean isMandatoryCreatureGraveyardReturn(final SpellAbility sa,
-            final List<ZoneType> origin, final String type) {
-        return sa.hasParam("Mandatory") && !sa.usesTargeting() && sa.hasParam("DefinedPlayer")
-                && "Player".equals(sa.getParam("DefinedPlayer")) && "Creature".equals(type)
-                && "1".equals(sa.getParamOrDefault("ChangeNum", "1"))
-                && ZoneType.Battlefield.equals(ZoneType.smartValueOf(sa.getParam("Destination")))
-                && origin != null && origin.size() == 1 && ZoneType.Graveyard.equals(origin.get(0));
+    private static boolean canIgnoreEmptyDefinedPlayers(final Player ai, final SpellAbility sa,
+            final List<ZoneType> origin, final String destination, final Iterable<Player> pDefined) {
+        return !sa.usesTargeting() && !sa.isCurse() && Iterables.contains(pDefined, ai)
+                && ("Hand".equals(destination) || "Battlefield".equals(destination))
+                && origin != null && origin.size() == 1
+                && (origin.get(0) == ZoneType.Library || origin.get(0) == ZoneType.Graveyard);
     }
 
     /**

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 import forge.ai.AITest;
+import forge.ai.AiPlayDecision;
+import forge.ai.PlayerControllerAi;
 import forge.ai.SpellApiToAi;
 import forge.game.Game;
 import forge.game.ability.ApiType;
@@ -71,40 +73,6 @@ public class ChangeZoneAiTest extends AITest {
     }
 
     @Test
-    public void testWeirdHarvestWithEmptyOpponentLibrary() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-
-        addCards("Forest", 5, ai);
-        addCardToZone("Runeclaw Bear", ai, ZoneType.Library);
-        Card harvest = addCardToZone("Weird Harvest", ai, ZoneType.Hand);
-        SpellAbility sa = harvest.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
-
-        AssertJUnit.assertTrue("AI should cast Weird Harvest when only its library has a creature",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
-        AssertJUnit.assertTrue("Weird Harvest should pay a positive X value",
-                sa.getXManaCostPaid() > 0);
-    }
-
-    @Test
-    public void testNewFrontiersWithEmptyOpponentLibrary() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-
-        addCards("Forest", 5, ai);
-        addCardToZone("Forest", ai, ZoneType.Library);
-        Card frontiers = addCardToZone("New Frontiers", ai, ZoneType.Hand);
-        SpellAbility sa = frontiers.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
-
-        AssertJUnit.assertTrue("AI should cast New Frontiers when only its library has a basic land",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
-        AssertJUnit.assertTrue("New Frontiers should pay a positive X value",
-                sa.getXManaCostPaid() > 0);
-    }
-
-    @Test
     public void testExhumeWithMixedGraveyards() {
         Game game = initAndCreateThreePlayerGame();
         Player ai = game.getPlayers().get(1);
@@ -122,19 +90,24 @@ public class ChangeZoneAiTest extends AITest {
     }
 
     @Test
-    public void testLibraryRetrievalRequiresAnOwnCard() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-        Player opponent = game.getPlayers().get(0);
+    public void testExhumeRequiresAnOwnCreature() {
+        for (String ownCard : new String[] {null, "Swamp"}) {
+            Game game = initAndCreateGame();
+            Player ai = game.getPlayers().get(1);
+            Player opponent = game.getPlayers().get(0);
 
-        addCards("Forest", 5, ai);
-        addCardToZone("Forest", opponent, ZoneType.Library);
-        Card frontiers = addCardToZone("New Frontiers", ai, ZoneType.Hand);
-        SpellAbility sa = frontiers.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
+            addCards("Swamp", 2, ai);
+            if (ownCard != null) {
+                addCardToZone(ownCard, ai, ZoneType.Graveyard);
+            }
+            addCardToZone("Grizzly Bears", opponent, ZoneType.Graveyard);
+            Card exhume = addCardToZone("Exhume", ai, ZoneType.Hand);
+            SpellAbility sa = exhume.getSpellAbilities().get(0);
+            sa.setActivatingPlayer(ai);
 
-        AssertJUnit.assertFalse("AI should not cast New Frontiers without an eligible own card",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+            AssertJUnit.assertFalse("AI should not cast Exhume without an own creature",
+                    ((PlayerControllerAi) ai.getController()).getAi().canPlaySa(sa) == AiPlayDecision.WillPlay);
+        }
     }
 
     @Test

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
@@ -69,4 +69,118 @@ public class ChangeZoneAiTest extends AITest {
         AssertJUnit.assertTrue("AI should cast Exhume when only its graveyard has a creature",
                 SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
     }
+
+    @Test
+    public void testWeirdHarvestWithEmptyOpponentLibrary() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Forest", 5, ai);
+        addCardToZone("Runeclaw Bear", ai, ZoneType.Library);
+        Card harvest = addCardToZone("Weird Harvest", ai, ZoneType.Hand);
+        SpellAbility sa = harvest.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should cast Weird Harvest when only its library has a creature",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertTrue("Weird Harvest should pay a positive X value",
+                sa.getXManaCostPaid() > 0);
+    }
+
+    @Test
+    public void testNewFrontiersWithEmptyOpponentLibrary() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Forest", 5, ai);
+        addCardToZone("Forest", ai, ZoneType.Library);
+        Card frontiers = addCardToZone("New Frontiers", ai, ZoneType.Hand);
+        SpellAbility sa = frontiers.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should cast New Frontiers when only its library has a basic land",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertTrue("New Frontiers should pay a positive X value",
+                sa.getXManaCostPaid() > 0);
+    }
+
+    @Test
+    public void testExhumeWithMixedGraveyards() {
+        Game game = initAndCreateThreePlayerGame();
+        Player ai = game.getPlayers().get(1);
+        Player ally = game.getPlayers().get(2);
+
+        addCards("Swamp", 2, ai);
+        addCardToZone("Akroma, Angel of Wrath", ai, ZoneType.Graveyard);
+        addCardToZone("Grizzly Bears", ally, ZoneType.Graveyard);
+        Card exhume = addCardToZone("Exhume", ai, ZoneType.Hand);
+        SpellAbility sa = exhume.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should cast Exhume when one opponent has no eligible creature",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+    }
+
+    @Test
+    public void testLibraryRetrievalRequiresAnOwnCard() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Forest", 5, ai);
+        addCardToZone("Forest", opponent, ZoneType.Library);
+        Card frontiers = addCardToZone("New Frontiers", ai, ZoneType.Hand);
+        SpellAbility sa = frontiers.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertFalse("AI should not cast New Frontiers without an eligible own card",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+    }
+
+    @Test
+    public void testExhumeWithGrafdiggersCage() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Swamp", 2, ai);
+        addCardToZone("Akroma, Angel of Wrath", ai, ZoneType.Graveyard);
+        addCard("Grafdigger's Cage", opponent);
+        game.getAction().checkStateEffects(true);
+        Card exhume = addCardToZone("Exhume", ai, ZoneType.Hand);
+        SpellAbility sa = exhume.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertFalse("AI should not cast Exhume through Grafdigger's Cage",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+    }
+
+    @Test
+    public void testCurfewWithEmptyOpponentBattlefield() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Island", ai);
+        addCard("Runeclaw Bear", ai);
+        Card curfew = addCardToZone("Curfew", ai, ZoneType.Hand);
+        SpellAbility sa = curfew.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertFalse("AI should not cast Curfew when an opponent has no creature",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+    }
+
+    @Test
+    public void testMindSwordsWithEmptyOpponentHand() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Swamp", 2, ai);
+        Card swords = addCardToZone("Mind Swords", ai, ZoneType.Hand);
+        SpellAbility sa = swords.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertFalse("AI should not cast Mind Swords when an opponent has no cards",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+    }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
@@ -73,23 +73,6 @@ public class ChangeZoneAiTest extends AITest {
     }
 
     @Test
-    public void testExhumeWithMixedGraveyards() {
-        Game game = initAndCreateThreePlayerGame();
-        Player ai = game.getPlayers().get(1);
-        Player ally = game.getPlayers().get(2);
-
-        addCards("Swamp", 2, ai);
-        addCardToZone("Akroma, Angel of Wrath", ai, ZoneType.Graveyard);
-        addCardToZone("Grizzly Bears", ally, ZoneType.Graveyard);
-        Card exhume = addCardToZone("Exhume", ai, ZoneType.Hand);
-        SpellAbility sa = exhume.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
-
-        AssertJUnit.assertTrue("AI should cast Exhume when one opponent has no eligible creature",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
-    }
-
-    @Test
     public void testExhumeRequiresAnOwnCreature() {
         for (String ownCard : new String[] {null, "Swamp"}) {
             Game game = initAndCreateGame();
@@ -110,50 +93,4 @@ public class ChangeZoneAiTest extends AITest {
         }
     }
 
-    @Test
-    public void testExhumeWithGrafdiggersCage() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-        Player opponent = game.getPlayers().get(0);
-
-        addCards("Swamp", 2, ai);
-        addCardToZone("Akroma, Angel of Wrath", ai, ZoneType.Graveyard);
-        addCard("Grafdigger's Cage", opponent);
-        game.getAction().checkStateEffects(true);
-        Card exhume = addCardToZone("Exhume", ai, ZoneType.Hand);
-        SpellAbility sa = exhume.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
-
-        AssertJUnit.assertFalse("AI should not cast Exhume through Grafdigger's Cage",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
-    }
-
-    @Test
-    public void testCurfewWithEmptyOpponentBattlefield() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-
-        addCard("Island", ai);
-        addCard("Runeclaw Bear", ai);
-        Card curfew = addCardToZone("Curfew", ai, ZoneType.Hand);
-        SpellAbility sa = curfew.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
-
-        AssertJUnit.assertFalse("AI should not cast Curfew when an opponent has no creature",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
-    }
-
-    @Test
-    public void testMindSwordsWithEmptyOpponentHand() {
-        Game game = initAndCreateGame();
-        Player ai = game.getPlayers().get(1);
-
-        addCards("Swamp", 2, ai);
-        Card swords = addCardToZone("Mind Swords", ai, ZoneType.Hand);
-        SpellAbility sa = swords.getSpellAbilities().get(0);
-        sa.setActivatingPlayer(ai);
-
-        AssertJUnit.assertFalse("AI should not cast Mind Swords when an opponent has no cards",
-                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
-    }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
@@ -54,4 +54,19 @@ public class ChangeZoneAiTest extends AITest {
                     t.getController().equals(ai));
         }
     }
+
+    @Test
+    public void testExhumeWithEmptyOpponentGraveyard() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCards("Swamp", 2, ai);
+        addCardToZone("Akroma, Angel of Wrath", ai, ZoneType.Graveyard);
+        Card exhume = addCardToZone("Exhume", ai, ZoneType.Hand);
+        SpellAbility sa = exhume.getSpellAbilities().get(0);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should cast Exhume when only its graveyard has a creature",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+    }
 }

--- a/forge-gui/res/cardsfolder/e/exhume.txt
+++ b/forge-gui/res/cardsfolder/e/exhume.txt
@@ -2,6 +2,4 @@ Name:Exhume
 ManaCost:1 B
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ChangeType$ Creature | DefinedPlayer$ Player | ChangeNum$ 1 | Hidden$ True | Mandatory$ True | SpellDescription$ Each player puts a creature card from their graveyard onto the battlefield.
-SVar:X:Count$ValidGraveyard Creature.YouOwn
-SVar:NeedsToPlayVar:X GE1
 Oracle:Each player puts a creature card from their graveyard onto the battlefield.


### PR DESCRIPTION
An empty opposing graveyard can veto Exhume even when the AI has a creature to return. Ignore empty participants in shared library/graveyard retrieval while retaining the AI’s own candidate and battlefield-entry checks.

I used Codex to help author this change.
