### PR TITLE
Implement DeckRuleCopies + cache tokenized DeckRule lines per CardFace

### DIFF
--- a/forge-core/src/main/java/forge/card/CardFace.java
+++ b/forge-core/src/main/java/forge/card/CardFace.java
@@ -69,6 +69,43 @@ final class CardFace implements ICardFace, Cloneable {
     // these are raw and unparsed used for Card creation
     @Override public Iterable<String> getKeywords()   { return keywords; }
     @Override public Iterable<String> getDeckRules()  { return deckRules; }
+
+    private transient List<DeckRuleLine> tokenizedDeckRules = null;
+
+    /** This face's own {@code DeckRule:} lines, split into (rule class, params) pairs and cached - computed once per face and shared across every printing, rather than once per {@code PaperCard}. */
+    @Override public List<DeckRuleLine> getTokenizedDeckRules() {
+        if (tokenizedDeckRules == null) {
+            final List<DeckRuleLine> result = new ArrayList<>();
+            for (final String raw : deckRules) {
+                final int colonPos = raw.indexOf(':');
+                final String ruleClass = colonPos > 0 ? raw.substring(0, colonPos) : raw;
+                final String rest = colonPos > 0 ? raw.substring(colonPos + 1) : "";
+                result.add(new DeckRuleLine(ruleClass, parseDeckRuleParams(rest)));
+            }
+            tokenizedDeckRules = result;
+        }
+        return tokenizedDeckRules;
+    }
+
+    /** Splits a {@code Key$ Value | Key2$ Value2} parameter string (see forge.deck.DeckRule, which builds the typed rule objects from this). */
+    private static Map<String, String> parseDeckRuleParams(final String rest) {
+        final Map<String, String> params = new LinkedHashMap<>();
+        for (final String piece : rest.split("\\|")) {
+            final String trimmed = piece.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            final int dollarPos = trimmed.indexOf('$');
+            if (dollarPos < 0) {
+                continue;
+            }
+            final String key = trimmed.substring(0, dollarPos).trim();
+            final String value = trimmed.substring(dollarPos + 1).trim();
+            params.put(key, value);
+        }
+        return params;
+    }
+
     @Override public Iterable<String> getAbilities()  { return abilities; }
     @Override public Iterable<String> getStaticAbilities() { return staticAbilities; }
     @Override public Iterable<String> getTriggers()   { return triggers; }

--- a/forge-core/src/main/java/forge/card/CardRules.java
+++ b/forge-core/src/main/java/forge/card/CardRules.java
@@ -906,16 +906,6 @@ public final class CardRules implements ICardCharacteristics {
         return false;
     }
 
-    public Integer getKeywordMagnitude(final String k) {
-        for (final String inst : mainPart.getKeywords()) {
-            final String[] parts = inst.split(":");
-            if (parts[0].equals(k) && StringUtils.isNumeric(parts[1])) {
-                return Integer.valueOf(parts[1]);
-            }
-        }
-        return null;
-    }
-
     public ColorSet getDeckbuildingColors() {
         if (deckbuildingColors == null) {
             byte colors = 0;

--- a/forge-core/src/main/java/forge/card/CardRulesPredicates.java
+++ b/forge-core/src/main/java/forge/card/CardRulesPredicates.java
@@ -328,8 +328,8 @@ public final class CardRulesPredicates {
         return result == null ? card -> false : result;
     }
 
-    /** Tokenizes dot-then-plus, matching {@code Card.isValid()}'s own restriction-string split. */
-    private static Predicate<CardRules> restrictionBranch(final String rawBranch) {
+    /** Tokenizes dot-then-plus, matching {@code Card.isValid()}'s own restriction-string split. Also usable directly on a single already-isolated branch (see {@code DeckRule:Copies}' CARDNAME resolution). */
+    public static Predicate<CardRules> restrictionBranch(final String rawBranch) {
         final List<String> typeWords = new ArrayList<>();
         final String[] firstSplit = rawBranch.split("\\.", 2);
         final List<String> tokens = new ArrayList<>();
@@ -349,6 +349,9 @@ public final class CardRulesPredicates {
                 branch = branch == null ? statFilter : branch.and(statFilter);
             } else if (token.equals("Permanent")) {
                 branch = branch == null ? IS_PERMANENT : branch.and(IS_PERMANENT);
+            } else if (token.startsWith("named")) {
+                final Predicate<CardRules> namePredicate = name(PredicateString.StringOp.EQUALS, token.substring("named".length()));
+                branch = branch == null ? namePredicate : branch.and(namePredicate);
             } else {
                 typeWords.add(token);
             }

--- a/forge-core/src/main/java/forge/card/DeckRuleLine.java
+++ b/forge-core/src/main/java/forge/card/DeckRuleLine.java
@@ -1,0 +1,27 @@
+package forge.card;
+
+import java.util.Map;
+
+/**
+ * One tokenized {@code DeckRule:<ruleClass>:<params>} line: the rule class name and its
+ * {@code Key$ Value} params, split but not yet built into a typed rule object. See
+ * {@code forge.deck.DeckRule}, which does that last step (it needs per-printing/per-instance
+ * data - like a commander's marked colors - that a card face alone doesn't have).
+ */
+public final class DeckRuleLine {
+    private final String ruleClass;
+    private final Map<String, String> params;
+
+    DeckRuleLine(final String ruleClass, final Map<String, String> params) {
+        this.ruleClass = ruleClass;
+        this.params = params;
+    }
+
+    public String getRuleClass() {
+        return ruleClass;
+    }
+
+    public Map<String, String> getParams() {
+        return params;
+    }
+}

--- a/forge-core/src/main/java/forge/card/ICardRawAbilites.java
+++ b/forge-core/src/main/java/forge/card/ICardRawAbilites.java
@@ -1,11 +1,13 @@
 package forge.card;
 
+import java.util.List;
 import java.util.Map.Entry;
 
 public interface ICardRawAbilites
 {
     Iterable<String> getKeywords();
     Iterable<String> getDeckRules();
+    List<DeckRuleLine> getTokenizedDeckRules();
     Iterable<String> getReplacements();
     Iterable<String> getTriggers();
     Iterable<String> getDraftActions();

--- a/forge-core/src/main/java/forge/deck/DeckFormat.java
+++ b/forge-core/src/main/java/forge/deck/DeckFormat.java
@@ -18,7 +18,6 @@
 package forge.deck;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import forge.StaticData;
 import forge.card.*;
 import forge.deck.generation.DeckGenPool;
@@ -526,15 +525,33 @@ public enum DeckFormat {
         return null;
     }
 
+    /** True if {@code iCard} is a basic land, or its own DeckRule:Copies allows unlimited copies. */
     public static boolean canHaveAnyNumberOf(final IPaperCard iCard) {
-        return iCard.getRules().getType().isBasicLand()
-            || Iterables.contains(iCard.getRules().getMainPart().getKeywords(),
-                "A deck can have any number of cards named CARDNAME.");
+        if (iCard.getRules().getType().isBasicLand()) {
+            return true;
+        }
+        final Integer limit = getOwnCopiesLimit(iCard);
+        return limit != null && limit == Integer.MAX_VALUE;
     }
 
+    /** This card's own DeckRule:Copies limit, if any; null falls back to the format default. */
     public static Integer canHaveSpecificNumberInDeck(final IPaperCard card) {
-        // Ideally, this would be parsed during card parsing and set this value
-        return card.getRules().getKeywordMagnitude("DeckLimit");
+        final Integer limit = getOwnCopiesLimit(card);
+        return limit != null && limit != Integer.MAX_VALUE ? limit : null;
+    }
+
+    /** The DeckRule:Copies limit {@code iCard} imposes on itself, if any. */
+    private static Integer getOwnCopiesLimit(final IPaperCard iCard) {
+        final CardRules rules = iCard.getRules();
+        for (final DeckRule rule : DeckRule.parseAll(iCard)) {
+            if (rule instanceof DeckRuleCopies) {
+                final Integer limit = ((DeckRuleCopies) rule).getLimit(rules);
+                if (limit != null) {
+                    return limit;
+                }
+            }
+        }
+        return null;
     }
 
     public static String getPlaneSectionConformanceProblem(final CardPool planes) {

--- a/forge-core/src/main/java/forge/deck/DeckFormat.java
+++ b/forge-core/src/main/java/forge/deck/DeckFormat.java
@@ -276,7 +276,7 @@ public enum DeckFormat {
         final List<DeckRuleSize> commanderSizeRules = new ArrayList<>();
         if (hasCommander()) {
             for (final PaperCard cmd : deck.getCommanders()) {
-                for (final DeckRule rule : DeckRule.parseAll(cmd)) {
+                for (final DeckRule rule : cmd.getDeckRuleList()) {
                     if (!rule.isActiveFor(DeckSection.Commander)) {
                         continue;
                     }
@@ -543,7 +543,7 @@ public enum DeckFormat {
     /** The DeckRule:Copies limit {@code iCard} imposes on itself, if any. */
     private static Integer getOwnCopiesLimit(final IPaperCard iCard) {
         final CardRules rules = iCard.getRules();
-        for (final DeckRule rule : DeckRule.parseAll(iCard)) {
+        for (final DeckRule rule : iCard.getDeckRuleList()) {
             if (rule instanceof DeckRuleCopies) {
                 final Integer limit = ((DeckRuleCopies) rule).getLimit(rules);
                 if (limit != null) {
@@ -691,7 +691,7 @@ public enum DeckFormat {
         final List<DeckRuleColorIdentity> ciRules = new ArrayList<>();
         for (final PaperCard p : commanders) {
             cmdCI |= p.getRules().getColorIdentity().getColor();
-            for (final DeckRule rule : DeckRule.parseAll(p)) {
+            for (final DeckRule rule : p.getDeckRuleList()) {
                 if (rule instanceof DeckRuleColorIdentity && rule.isActiveFor(DeckSection.Commander)) {
                     ciRules.add((DeckRuleColorIdentity) rule);
                 }

--- a/forge-core/src/main/java/forge/deck/DeckRule.java
+++ b/forge-core/src/main/java/forge/deck/DeckRule.java
@@ -62,24 +62,15 @@ public abstract class DeckRule {
         return description;
     }
 
-    /** Parses every {@code DeckRule:} line on the given card into typed rule objects (also picks up its marked colors for AllowedAdditionalColor$, and its own name for Copies' CARDNAME). */
+    /** Parses every {@code DeckRule:} line on the given card into typed rule objects (also picks up its marked colors for AllowedAdditionalColor$, and its own name for Copies' CARDNAME resolution). Cached on {@code PaperCard} - call {@code card.getDeckRuleList()} instead of this directly. */
     public static List<DeckRule> parseAll(final IPaperCard card) {
         final CardRules rules = card.getRules();
         if (rules == null) {
             return new ArrayList<>();
         }
         final byte chosenAdditionalColors = card.getMarkedColors() != null ? card.getMarkedColors().getColor() : 0;
-        return parseAll(rules.getDeckRules(), chosenAdditionalColors, rules.getName());
-    }
-
-    /** Parses a card face's raw {@code DeckRule:} line values (see {@link #parseAll(IPaperCard)}). */
-    public static List<DeckRule> parseAll(final Iterable<String> rawDeckRuleLines, final String ownerName) {
-        return parseAll(rawDeckRuleLines, (byte) 0, ownerName);
-    }
-
-    private static List<DeckRule> parseAll(final Iterable<String> rawDeckRuleLines, final byte chosenAdditionalColors, final String ownerName) {
         final List<DeckRule> result = new ArrayList<>();
-        for (final String raw : rawDeckRuleLines) {
+        for (final String raw : rules.getDeckRules()) {
             final int colonPos = raw.indexOf(':');
             final String ruleClass = colonPos > 0 ? raw.substring(0, colonPos) : raw;
             final String rest = colonPos > 0 ? raw.substring(colonPos + 1) : "";
@@ -92,7 +83,7 @@ public abstract class DeckRule {
                     result.add(new DeckRuleSize(params));
                     break;
                 case "Copies":
-                    result.add(new DeckRuleCopies(params, ownerName));
+                    result.add(new DeckRuleCopies(params, rules.getName()));
                     break;
                 default:
                     break; // unrecognized rule class - ignore

--- a/forge-core/src/main/java/forge/deck/DeckRule.java
+++ b/forge-core/src/main/java/forge/deck/DeckRule.java
@@ -18,11 +18,11 @@
 package forge.deck;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import forge.card.CardRules;
+import forge.card.DeckRuleLine;
+import forge.card.ICardFace;
 import forge.item.IPaperCard;
 
 /**
@@ -62,52 +62,30 @@ public abstract class DeckRule {
         return description;
     }
 
-    /** Parses every {@code DeckRule:} line on the given card into typed rule objects (also picks up its marked colors for AllowedAdditionalColor$, and its own name for Copies' CARDNAME resolution). Cached on {@code PaperCard} - call {@code card.getDeckRuleList()} instead of this directly. */
+    /** Assembles every {@code DeckRule:} line across every face of the given card into typed rule objects (also picks up its marked colors for AllowedAdditionalColor$, and each face's own name for Copies' CARDNAME resolution). The expensive per-line tokenizing is cached per {@code CardFace} (shared across every printing); call {@code card.getDeckRuleList()} instead of this directly. */
     public static List<DeckRule> parseAll(final IPaperCard card) {
-        final CardRules rules = card.getRules();
-        if (rules == null) {
+        if (card.getRules() == null) {
             return new ArrayList<>();
         }
         final byte chosenAdditionalColors = card.getMarkedColors() != null ? card.getMarkedColors().getColor() : 0;
         final List<DeckRule> result = new ArrayList<>();
-        for (final String raw : rules.getDeckRules()) {
-            final int colonPos = raw.indexOf(':');
-            final String ruleClass = colonPos > 0 ? raw.substring(0, colonPos) : raw;
-            final String rest = colonPos > 0 ? raw.substring(colonPos + 1) : "";
-            final Map<String, String> params = parseParams(rest);
-            switch (ruleClass) {
-                case "ColorIdentity":
-                    result.add(new DeckRuleColorIdentity(params, chosenAdditionalColors));
-                    break;
-                case "Size":
-                    result.add(new DeckRuleSize(params));
-                    break;
-                case "Copies":
-                    result.add(new DeckRuleCopies(params, rules.getName()));
-                    break;
-                default:
-                    break; // unrecognized rule class - ignore
+        for (final ICardFace face : card.getAllFaces()) {
+            for (final DeckRuleLine line : face.getTokenizedDeckRules()) {
+                switch (line.getRuleClass()) {
+                    case "ColorIdentity":
+                        result.add(new DeckRuleColorIdentity(line.getParams(), chosenAdditionalColors));
+                        break;
+                    case "Size":
+                        result.add(new DeckRuleSize(line.getParams()));
+                        break;
+                    case "Copies":
+                        result.add(new DeckRuleCopies(line.getParams(), face.getName()));
+                        break;
+                    default:
+                        break; // unrecognized rule class - ignore
+                }
             }
         }
         return result;
-    }
-
-    /** Splits a {@code Key$ Value | Key2$ Value2} parameter string. */
-    protected static Map<String, String> parseParams(final String rest) {
-        final Map<String, String> params = new LinkedHashMap<>();
-        for (final String piece : rest.split("\\|")) {
-            final String trimmed = piece.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-            final int dollarPos = trimmed.indexOf('$');
-            if (dollarPos < 0) {
-                continue;
-            }
-            final String key = trimmed.substring(0, dollarPos).trim();
-            final String value = trimmed.substring(dollarPos + 1).trim();
-            params.put(key, value);
-        }
-        return params;
     }
 }

--- a/forge-core/src/main/java/forge/deck/DeckRule.java
+++ b/forge-core/src/main/java/forge/deck/DeckRule.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import forge.card.CardRules;
-import forge.item.PaperCard;
+import forge.item.IPaperCard;
 
 /**
  * A deckbuilding-legality rule from a card's own {@code DeckRule:} line, e.g.
@@ -62,22 +62,22 @@ public abstract class DeckRule {
         return description;
     }
 
-    /** Parses every {@code DeckRule:} line on the given card into typed rule objects (also picks up its marked colors for AllowedAdditionalColor$). */
-    public static List<DeckRule> parseAll(final PaperCard card) {
+    /** Parses every {@code DeckRule:} line on the given card into typed rule objects (also picks up its marked colors for AllowedAdditionalColor$, and its own name for Copies' CARDNAME). */
+    public static List<DeckRule> parseAll(final IPaperCard card) {
         final CardRules rules = card.getRules();
         if (rules == null) {
             return new ArrayList<>();
         }
         final byte chosenAdditionalColors = card.getMarkedColors() != null ? card.getMarkedColors().getColor() : 0;
-        return parseAll(rules.getDeckRules(), chosenAdditionalColors);
+        return parseAll(rules.getDeckRules(), chosenAdditionalColors, rules.getName());
     }
 
-    /** Parses a card face's raw {@code DeckRule:} line values (see {@link #parseAll(PaperCard)}). */
-    public static List<DeckRule> parseAll(final Iterable<String> rawDeckRuleLines) {
-        return parseAll(rawDeckRuleLines, (byte) 0);
+    /** Parses a card face's raw {@code DeckRule:} line values (see {@link #parseAll(IPaperCard)}). */
+    public static List<DeckRule> parseAll(final Iterable<String> rawDeckRuleLines, final String ownerName) {
+        return parseAll(rawDeckRuleLines, (byte) 0, ownerName);
     }
 
-    private static List<DeckRule> parseAll(final Iterable<String> rawDeckRuleLines, final byte chosenAdditionalColors) {
+    private static List<DeckRule> parseAll(final Iterable<String> rawDeckRuleLines, final byte chosenAdditionalColors, final String ownerName) {
         final List<DeckRule> result = new ArrayList<>();
         for (final String raw : rawDeckRuleLines) {
             final int colonPos = raw.indexOf(':');
@@ -90,6 +90,9 @@ public abstract class DeckRule {
                     break;
                 case "Size":
                     result.add(new DeckRuleSize(params));
+                    break;
+                case "Copies":
+                    result.add(new DeckRuleCopies(params, ownerName));
                     break;
                 default:
                     break; // unrecognized rule class - ignore

--- a/forge-core/src/main/java/forge/deck/DeckRuleCopies.java
+++ b/forge-core/src/main/java/forge/deck/DeckRuleCopies.java
@@ -1,0 +1,79 @@
+/*
+ * Forge: Play Magic: the Gathering.
+ * Copyright (C) 2011  Forge Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package forge.deck;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import forge.card.CardRules;
+import forge.card.CardRulesPredicates;
+import forge.util.PredicateString.StringOp;
+
+/**
+ * {@code DeckRule:Copies:Limit$ <Unlimited|n> | Affected$ <branches>} - overrides the format's
+ * max-copies limit for matching cards. Branch grammar: {@link CardRulesPredicates#restrictionList},
+ * plus {@code Name:<card name>} ({@code CARDNAME} for this rule's own bearing card).
+ */
+public class DeckRuleCopies extends DeckRule {
+    private static final String UNLIMITED = "Unlimited";
+    private static final String SELF_NAME = "CARDNAME";
+
+    private final Predicate<CardRules> affectedPredicate;
+    private final boolean unlimited;
+    private final int limit;
+
+    DeckRuleCopies(final Map<String, String> params, final String ownerName) {
+        super(params);
+        affectedPredicate = parseAffected(params.get("Affected"), ownerName);
+        final String limitParam = params.get("Limit");
+        unlimited = UNLIMITED.equalsIgnoreCase(limitParam);
+        limit = !unlimited && limitParam != null ? Integer.parseInt(limitParam.trim()) : 0;
+    }
+
+    /** Splits on commas before resolving Name:CARDNAME, so a comma in the resolved name (e.g. "Vazal, the Compleat") isn't mistaken for another branch. */
+    private static Predicate<CardRules> parseAffected(final String rawValue, final String ownerName) {
+        if (rawValue == null) {
+            return card -> false;
+        }
+        Predicate<CardRules> result = null;
+        for (final String rawBranch : rawValue.split(",")) {
+            final String trimmed = rawBranch.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            final Predicate<CardRules> branch;
+            if (trimmed.startsWith("Name:")) {
+                final String rawName = trimmed.substring("Name:".length());
+                final String resolvedName = SELF_NAME.equals(rawName) ? ownerName : rawName;
+                branch = CardRulesPredicates.name(StringOp.EQUALS, resolvedName);
+            } else {
+                branch = CardRulesPredicates.restrictionList(trimmed);
+            }
+            result = result == null ? branch : result.or(branch);
+        }
+        return result == null ? card -> false : result;
+    }
+
+    /** The max copies of {@code candidate} this rule allows, or null if it doesn't match {@code Affected$}. */
+    public Integer getLimit(final CardRules candidate) {
+        if (!affectedPredicate.test(candidate)) {
+            return null;
+        }
+        return unlimited ? Integer.MAX_VALUE : limit;
+    }
+}

--- a/forge-core/src/main/java/forge/deck/DeckRuleCopies.java
+++ b/forge-core/src/main/java/forge/deck/DeckRuleCopies.java
@@ -22,12 +22,11 @@ import java.util.function.Predicate;
 
 import forge.card.CardRules;
 import forge.card.CardRulesPredicates;
-import forge.util.PredicateString.StringOp;
 
 /**
  * {@code DeckRule:Copies:Limit$ <Unlimited|n> | Affected$ <branches>} - overrides the format's
- * max-copies limit for matching cards. Branch grammar: {@link CardRulesPredicates#restrictionList},
- * plus {@code Name:<card name>} ({@code CARDNAME} for this rule's own bearing card).
+ * max-copies limit for matching cards. Branch grammar: {@link CardRulesPredicates#restrictionBranch}
+ * (comma-separated, OR'd), typically {@code namedCARDNAME} for this rule's own bearing card.
  */
 public class DeckRuleCopies extends DeckRule {
     private static final String UNLIMITED = "Unlimited";
@@ -45,7 +44,7 @@ public class DeckRuleCopies extends DeckRule {
         limit = !unlimited && limitParam != null ? Integer.parseInt(limitParam.trim()) : 0;
     }
 
-    /** Splits on commas before resolving Name:CARDNAME, so a comma in the resolved name (e.g. "Vazal, the Compleat") isn't mistaken for another branch. */
+    /** Resolves each branch's own CARDNAME before parsing it, so a comma in the resolved name (e.g. "Vazal, the Compleat") can't be mistaken for another branch. */
     private static Predicate<CardRules> parseAffected(final String rawValue, final String ownerName) {
         if (rawValue == null) {
             return card -> false;
@@ -56,14 +55,7 @@ public class DeckRuleCopies extends DeckRule {
             if (trimmed.isEmpty()) {
                 continue;
             }
-            final Predicate<CardRules> branch;
-            if (trimmed.startsWith("Name:")) {
-                final String rawName = trimmed.substring("Name:".length());
-                final String resolvedName = SELF_NAME.equals(rawName) ? ownerName : rawName;
-                branch = CardRulesPredicates.name(StringOp.EQUALS, resolvedName);
-            } else {
-                branch = CardRulesPredicates.restrictionList(trimmed);
-            }
+            final Predicate<CardRules> branch = CardRulesPredicates.restrictionBranch(trimmed.replace(SELF_NAME, ownerName));
             result = result == null ? branch : result.or(branch);
         }
         return result == null ? card -> false : result;

--- a/forge-core/src/main/java/forge/item/IPaperCard.java
+++ b/forge-core/src/main/java/forge/item/IPaperCard.java
@@ -4,6 +4,7 @@ import forge.card.CardRarity;
 import forge.card.CardRules;
 import forge.card.ColorSet;
 import forge.card.ICardFace;
+import forge.deck.DeckRule;
 
 import java.io.Serializable;
 import java.util.List;
@@ -35,6 +36,7 @@ public interface IPaperCard extends InventoryItem, Serializable {
     List<ICardFace> getAllFaces();
     String getCardImageKey();
     String getCardAltImageKey();
+    List<DeckRule> getDeckRuleList();
 
     boolean isRebalanced();
 

--- a/forge-core/src/main/java/forge/item/PaperCard.java
+++ b/forge-core/src/main/java/forge/item/PaperCard.java
@@ -113,14 +113,10 @@ public class PaperCard implements Comparable<IPaperCard>, InventoryItemFromSet, 
         return rules;
     }
 
-    private transient List<DeckRule> deckRuleList = null;
-
+    /** The complete, assembled list across every face (see {@code ICardFace.getTokenizedDeckRules()} - each face caches its own parsing, shared across every printing, so this stays cheap). */
     @Override
     public List<DeckRule> getDeckRuleList() {
-        if (deckRuleList == null) {
-            deckRuleList = DeckRule.parseAll(this);
-        }
-        return deckRuleList;
+        return DeckRule.parseAll(this);
     }
 
     @Override

--- a/forge-core/src/main/java/forge/item/PaperCard.java
+++ b/forge-core/src/main/java/forge/item/PaperCard.java
@@ -20,6 +20,7 @@ package forge.item;
 import forge.ImageKeys;
 import forge.StaticData;
 import forge.card.*;
+import forge.deck.DeckRule;
 import forge.util.*;
 import org.apache.commons.lang3.StringUtils;
 
@@ -110,6 +111,16 @@ public class PaperCard implements Comparable<IPaperCard>, InventoryItemFromSet, 
     @Override
     public CardRules getRules() {
         return rules;
+    }
+
+    private transient List<DeckRule> deckRuleList = null;
+
+    @Override
+    public List<DeckRule> getDeckRuleList() {
+        if (deckRuleList == null) {
+            deckRuleList = DeckRule.parseAll(this);
+        }
+        return deckRuleList;
     }
 
     @Override

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -2,6 +2,7 @@ package forge.item;
 
 import forge.ImageKeys;
 import forge.card.*;
+import forge.deck.DeckRule;
 import forge.util.MyRandom;
 import org.apache.commons.lang3.StringUtils;
 
@@ -135,6 +136,12 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
     @Override
     public CardRules getRules() {
         return cardRules;
+    }
+
+    @Override
+    public List<DeckRule> getDeckRuleList() {
+        // Tokens are never a deck's own card pool entry, so this is never worth caching.
+        return DeckRule.parseAll(this);
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2463,9 +2463,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                         s.append(" on it.");
                     }
                     sbLong.append(s).append("\r\n");
-                } else if (keyword.startsWith("DeckLimit")) {
-                    final String[] k = keyword.split(":");
-                    sbLong.append(k[2]).append("\r\n");
                 } else if (keyword.startsWith("Enchant") && inst instanceof KeywordWithType kwt) {
                     String desc = kwt.getTypeDescription();
                     sbLong.append("Enchant ").append(desc).append("\r\n");
@@ -2908,7 +2905,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
         // DeckRule descriptions (e.g. Rulebreaker) print alongside the card's other rules text.
         if (getRules() != null) {
-            for (final DeckRule rule : DeckRule.parseAll(getRules().getDeckRules())) {
+            for (final DeckRule rule : DeckRule.parseAll(getRules().getDeckRules(), getRules().getName())) {
                 final String desc = rule.getDescription();
                 if (!desc.isEmpty()) {
                     sb.append(desc).append(linebreak);
@@ -3281,9 +3278,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                     append(String.format(inst.getReminderText(), "{" + getManaCost().getGenericCost() + "}"))
                     .append(")");
                     sbBefore.append("\r\n\r\n");
-                } else if (keyword.startsWith("DeckLimit")) {
-                    final String[] k = keyword.split(":");
-                    sbBefore.append(k[2]).append("\r\n");
                 }
             } catch (Exception e) {
                 String msg = "Card:abilityTextInstantSorcery: crash in Keyword parsing";
@@ -3294,6 +3288,16 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                 Sentry.addBreadcrumb(bread);
 
                 throw new RuntimeException("Error in Card " + this.getName() + " with Keyword " + keyword, e);
+            }
+        }
+
+        // DeckRule descriptions (e.g. Copies limits) print alongside the card's other rules text.
+        if (getRules() != null) {
+            for (final DeckRule rule : DeckRule.parseAll(getRules().getDeckRules(), getRules().getName())) {
+                final String desc = rule.getDescription();
+                if (!desc.isEmpty()) {
+                    sbBefore.append(desc).append("\r\n");
+                }
             }
         }
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2904,8 +2904,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         sb.append(keywordText).append(keywordText.length() > 0 ? linebreak : "");
 
         // DeckRule descriptions (e.g. Rulebreaker) print alongside the card's other rules text.
-        if (getRules() != null) {
-            for (final DeckRule rule : DeckRule.parseAll(getRules().getDeckRules(), getRules().getName())) {
+        final IPaperCard pc = getPaperCard();
+        if (pc != null) {
+            for (final DeckRule rule : pc.getDeckRuleList()) {
                 final String desc = rule.getDescription();
                 if (!desc.isEmpty()) {
                     sb.append(desc).append(linebreak);
@@ -3292,8 +3293,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         }
 
         // DeckRule descriptions (e.g. Copies limits) print alongside the card's other rules text.
-        if (getRules() != null) {
-            for (final DeckRule rule : DeckRule.parseAll(getRules().getDeckRules(), getRules().getName())) {
+        final IPaperCard pc = getPaperCard();
+        if (pc != null) {
+            for (final DeckRule rule : pc.getDeckRuleList()) {
                 final String desc = rule.getDescription();
                 if (!desc.isEmpty()) {
                     sbBefore.append(desc).append("\r\n");

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/ACEditorBase.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/ACEditorBase.java
@@ -672,7 +672,7 @@ public abstract class ACEditorBase<TItem extends InventoryItem, TModel extends D
             final Deck currentDeck = (Deck) CDeckEditorUI.SINGLETON_INSTANCE.getCurrentEditorController().getDeckController().getModel();
             if (currentDeck == null) { return; }
 
-            for (final DeckRule rule : DeckRule.parseAll(existingCard)) {
+            for (final DeckRule rule : existingCard.getDeckRuleList()) {
                 if (!(rule instanceof DeckRuleColorIdentity) || !rule.isActiveFor(DeckSection.Commander)) {
                     continue;
                 }

--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -633,7 +633,7 @@ public class DuelScene extends ForgeScene {
     //Applies DeckRule:Size:AdjustMax$ from any commander that has one (e.g. Whtz, the Bibliophile).
     private static int applyCommanderSizeRule(List<PaperCard> commanders, int maxDeckSize) {
         for(PaperCard commander : commanders) {
-            for(DeckRule rule : DeckRule.parseAll(commander)) {
+            for(DeckRule rule : commander.getDeckRuleList()) {
                 if(!(rule instanceof DeckRuleSize) || !rule.isActiveFor(DeckSection.Commander))
                     continue;
                 DeckRuleSize sizeRule = (DeckRuleSize) rule;
@@ -700,7 +700,7 @@ public class DuelScene extends ForgeScene {
         for(PaperCard commander : playerDeck.getCommanders()) {
             cmdCI |= commander.getRules().getColorIdentity().getColor();
             wildColors += commander.getRules().getAddsWildCardColor() ? 1 : 0;
-            for(DeckRule rule : DeckRule.parseAll(commander)) {
+            for(DeckRule rule : commander.getDeckRuleList()) {
                 if(rule instanceof DeckRuleColorIdentity && rule.isActiveFor(DeckSection.Commander))
                     ciRules.add((DeckRuleColorIdentity) rule);
             }

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -1656,7 +1656,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
                 return rules;
             }
             for (final PaperCard p : deck.getCommanders()) {
-                for (final DeckRule rule : DeckRule.parseAll(p)) {
+                for (final DeckRule rule : p.getDeckRuleList()) {
                     if (rule instanceof DeckRuleColorIdentity && rule.isActiveFor(DeckSection.Commander)) {
                         rules.add((DeckRuleColorIdentity) rule);
                     }
@@ -2139,7 +2139,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
             }
 
             if (currentDeck != null && deckSection == DeckSection.Commander) {
-                for (final DeckRule rule : DeckRule.parseAll(card)) {
+                for (final DeckRule rule : card.getDeckRuleList()) {
                     if (!(rule instanceof DeckRuleColorIdentity) || !rule.isActiveFor(DeckSection.Commander)) {
                         continue;
                     }

--- a/forge-gui/res/cardsfolder/c/cid_timeless_artificer.txt
+++ b/forge-gui/res/cardsfolder/c/cid_timeless_artificer.txt
@@ -3,7 +3,7 @@ ManaCost:2 W U
 Types:Legendary Creature Human Artificer
 PT:4/4
 K:Cycling:W U
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Creature.Artifact+YouCtrl,Creature.Hero+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Artifact creatures and Heroes you control get +1/+1 for each Artificer you control and each Artificer card in your graveyard.
 SVar:X:Count$ValidBattlefield,Graveyard Artificer.YouCtrl
 DeckHas:Ability$Discard

--- a/forge-gui/res/cardsfolder/c/cid_timeless_artificer.txt
+++ b/forge-gui/res/cardsfolder/c/cid_timeless_artificer.txt
@@ -2,8 +2,8 @@ Name:Cid, Timeless Artificer
 ManaCost:2 W U
 Types:Legendary Creature Human Artificer
 PT:4/4
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 K:Cycling:W U
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Creature.Artifact+YouCtrl,Creature.Hero+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Artifact creatures and Heroes you control get +1/+1 for each Artificer you control and each Artificer card in your graveyard.
 SVar:X:Count$ValidBattlefield,Graveyard Artificer.YouCtrl
 DeckHas:Ability$Discard

--- a/forge-gui/res/cardsfolder/d/dragons_approach.txt
+++ b/forge-gui/res/cardsfolder/d/dragons_approach.txt
@@ -1,7 +1,7 @@
 Name:Dragon's Approach
 ManaCost:2 R
 Types:Sorcery
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:SP$ DealDamage | Defined$ Player.Opponent | NumDmg$ 3 | SubAbility$ DBSearch | SpellDescription$ CARDNAME deals 3 damage to each opponent. You may exile CARDNAME and four cards named Dragon's Approach from your graveyard. If you do, search your library for a Dragon creature card, put it onto the battlefield, then shuffle.
 SVar:DBSearch:DB$ ChangeZone | UnlessCost$ ExileFromGrave<4/Card.namedDragon's Approach> ExileFromStack<1/Card.Self> | UnlessSwitched$ True | UnlessPayer$ You | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Dragon | ChangeNum$ 1 | SpellDescription$ Search your library for a Dragon creature card, put it onto the battlefield, then shuffle.
 Oracle:Dragon's Approach deals 3 damage to each opponent. You may exile Dragon's Approach and four cards named Dragon's Approach from your graveyard. If you do, search your library for a Dragon creature card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Dragon's Approach.

--- a/forge-gui/res/cardsfolder/d/dragons_approach.txt
+++ b/forge-gui/res/cardsfolder/d/dragons_approach.txt
@@ -1,7 +1,7 @@
 Name:Dragon's Approach
 ManaCost:2 R
 Types:Sorcery
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:SP$ DealDamage | Defined$ Player.Opponent | NumDmg$ 3 | SubAbility$ DBSearch | SpellDescription$ CARDNAME deals 3 damage to each opponent. You may exile CARDNAME and four cards named Dragon's Approach from your graveyard. If you do, search your library for a Dragon creature card, put it onto the battlefield, then shuffle.
 SVar:DBSearch:DB$ ChangeZone | UnlessCost$ ExileFromGrave<4/Card.namedDragon's Approach> ExileFromStack<1/Card.Self> | UnlessSwitched$ True | UnlessPayer$ You | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Dragon | ChangeNum$ 1 | SpellDescription$ Search your library for a Dragon creature card, put it onto the battlefield, then shuffle.
 Oracle:Dragon's Approach deals 3 damage to each opponent. You may exile Dragon's Approach and four cards named Dragon's Approach from your graveyard. If you do, search your library for a Dragon creature card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Dragon's Approach.

--- a/forge-gui/res/cardsfolder/g/gleemox.txt
+++ b/forge-gui/res/cardsfolder/g/gleemox.txt
@@ -1,6 +1,6 @@
 Name:Gleemox
 ManaCost:0
 Types:Artifact
-K:DeckLimit:0:This card is banned.
+DeckRule:Copies:Limit$ 0 | Affected$ Name:CARDNAME | Description$ This card is banned.
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 Oracle:{T}: Add one mana of any color.\nThis card is banned.

--- a/forge-gui/res/cardsfolder/g/gleemox.txt
+++ b/forge-gui/res/cardsfolder/g/gleemox.txt
@@ -1,6 +1,6 @@
 Name:Gleemox
 ManaCost:0
 Types:Artifact
-DeckRule:Copies:Limit$ 0 | Affected$ Name:CARDNAME | Description$ This card is banned.
+DeckRule:Copies:Limit$ 0 | Affected$ namedCARDNAME | Description$ This card is banned.
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 Oracle:{T}: Add one mana of any color.\nThis card is banned.

--- a/forge-gui/res/cardsfolder/h/hare_apparent.txt
+++ b/forge-gui/res/cardsfolder/h/hare_apparent.txt
@@ -2,7 +2,7 @@ Name:Hare Apparent
 ManaCost:1 W
 Types:Creature Rabbit Noble
 PT:2/2
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_rabbit | TokenOwner$ You | AILogic$ Always
 SVar:X:Count$Valid Creature.namedHare Apparent+YouCtrl+Other

--- a/forge-gui/res/cardsfolder/h/hare_apparent.txt
+++ b/forge-gui/res/cardsfolder/h/hare_apparent.txt
@@ -2,7 +2,7 @@ Name:Hare Apparent
 ManaCost:1 W
 Types:Creature Rabbit Noble
 PT:2/2
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_rabbit | TokenOwner$ You | AILogic$ Always
 SVar:X:Count$Valid Creature.namedHare Apparent+YouCtrl+Other

--- a/forge-gui/res/cardsfolder/n/nazgul.txt
+++ b/forge-gui/res/cardsfolder/n/nazgul.txt
@@ -2,8 +2,8 @@ Name:Nazgûl
 ManaCost:2 B
 Types:Creature Wraith Knight
 PT:1/2
+DeckRule:Copies:Limit$ 9 | Affected$ namedCARDNAME | Description$ A deck can have up to nine cards named CARDNAME.
 K:Deathtouch
-DeckRule:Copies:Limit$ 9 | Affected$ Name:CARDNAME | Description$ A deck can have up to nine cards named CARDNAME.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTempt | TriggerDescription$ When CARDNAME enters, the Ring tempts you.
 SVar:TrigTempt:DB$ RingTemptsYou
 T:Mode$ RingTemptsYou | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCounters | TriggerDescription$ Whenever the Ring tempts you, put a +1/+1 counter on each Wraith you control.

--- a/forge-gui/res/cardsfolder/n/nazgul.txt
+++ b/forge-gui/res/cardsfolder/n/nazgul.txt
@@ -3,7 +3,7 @@ ManaCost:2 B
 Types:Creature Wraith Knight
 PT:1/2
 K:Deathtouch
-K:DeckLimit:9:A deck can have up to nine cards named CARDNAME.
+DeckRule:Copies:Limit$ 9 | Affected$ Name:CARDNAME | Description$ A deck can have up to nine cards named CARDNAME.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTempt | TriggerDescription$ When CARDNAME enters, the Ring tempts you.
 SVar:TrigTempt:DB$ RingTemptsYou
 T:Mode$ RingTemptsYou | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCounters | TriggerDescription$ Whenever the Ring tempts you, put a +1/+1 counter on each Wraith you control.

--- a/forge-gui/res/cardsfolder/o/once_more_with_feeling.txt
+++ b/forge-gui/res/cardsfolder/o/once_more_with_feeling.txt
@@ -1,7 +1,7 @@
 Name:Once More with Feeling
 ManaCost:W W W W
 Types:Sorcery
-K:DeckLimit:1:DCI ruling — A deck can have only one card named Once More with Feeling.
+DeckRule:Copies:Limit$ 1 | Affected$ Name:CARDNAME | Description$ DCI ruling — A deck can have only one card named CARDNAME.
 A:SP$ ChangeZoneAll | ChangeType$ Permanent | Origin$ Battlefield,Graveyard | Destination$ Exile | SubAbility$ DBShuffle | SpellDescription$ Exile all permanents and all cards from all graveyards. Each player shuffles their hand into their library, then draws seven cards. Each player's life total becomes 10. Exile CARDNAME.
 SVar:DBShuffle:DB$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand | Destination$ Library | Shuffle$ True | UseAllOriginZones$ True | SubAbility$ DBDraw | StackDescription$ None
 SVar:DBDraw:DB$ Draw | NumCards$ 7 | Defined$ Player | SubAbility$ SetAllLife | StackDescription$ None

--- a/forge-gui/res/cardsfolder/o/once_more_with_feeling.txt
+++ b/forge-gui/res/cardsfolder/o/once_more_with_feeling.txt
@@ -1,7 +1,7 @@
 Name:Once More with Feeling
 ManaCost:W W W W
 Types:Sorcery
-DeckRule:Copies:Limit$ 1 | Affected$ Name:CARDNAME | Description$ DCI ruling — A deck can have only one card named CARDNAME.
+DeckRule:Copies:Limit$ 1 | Affected$ namedCARDNAME | Description$ DCI ruling — A deck can have only one card named CARDNAME.
 A:SP$ ChangeZoneAll | ChangeType$ Permanent | Origin$ Battlefield,Graveyard | Destination$ Exile | SubAbility$ DBShuffle | SpellDescription$ Exile all permanents and all cards from all graveyards. Each player shuffles their hand into their library, then draws seven cards. Each player's life total becomes 10. Exile CARDNAME.
 SVar:DBShuffle:DB$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand | Destination$ Library | Shuffle$ True | UseAllOriginZones$ True | SubAbility$ DBDraw | StackDescription$ None
 SVar:DBDraw:DB$ Draw | NumCards$ 7 | Defined$ Player | SubAbility$ SetAllLife | StackDescription$ None

--- a/forge-gui/res/cardsfolder/p/persistent_petitioners.txt
+++ b/forge-gui/res/cardsfolder/p/persistent_petitioners.txt
@@ -2,7 +2,7 @@ Name:Persistent Petitioners
 ManaCost:1 U
 Types:Creature Human Advisor
 PT:1/3
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | ValidTgts$ Player | SpellDescription$ Target player mills a card.
 A:AB$ Mill | Cost$ tapXType<4/Advisor> | NumCards$ 12 | ValidTgts$ Player | SpellDescription$ Target player mills twelve cards.
 SVar:BuffedBy:Creature.namedPersistent Petitioners

--- a/forge-gui/res/cardsfolder/p/persistent_petitioners.txt
+++ b/forge-gui/res/cardsfolder/p/persistent_petitioners.txt
@@ -2,7 +2,7 @@ Name:Persistent Petitioners
 ManaCost:1 U
 Types:Creature Human Advisor
 PT:1/3
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | ValidTgts$ Player | SpellDescription$ Target player mills a card.
 A:AB$ Mill | Cost$ tapXType<4/Advisor> | NumCards$ 12 | ValidTgts$ Player | SpellDescription$ Target player mills twelve cards.
 SVar:BuffedBy:Creature.namedPersistent Petitioners

--- a/forge-gui/res/cardsfolder/r/rat_colony.txt
+++ b/forge-gui/res/cardsfolder/r/rat_colony.txt
@@ -2,7 +2,7 @@ Name:Rat Colony
 ManaCost:1 B
 Types:Creature Rat
 PT:2/1
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | Description$ CARDNAME gets +1/+0 for each other Rat you control.
 SVar:X:Count$Valid Rat.YouCtrl+Other
 SVar:BuffedBy:Rat

--- a/forge-gui/res/cardsfolder/r/rat_colony.txt
+++ b/forge-gui/res/cardsfolder/r/rat_colony.txt
@@ -2,7 +2,7 @@ Name:Rat Colony
 ManaCost:1 B
 Types:Creature Rat
 PT:2/1
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | Description$ CARDNAME gets +1/+0 for each other Rat you control.
 SVar:X:Count$Valid Rat.YouCtrl+Other
 SVar:BuffedBy:Rat

--- a/forge-gui/res/cardsfolder/r/relentless_rats.txt
+++ b/forge-gui/res/cardsfolder/r/relentless_rats.txt
@@ -2,7 +2,7 @@ Name:Relentless Rats
 ManaCost:1 B B
 Types:Creature Rat
 PT:2/2
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each other creature on the battlefield named Relentless Rats.
 SVar:X:Count$Valid Creature.namedRelentless Rats+Other
 SVar:BuffedBy:Creature.namedRelentless Rats

--- a/forge-gui/res/cardsfolder/r/relentless_rats.txt
+++ b/forge-gui/res/cardsfolder/r/relentless_rats.txt
@@ -2,7 +2,7 @@ Name:Relentless Rats
 ManaCost:1 B B
 Types:Creature Rat
 PT:2/2
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each other creature on the battlefield named Relentless Rats.
 SVar:X:Count$Valid Creature.namedRelentless Rats+Other
 SVar:BuffedBy:Creature.namedRelentless Rats

--- a/forge-gui/res/cardsfolder/s/seven_dwarves.txt
+++ b/forge-gui/res/cardsfolder/s/seven_dwarves.txt
@@ -2,7 +2,7 @@ Name:Seven Dwarves
 ManaCost:1 R
 Types:Creature Dwarf
 PT:2/2
-DeckRule:Copies:Limit$ 7 | Affected$ Name:CARDNAME | Description$ A deck can have up to seven cards named CARDNAME.
+DeckRule:Copies:Limit$ 7 | Affected$ namedCARDNAME | Description$ A deck can have up to seven cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each other creature named Seven Dwarves you control.
 SVar:X:Count$Valid Creature.namedSeven Dwarves+Other+YouCtrl
 SVar:BuffedBy:Creature.namedSeven Dwarves

--- a/forge-gui/res/cardsfolder/s/seven_dwarves.txt
+++ b/forge-gui/res/cardsfolder/s/seven_dwarves.txt
@@ -2,7 +2,7 @@ Name:Seven Dwarves
 ManaCost:1 R
 Types:Creature Dwarf
 PT:2/2
-K:DeckLimit:7:A deck can have up to seven cards named CARDNAME.
+DeckRule:Copies:Limit$ 7 | Affected$ Name:CARDNAME | Description$ A deck can have up to seven cards named CARDNAME.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each other creature named Seven Dwarves you control.
 SVar:X:Count$Valid Creature.namedSeven Dwarves+Other+YouCtrl
 SVar:BuffedBy:Creature.namedSeven Dwarves

--- a/forge-gui/res/cardsfolder/s/shadowborn_apostle.txt
+++ b/forge-gui/res/cardsfolder/s/shadowborn_apostle.txt
@@ -2,7 +2,7 @@ Name:Shadowborn Apostle
 ManaCost:B
 Types:Creature Human Cleric
 PT:1/1
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:AB$ ChangeZone | Cost$ B Sac<6/Creature.namedShadowborn Apostle/creatures named Shadowborn Apostle> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Demon | ChangeNum$ 1 | SpellDescription$ Search your library for a Demon creature card, put it onto the battlefield, then shuffle.
 SVar:AIPreference:SacCost$Card
 DeckHints:Name$Shadowborn Demon

--- a/forge-gui/res/cardsfolder/s/shadowborn_apostle.txt
+++ b/forge-gui/res/cardsfolder/s/shadowborn_apostle.txt
@@ -2,7 +2,7 @@ Name:Shadowborn Apostle
 ManaCost:B
 Types:Creature Human Cleric
 PT:1/1
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:AB$ ChangeZone | Cost$ B Sac<6/Creature.namedShadowborn Apostle/creatures named Shadowborn Apostle> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Demon | ChangeNum$ 1 | SpellDescription$ Search your library for a Demon creature card, put it onto the battlefield, then shuffle.
 SVar:AIPreference:SacCost$Card
 DeckHints:Name$Shadowborn Demon

--- a/forge-gui/res/cardsfolder/s/slime_against_humanity.txt
+++ b/forge-gui/res/cardsfolder/s/slime_against_humanity.txt
@@ -1,10 +1,10 @@
 Name:Slime Against Humanity
 ManaCost:2 G
 Types:Sorcery
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:SP$ Token | TokenScript$ g_0_0_ooze_trample | RememberTokens$ True | SubAbility$ DBPutCounters | SpellDescription$ Create a 0/0 green Ooze creature token with trample.
 SVar:DBPutCounters:DB$ PutCounter | Defined$ Remembered | CounterType$ P1P1 | CounterNum$ Count$ValidGraveyard,Exile Ooze.YouOwn,Card.YouOwn+namedSlime Against Humanity/Plus.2 | StackDescription$ SpellDescription | SubAbility$ DBCleanup | SpellDescription$ Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 DeckHas:Ability$Token & Type$Ooze
 DeckHints:Type$Ooze
 Oracle:Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.\nA deck can have any number of cards named Slime Against Humanity.

--- a/forge-gui/res/cardsfolder/s/slime_against_humanity.txt
+++ b/forge-gui/res/cardsfolder/s/slime_against_humanity.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ Token | TokenScript$ g_0_0_ooze_trample | RememberTokens$ True | SubAbility$ DBPutCounters | SpellDescription$ Create a 0/0 green Ooze creature token with trample.
 SVar:DBPutCounters:DB$ PutCounter | Defined$ Remembered | CounterType$ P1P1 | CounterNum$ Count$ValidGraveyard,Exile Ooze.YouOwn,Card.YouOwn+namedSlime Against Humanity/Plus.2 | StackDescription$ SpellDescription | SubAbility$ DBCleanup | SpellDescription$ Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 DeckHas:Ability$Token & Type$Ooze
 DeckHints:Type$Ooze
 Oracle:Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.\nA deck can have any number of cards named Slime Against Humanity.

--- a/forge-gui/res/cardsfolder/t/tempest_hawk.txt
+++ b/forge-gui/res/cardsfolder/t/tempest_hawk.txt
@@ -2,8 +2,8 @@ Name:Tempest Hawk
 ManaCost:2 W
 Types:Creature Bird
 PT:2/2
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigSearch | OptionalDecider$ You | CombatDamage$ True | TriggerDescription$ Whenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.namedTempest Hawk | ChangeNum$ 1 | ShuffleNonMandatory$ True
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 Oracle:Flying\nWhenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\nA deck can have any number of cards named Tempest Hawk.

--- a/forge-gui/res/cardsfolder/t/tempest_hawk.txt
+++ b/forge-gui/res/cardsfolder/t/tempest_hawk.txt
@@ -5,5 +5,5 @@ PT:2/2
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigSearch | OptionalDecider$ You | CombatDamage$ True | TriggerDescription$ Whenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.namedTempest Hawk | ChangeNum$ 1 | ShuffleNonMandatory$ True
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 Oracle:Flying\nWhenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\nA deck can have any number of cards named Tempest Hawk.

--- a/forge-gui/res/cardsfolder/t/templar_knight.txt
+++ b/forge-gui/res/cardsfolder/t/templar_knight.txt
@@ -2,8 +2,8 @@ Name:Templar Knight
 ManaCost:1 W
 Types:Creature Human Knight
 PT:3/1
+DeckRule:Copies:Limit$ Unlimited | Affected$ namedCARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 K:Vigilance
-DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:AB$ ChangeZone | Cost$ W tapXType<5/Creature.attacking+namedTemplar Knight/attacking creatures named Templar Knight> | StackDescription$ SpellDescription | Origin$ Library | Destination$ Battlefield | ChangeType$ Artifact.Legendary+YouOwn | ChangeNum$ 1 | SpellDescription$ Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.
 DeckHints:Type$Artifact & Type$Legendary
 Oracle:Vigilance\n{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Templar Knight.

--- a/forge-gui/res/cardsfolder/t/templar_knight.txt
+++ b/forge-gui/res/cardsfolder/t/templar_knight.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Creature Human Knight
 PT:3/1
 K:Vigilance
-K:A deck can have any number of cards named CARDNAME.
+DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
 A:AB$ ChangeZone | Cost$ W tapXType<5/Creature.attacking+namedTemplar Knight/attacking creatures named Templar Knight> | StackDescription$ SpellDescription | Origin$ Library | Destination$ Battlefield | ChangeType$ Artifact.Legendary+YouOwn | ChangeNum$ 1 | SpellDescription$ Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.
 DeckHints:Type$Artifact & Type$Legendary
 Oracle:Vigilance\n{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Templar Knight.

--- a/forge-gui/res/cardsfolder/v/vazal_the_compleat.txt
+++ b/forge-gui/res/cardsfolder/v/vazal_the_compleat.txt
@@ -2,7 +2,7 @@ Name:Vazal, the Compleat
 ManaCost:3 G G G
 Types:Legendary Artifact Creature Phyrexian
 PT:7/7
-K:DeckLimit:1:Megalegendary (Your deck can have only one copy of this card.)
+DeckRule:Copies:Limit$ 1 | Affected$ Name:CARDNAME | Description$ Megalegendary (Your deck can have only one copy of this card.)
 K:Vigilance
 K:Trample
 S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | GainsAbilitiesOf$ Permanent.Other | Description$ CARDNAME has all activated abilities of each other permanent on the battlefield.

--- a/forge-gui/res/cardsfolder/v/vazal_the_compleat.txt
+++ b/forge-gui/res/cardsfolder/v/vazal_the_compleat.txt
@@ -2,7 +2,7 @@ Name:Vazal, the Compleat
 ManaCost:3 G G G
 Types:Legendary Artifact Creature Phyrexian
 PT:7/7
-DeckRule:Copies:Limit$ 1 | Affected$ Name:CARDNAME | Description$ Megalegendary (Your deck can have only one copy of this card.)
+DeckRule:Copies:Limit$ 1 | Affected$ namedCARDNAME | Description$ Megalegendary (Your deck can have only one copy of this card.)
 K:Vigilance
 K:Trample
 S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | GainsAbilitiesOf$ Permanent.Other | Description$ CARDNAME has all activated abilities of each other permanent on the battlefield.


### PR DESCRIPTION
## Summary

This implements `DeckRule:Copies`, the per-card copy-count rule class sketched in [#8066](https://github.com/Card-Forge/forge/issues/8066), building on the `DeckRule:` framework and `DeckRuleColorIdentity`/`DeckRuleSize` groundwork from [#11740](https://github.com/Card-Forge/forge/pull/11740). It replaces the two ad hoc mechanisms that previously implemented per-card copy-count exceptions — the `K:DeckLimit:N:...` keyword and a raw, string-matched `K:A deck can have any number of cards named CARDNAME.` keyword — with a single `DeckRule:Copies:Limit$ <Unlimited|n> | Affected$ <branches>` line, and migrates all 15 cards that used either mechanism.

`DeckRule:` line parsing is also restructured into two steps: the expensive part (splitting a raw `DeckRule:` string into a rule class and its params) is now tokenized once per `CardFace` and cached there, shared across every printing of a card; only the cheap part (building the actual typed rule object) still happens per access.

## Background

[#8066](https://github.com/Card-Forge/forge/issues/8066) sketches `DeckRuleCopies` roughly like:

> ```
> # Seven Dwarves
> DeckRule:Copies:Limit$ 7 | Affected$ Name:CARDNAME | Description$ A deck can have up to seven cards named CARDNAME.
>
> # Relentless Rats
> DeckRule:Copies:Limit$ Unlimited | Affected$ Name:CARDNAME | Description$ A deck can have any number of cards named CARDNAME.
> ```

Before this PR, per-card copy limits were implemented two different, unrelated ways:

- **`K:DeckLimit:N:<description text>`** — a pseudo-keyword read via `CardRules.getKeywordMagnitude("DeckLimit")`, with its own special-cased text rendering in `Card.java`.
- **`K:A deck can have any number of cards named CARDNAME.`** — not a real keyword at all, just an unrecognized `K:` line whose literal text `DeckFormat.canHaveAnyNumberOf()` matched with `Iterables.contains(...)`.

Both are deckbuilding-legality effects, not live-game ones — exactly what #8066's `DeckRuleCopies` is meant to formalize, in the same spirit as `DeckRuleColorIdentity`/`DeckRuleSize` from #11740.

## New: `DeckRuleCopies` (`forge-core`)

One new class, `forge.deck.DeckRuleCopies`:

```
DeckRule:Copies:Limit$ <Unlimited|n> | Affected$ <branches>
```

- **`Limit$ <Unlimited|n>`** — the max copies of a matching card allowed in a deck.
- **`Affected$ <branches>`** — required; which cards the limit applies to. Reuses the same comma-separated branch grammar `DeckRuleColorIdentity`'s `Exempt$` uses (`CardRulesPredicates#restrictionBranch`, `public` so `DeckRuleCopies` can call it directly on a single already-isolated branch). That shared grammar has a `named<Name>` token form — e.g. `namedCARDNAME` — that matches on an exact card name via the existing `CardRulesPredicates.name(EQUALS, ...)` helper, as a plain, colon-free alternative to #8066's `Name:CARDNAME` sketch above.
  * `DeckRuleCopies` substitutes the literal token `CARDNAME` with the rule's own bearing face's real name *before* handing the branch to `restrictionBranch()`, and does that substitution per-branch, after `Affected$`'s value has already been split on commas — so a comma inside the resolved name (e.g. "Vazal, the Compleat") can never be mistaken for a second branch.
- Each migrated card keeps its own oracle-accurate `Description$` rather than generic template text — e.g. Gleemox keeps `This card is banned.` and Once More with Feeling keeps its `DCI ruling —` phrasing.

## Parsing & caching: tokenize once per `CardFace`, build once per access

`DeckRule:` lines used to be re-split from raw strings (colon, pipe, dollar-sign parsing) on every single call to `DeckRule.parseAll`, and that result was then cached once per `PaperCard`. Two problems with that: the cache lived on the wrong object (different printings of the same card are different `PaperCard` instances, so each one redid the same tokenizing work from scratch the first time it was touched), and it only ever looked at the card's main face — a `DeckRule:` line on a card's other face was silently ignored.

This restructures it into two layers:

- **`forge.card.DeckRuleLine`** (new) — a plain, immutable `(ruleClass, params)` pair: one tokenized `DeckRule:` line, not yet built into a typed rule object.
- **`ICardRawAbilites`** gains `List<DeckRuleLine> getTokenizedDeckRules()`.
- **`CardFace`** implements it: splits each raw `DeckRule:` string into a `DeckRuleLine` and caches the resulting list in a `private transient` field, computed once and shared across every `PaperCard` printing built from that face. The `Key$ Value | Key2$ Value2` param-splitting logic that used to live in `DeckRule.parseParams` moved here verbatim (renamed `parseDeckRuleParams`).
- **`DeckRule.parseAll(IPaperCard)`** now loops over `card.getAllFaces()` instead of only `card.getRules().getDeckRules()` (the main face), and for each face reads its own cached `getTokenizedDeckRules()` before building typed rule objects (`DeckRuleColorIdentity`, `DeckRuleSize`, `DeckRuleCopies`) from them. Each face's own name is threaded into `DeckRuleCopies` for its own `CARDNAME` resolution, rather than the card's overall name — so a `DeckRule:Copies` line on a specific face of a multi-faced card resolves `CARDNAME` to that face's name, not the combined card name. This part — building the typed objects — is deliberately *not* cached, since it's cheap once the tokenizing is already done, and still needs to fold in per-`PaperCard` data (a commander's marked colors, for `AllowedAdditionalColor$`) that can't be shared across printings.
- **`PaperCard.getDeckRuleList()`** drops its own `private transient List<DeckRule> deckRuleList` cache field entirely and just calls `DeckRule.parseAll(this)` directly on every access — the expensive work it used to exist to avoid now lives (and is shared) one level down, on `CardFace`.
- **`PaperToken.getDeckRuleList()`** is unchanged — still an uncached passthrough to `DeckRule.parseAll(this)`, since tokens are never a deck's own card-pool entry.

## Other engine plumbing (from the earlier round, unchanged here)

**`forge-core`**
- `DeckFormat.java` — `canHaveAnyNumberOf()` / `canHaveSpecificNumberInDeck()` go through a private `getOwnCopiesLimit(IPaperCard)` helper that scans `getDeckRuleList()` for a `DeckRuleCopies` entry. `getMaxCardCopies(PaperCard)` and `getDeckConformanceProblem()` call `getDeckRuleList()` instead of `DeckRule.parseAll(...)` directly.
- `CardRules.java` — `getKeywordMagnitude(String)` was removed; it only ever existed to read `DeckLimit`'s numeric argument.

**`forge-game`**
- `Card.java` — the two `DeckLimit`-specific text branches (creature/permanent ability text, and `abilityTextInstantSorcery()`) are gone. The creature/permanent path already folds each active `DeckRule`'s `Description$` into the card's live text (from #11740); `abilityTextInstantSorcery()` gained that rendering here, since two migrated cards (Once More with Feeling, Dragon's Approach) are sorceries.

**Call sites on the cache**
`ACEditorBase.java` (desktop deck editor), `FDeckEditor.java` (mobile deck editor), and `DuelScene.java` (Adventure mode) all call `card.getDeckRuleList()` rather than `DeckRule.parseAll(card)` directly, for their `DeckRuleColorIdentity`/`DeckRuleSize` handling. None of them touch `DeckRuleCopies` — Copies is only ever reached through `DeckFormat.canHaveAnyNumberOf()` / `canHaveSpecificNumberInDeck()` / `getMaxCardCopies()`, so no Copies-specific UI change is needed anywhere.

## Cards migrated

All 15 cards that used either old mechanism, all using `Affected$ namedCARDNAME`:

| Card | Old mechanism | New `Limit$` |
| --- | --- | --- |
| Relentless Rats | `K:A deck can have any number...` | `Unlimited` |
| Rat Colony | `K:A deck can have any number...` | `Unlimited` |
| Templar Knight | `K:A deck can have any number...` | `Unlimited` |
| Tempest Hawk | `K:A deck can have any number...` | `Unlimited` |
| Hare Apparent | `K:A deck can have any number...` | `Unlimited` |
| Persistent Petitioners | `K:A deck can have any number...` | `Unlimited` |
| Cid, Timeless Artificer | `K:A deck can have any number...` | `Unlimited` |
| Slime Against Humanity | `K:A deck can have any number...` | `Unlimited` |
| Shadowborn Apostle | `K:A deck can have any number...` | `Unlimited` |
| Dragon's Approach | `K:A deck can have any number...` | `Unlimited` |
| Once More with Feeling | `K:DeckLimit:1:...` | `1` |
| Vazal, the Compleat | `K:DeckLimit:1:...` | `1` |
| Nazgûl | `K:DeckLimit:9:...` | `9` |
| Seven Dwarves | `K:DeckLimit:7:...` | `7` |
| Gleemox | `K:DeckLimit:0:...` (ban) | `0` |

## Known limitations

- Gleemox wasn't a named target of this migration, but it used the exact same `K:DeckLimit` mechanism being removed (`DeckLimit:0` — its ban is implemented as a 0-copy limit); it's migrated to `Limit$ 0` here to avoid silently un-banning it. A dedicated `DeckRule:FormatRestrictions` (per #8066) would be the more semantically correct home for this later.
- `Affected$` has no "omit it to mean self" shorthand — every one of the 15 migrated cards has to spell out `Affected$ namedCARDNAME` in full. A future revision could default `Affected$` to the bearing face's own name when omitted, closer to #8066's terser sketch.
- Building the typed `DeckRule` list is no longer cached per `PaperCard` — a hot path calling `getDeckRuleList()` many times against the same instance will re-run the (cheap) object construction each time, though not the (expensive) string tokenizing.
- `DeckRule:Commander`, `DeckRule:FormatPool`, `DeckRule:Variants`, `DeckRule:FormatRestrictions` from #8066's fuller vision are still not implemented — only `Copies`, joining `ColorIdentity`/`Size` from #11740.
- Exhaustively re-checked `cardsfolder` for any other per-card copy-count mechanism beyond `K:DeckLimit`/the raw keyword (broad sweeps for "any number of", "up to N cards named", "Megalegendary", "banned", and every `K:` keyword verb containing "Deck/Limit/Copy") — no others found. A handful of similarly-worded tutor-effect cards (Squadron Hawk, Battalion Foot Soldier, Legion Conquistador, Gathering Throng, Howling Wolf, Nesting Wurm, Skyshroud Sentinel) were checked directly and confirmed unrelated.

***Code changes made with heavy assistance from Claude***