### PR TITLE
Add MTG Card Fetch Bot

### DIFF
--- a/.github/workflows/mtg-fetch-cards.yml
+++ b/.github/workflows/mtg-fetch-cards.yml
@@ -1,0 +1,22 @@
+name: Mtg Card Fetch Bot
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  fetch-card-references:
+    if: github.repository_owner == 'Card-Forge'
+    name: Fetch MTG Card
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: ldeluigi/mtg-fetch-action@v1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate fetching Magic: The Gathering (MTG) card references when relevant comments or issues are created. The workflow is configured to trigger on several types of GitHub events and utilizes an external action for its core functionality.

**New workflow for automated MTG card fetching:**

* Added `.github/workflows/mtg-fetch-cards.yml` to define a workflow named "Mtg Card Fetch Bot" that triggers on issue comments, new issues, pull request review submissions, and pull request review comments.
* Configured the workflow to run only when the repository owner is `Card-Forge`, and to use the `ldeluigi/mtg-fetch-action@v1` action for fetching card references.

The syntax to summon the cards is the usual [[square bracket]] for card text and {{curly bracket}} for card image previews