### PR TITLE
Implements 3 Non-Legal die roll cards

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityKey.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityKey.java
@@ -60,7 +60,7 @@ public enum AbilityKey {
     Destination("Destination"),
     Devoured("Devoured"),
     DicePTExchanges("DicePTExchanges"),
-    DiceResult("DiceResult"),
+    DiceResultModifier("DiceResultModifier"),
     Discard("Discard"),
     DiscardedBefore("DiscardedBefore"),
     DividedShieldAmount("DividedShieldAmount"),

--- a/forge-game/src/main/java/forge/game/ability/AbilityKey.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityKey.java
@@ -60,6 +60,7 @@ public enum AbilityKey {
     Destination("Destination"),
     Devoured("Devoured"),
     DicePTExchanges("DicePTExchanges"),
+    DiceResult("DiceResult"),
     Discard("Discard"),
     DiscardedBefore("DiscardedBefore"),
     DividedShieldAmount("DividedShieldAmount"),

--- a/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
@@ -11,6 +11,7 @@ import forge.game.event.GameEventRollDie;
 import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.player.PlayerController;
+import forge.game.replacement.ReplacementResult;
 import forge.game.replacement.ReplacementType;
 import forge.game.spellability.SpellAbility;
 import forge.game.trigger.TriggerType;
@@ -226,6 +227,15 @@ public class RollDiceEffect extends SpellAbilityEffect {
         for (Integer unmodified : naturalRolls) {
             // Add all the unmodified rolls into the results
             resultsList.add(new DieRollResult(unmodified, unmodified));
+        }
+
+        //replacement effects that affect die results
+        for (DieRollResult roll: resultsList) {
+            repParams.put(AbilityKey.DiceResult, roll.getModifiedValue());
+            if (Objects.requireNonNull(player.getGame().getReplacementHandler().run(ReplacementType.RollDice, repParams)) == ReplacementResult.Updated) {
+                roll.setModifiedValue((int) repParams.get(AbilityKey.DiceResult));
+                hasBeenModified = true;
+            }
         }
 
         // Vedalken Exchange

--- a/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
@@ -230,12 +230,12 @@ public class RollDiceEffect extends SpellAbilityEffect {
         }
 
         //replacement effects that affect die results
-        for (DieRollResult roll: resultsList) {
-            repParams.put(AbilityKey.DiceResult, roll.getModifiedValue());
-            if (Objects.requireNonNull(player.getGame().getReplacementHandler().run(ReplacementType.RollDice, repParams)) == ReplacementResult.Updated) {
-                roll.setModifiedValue((int) repParams.get(AbilityKey.DiceResult));
-                hasBeenModified = true;
+        int diceResultModifier = (int) repParams.get(AbilityKey.DiceResultModifier);
+        if (diceResultModifier != 0) {
+            for (DieRollResult roll : resultsList) {
+                    roll.setModifiedValue(roll.getModifiedValue() + diceResultModifier);
             }
+            hasBeenModified = true;
         }
 
         // Vedalken Exchange
@@ -416,6 +416,7 @@ public class RollDiceEffect extends SpellAbilityEffect {
         repParams.put(AbilityKey.Ignore, ignore);
         repParams.put(AbilityKey.DicePTExchanges, dicePTExchanges);
         repParams.put(AbilityKey.IgnoreChosen, ignoreChosenMap);
+        repParams.put(AbilityKey.DiceResultModifier, 0);
         switch (player.getGame().getReplacementHandler().run(ReplacementType.RollDice, repParams)) {
             case NotReplaced:
                 break;

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceRollDice.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceRollDice.java
@@ -43,6 +43,6 @@ public class ReplaceRollDice extends ReplacementEffect {
         sa.setReplacingObject(AbilityKey.Ignore, runParams.get(AbilityKey.Ignore));
         sa.setReplacingObject(AbilityKey.IgnoreChosen, runParams.get(AbilityKey.IgnoreChosen));
         sa.setReplacingObject(AbilityKey.DicePTExchanges, runParams.get(AbilityKey.DicePTExchanges));
-        sa.setReplacingObject(AbilityKey.DiceResult, runParams.get(AbilityKey.DiceResult));
+        sa.setReplacingObject(AbilityKey.DiceResultModifier, runParams.get(AbilityKey.DiceResultModifier));
     }
 }

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceRollDice.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceRollDice.java
@@ -43,5 +43,6 @@ public class ReplaceRollDice extends ReplacementEffect {
         sa.setReplacingObject(AbilityKey.Ignore, runParams.get(AbilityKey.Ignore));
         sa.setReplacingObject(AbilityKey.IgnoreChosen, runParams.get(AbilityKey.IgnoreChosen));
         sa.setReplacingObject(AbilityKey.DicePTExchanges, runParams.get(AbilityKey.DicePTExchanges));
+        sa.setReplacingObject(AbilityKey.DiceResult, runParams.get(AbilityKey.DiceResult));
     }
 }

--- a/forge-gui/res/cardsfolder/g/genevieve_conniving_dragon.txt
+++ b/forge-gui/res/cardsfolder/g/genevieve_conniving_dragon.txt
@@ -1,0 +1,17 @@
+Name:Genevieve, Conniving Dragon
+ManaCost:W U B R G
+Types:Legendary Creature Elder Dragon Gamer
+PT:5/5
+K:Flying
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE1 | Execute$ TrigRoll | TriggerDescription$ At the beginning of combat on your turn, roll the party die and create a number of Treasure tokens equal to the result.
+SVar:TrigRoll:DB$ RollDice | Amount$ 1 | ResultSVar$ Result | Sides$ S | SubAbility$ DBToken
+SVar:DBToken:DB$ Token | TokenScript$ c_a_treasure_sac | TokenAmount$ Result
+SVar:S:Count$Compare X EQ1.4.S2
+SVar:S2:Count$Compare X EQ2.8.S3
+SVar:S3:Count$Compare X EQ3.12.S4
+SVar:S4:Count$Compare X GE4.20.1
+SVar:X:Count$Party
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Party
+DeckHints:Type$Cleric|Rogue|Warrior|Wizard
+Oracle:At the beginning of combat on your turn, roll the party die and create a number of Treasure tokens equal to the result. (Your party consists of up to one of each of Cleric, Rogue, Warrior, and Wizard. If your party size is 1, the party die is a d4. It’s a d8 for 2, a d12 for 3, and a d20 for 4.)

--- a/forge-gui/res/cardsfolder/g/go_to_jail.txt
+++ b/forge-gui/res/cardsfolder/g/go_to_jail.txt
@@ -1,0 +1,15 @@
+Name:GO TO JAIL
+ManaCost:W
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile target creature an opponent controls.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME leaves the battlefield, return the exiled card to the battlefield under its owner's control.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player| TriggerZones$ Battlefield | CheckSVar$ InJail | Execute$ GetOutRoll | TriggerDescription$ At the beginning of the upkeep of the exiled card’s owner, that player rolls two six-sided dice. If they roll doubles, sacrifice this enchantment.
+SVar:TrigExile:DB$ ChangeZone | IsCurse$ True | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True
+SVar:TrigReturn:DB$ ChangeZone | Defined$ ExiledWith | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
+SVar:GetOutRoll:DB$ RollDice | Defined$ Player.Active | Amount$ 2 | Sides$ 6 | NoteDoubles$ True | SubAbility$ OutOfJail
+SVar:OutOfJail:DB$ Sacrifice | SacValid$ Self | ConditionCheckSVar$ Doubles
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:InJail:Count$ValidExile Card.IsRemembered+OwnedBy ActivePlayer
+SVar:PlayMain1:TRUE
+SVar:NeedsToPlay:Creature.OppCtrl
+Oracle:When this enchantment enters, exile target creature an opponent controls until this enchantment leaves the battlefield.\nAt the beginning of the upkeep of the exiled card’s owner, that player rolls two six-sided dice. If they roll doubles, sacrifice this enchantment.

--- a/forge-gui/res/cardsfolder/s/squirrel_powered_scheme.txt
+++ b/forge-gui/res/cardsfolder/s/squirrel_powered_scheme.txt
@@ -1,0 +1,8 @@
+Name:Squirrel-Powered Scheme
+ManaCost: 2 B
+Types: Enchantment
+R:Event$ RollDice | ActiveZones$ Battlefield | ValidPlayer$ You | ReplaceWith$ ResultPlus2
+SVar:ResultPlus2: DB$ ReplaceEffect | VarName$ DiceResult | VarValue$ X | Description$ Increase the result of each die you roll by 2.
+SVar:X:ReplaceCount$DiceResult/Plus.2
+AI:RemoveDeck:All
+Oracle:Increase the result of each die you roll by 2.

--- a/forge-gui/res/cardsfolder/s/squirrel_powered_scheme.txt
+++ b/forge-gui/res/cardsfolder/s/squirrel_powered_scheme.txt
@@ -2,7 +2,7 @@ Name:Squirrel-Powered Scheme
 ManaCost: 2 B
 Types: Enchantment
 R:Event$ RollDice | ActiveZones$ Battlefield | ValidPlayer$ You | ReplaceWith$ ResultPlus2
-SVar:ResultPlus2: DB$ ReplaceEffect | VarName$ DiceResult | VarValue$ X | Description$ Increase the result of each die you roll by 2.
-SVar:X:ReplaceCount$DiceResult/Plus.2
+SVar:ResultPlus2: DB$ ReplaceEffect | VarName$ DiceResultModifier | VarValue$ X | Description$ Increase the result of each die you roll by 2.
+SVar:X:ReplaceCount$DiceResultModifier/Plus.2
 AI:RemoveDeck:All
 Oracle:Increase the result of each die you roll by 2.


### PR DESCRIPTION
**Implemented the following cards:**
- GO TO JAIL
- Genevieve, Conniving Dragon
- Squirrel-Powered Scheme

includes engine changes to allow replacement effects to change die roll results

I tried to implement as many missing die roll related cards that I could, thinking that since we now have black-bordered cards that do something similar there wouldn't be a problem, but turns out most of them are hardcoded.

_I want to go over each missing die roll related card that I didn't implement and the reasons why:_
 - Krark's Other Thumb: Doubling the dice rolls and ignoring half is easy enough but that's not what the card actually does. Needs its own logic to roll dice in pairs. Gets extra complicated when involving more cards that cause rerolls like Barbarian Class or multiple of this cards.
 - Scooh: il-defined rules
 - Clam-I-Am: Would need to be hardcoded (reroll only on 3s. Possible multiple times if you keep getting 3s)
 - Goblin Blastronaunts: Triggers after the spell/ability resolves so there is nothing on the stack to copy
 - Goblin Bookie: Similar to Monitor Monitor but that one is hardcoded
 - Goblin Girder Gang: Art Matters
 - Pippa, Duchess of Dice: Similar to Monitor Monitor but that one is hardcoded
 - Snickering Squirrel: Similar to Xenosquirrels/Nightshift but those are hardcoded
 - Socketed Sprocketer: Similar to Vedalken Squirrel-Whacker but that one is hardcoded. Storing results appears on Centaur of Attention.
 - The Big Idea: Needs its own roll additional die logic
 - Wall of Fortune: Similar to Monitor Monitor but that one is hardcoded
 - Ricochet: Similar to Chaos Dragon but remembering the lowest player and rerolling if there is a tie
 - Free-Range Chicken: Similar to Long List of the Ents and Volo, Itinerant Scholar but noting die roll results rather than creature types. Maybe have StoreSVar support lists.