### PR TITLE
Enable Planechase and Archenemy variants in the network lobby

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -92,7 +92,7 @@ public class VLobby implements ILobbyView {
     private final ImmutableList<VariantCheckBox> vntBoxesLocal  =
             ImmutableList.of(vntVanguard, vntMomirBasic, vntMoJhoSto, vntCommander, vntOathbreaker, vntBrawl, vntTinyLeaders, vntPlanechase, vntArchenemy, vntArchenemyRumble);
     private final ImmutableList<VariantCheckBox> vntBoxesNetwork =
-            ImmutableList.of(vntVanguard, vntMomirBasic, vntMoJhoSto, vntCommander, vntOathbreaker, vntBrawl, vntTinyLeaders /*, vntPlanechase, vntArchenemy, vntArchenemyRumble */);
+            ImmutableList.of(vntVanguard, vntMomirBasic, vntMoJhoSto, vntCommander, vntOathbreaker, vntBrawl, vntTinyLeaders, vntPlanechase, vntArchenemy, vntArchenemyRumble);
 
     // Player frame elements
     private final JPanel playersFrame = new JPanel(new MigLayout("insets 0, gap 0 5, wrap, hidemode 3"));


### PR DESCRIPTION
Closes https://github.com/Card-Forge/forge/issues/11811

Planechase, Archenemy, and Archenemy Rumble are missing from the online lobby. They've been commented out of vntBoxesNetwork since Feb 2018, when 2b704e16c7 blanket-disabled every variant during a multiplayer lobby rework. The others were re-enabled over the following days; these three never were. This PR uncomments them.

Claude Code analysis found no fundamental blocker:

- VLobby.java:95 is the only place in the codebase gating these for network play.
- The transport already exists: PlanarDeck/SchemeDeck zones, PlanarPlayer, and CurrentPlane are tracked properties; DeltaSyncManager derives its zone set from ZoneType so needs no update; the Planes/Schemes deck sections travel over the same UpdateLobbyPlayerEvent path Vanguard's Avatar section uses today.
- All variant logic is host-side in forge-game.
- Mobile never had this restriction — OnlineLobbyScreen extends LobbyScreen, which registers all ten variants.
- No skew risk: per-player planar/scheme controls key off synced lobby data, not this list. No serialization changes.

This is an unblocking change - enabling variants may surface real bugs in normal play, where they can be reported and fixed on their merits. The issue reporter built and played with these enabled without apparent issues.

-----

🤖 Generated with [Claude Code](https://claude.com/claude-code)