### PR TITLE
Fix remaining My Laughter Echoes replay issues

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/AbandonEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AbandonEffect.java
@@ -34,6 +34,9 @@ public class AbandonEffect extends SpellAbilityEffect {
         controller.getZone(ZoneType.Command).remove(source);
         controller.getZone(ZoneType.SchemeDeck).add(source);
 
+        controller.getGame().getTriggerHandler().clearActiveTriggers(source, null);
+        controller.getGame().getTriggerHandler().registerActiveTrigger(source, false);
+
         final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
         runParams.put(AbilityKey.Scheme, source);
         controller.getGame().getTriggerHandler().runTrigger(TriggerType.Abandoned, runParams, false);

--- a/forge-game/src/main/java/forge/game/ability/effects/SetInMotionEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetInMotionEffect.java
@@ -25,20 +25,7 @@ public class SetInMotionEffect extends SpellAbilityEffect {
 
         for (int i = 0; i < repeats; i++) {
             if (again) {
-                Card scheme = null;
-
-                Object triggeredScheme = sa.getRootAbility().getTriggeringObject(AbilityKey.Scheme);
-                if (triggeredScheme instanceof Card) {
-                    scheme = controller.getGame().getCardState((Card) triggeredScheme, null);
-                }
-
-                if (scheme == null) {
-                    scheme = controller.getActiveScheme();
-                }
-
-                if (scheme != null) {
-                    controller.setSchemeInMotion(sa, scheme);
-                }
+                controller.setSchemeInMotion(sa, controller.getGame().getCardState((Card) sa.getRootAbility().getTriggeringObject(AbilityKey.Scheme), null));
             } else {
                 controller.setSchemeInMotion(sa);
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/SetInMotionEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetInMotionEffect.java
@@ -1,5 +1,6 @@
 package forge.game.ability.effects;
 
+import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.Card;
@@ -24,11 +25,23 @@ public class SetInMotionEffect extends SpellAbilityEffect {
 
         for (int i = 0; i < repeats; i++) {
             if (again) {
-                controller.setSchemeInMotion(sa, controller.getActiveScheme());
+                Card scheme = null;
+
+                Object triggeredScheme = sa.getRootAbility().getTriggeringObject(AbilityKey.Scheme);
+                if (triggeredScheme instanceof Card) {
+                    scheme = controller.getGame().getCardState((Card) triggeredScheme, null);
+                }
+
+                if (scheme == null) {
+                    scheme = controller.getActiveScheme();
+                }
+
+                if (scheme != null) {
+                    controller.setSchemeInMotion(sa, scheme);
+                }
             } else {
                 controller.setSchemeInMotion(sa);
             }
         }
     }
-
 }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -161,8 +161,6 @@ public class Player extends GameEntity implements Comparable<Player> {
     private CardCollection currentPlanes = new CardCollection();
     private CardCollection planeswalkedToThisTurn = new CardCollection();
 
-    private Card activeScheme = null;
-
     private NavigableMap<Long, Pair<Player, PlayerController>> controlledBy = Maps.newTreeMap();
     private NavigableMap<Long, Player> controlledWhileSearching = Maps.newTreeMap();
 
@@ -273,10 +271,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         return getZone(ZoneType.SchemeDeck).size() > 0; //Only the archenemy has schemes.
     }
 
-    public Card getActiveScheme() {
-        return activeScheme;
-    }
-
     public void setSchemeInMotion(SpellAbility cause) {
         setSchemeInMotion(cause, getZone(ZoneType.SchemeDeck).get(0));
     }
@@ -284,8 +278,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         if (game.getReplacementHandler().run(ReplacementType.SetInMotion, AbilityKey.mapFromAffected(this)) != ReplacementResult.NotReplaced) {
             return;
         }
-
-        activeScheme = scheme;
 
         Map<AbilityKey, Object> moveParams = AbilityKey.newMap();
         moveParams.put(AbilityKey.LastStateBattlefield, game.getLastStateBattlefield());

--- a/forge-gui/res/cardsfolder/m/my_laughter_echoes.txt
+++ b/forge-gui/res/cardsfolder/m/my_laughter_echoes.txt
@@ -1,7 +1,7 @@
 Name:My Laughter Echoes
 ManaCost:no cost
 Types:Ongoing Scheme
-T:Mode$ SetInMotion | ValidCard$ Card.!OnGoing | Execute$ Abandon | TriggerZones$ Command | TriggerDescription$ Whenever you set a non-ongoing scheme in motion, you may abandon this scheme. If you do, set that scheme in motion again.
+T:Mode$ SetInMotion | ValidCard$ !Ongoing | Execute$ Abandon | TriggerZones$ Command | TriggerDescription$ Whenever you set a non-ongoing scheme in motion, you may abandon this scheme. If you do, set that scheme in motion again.
 SVar:Abandon:DB$ Abandon | Optional$ True | RememberAbandoned$ True | SubAbility$ DBSetInMotionAgain
 SVar:DBSetInMotionAgain:DB$ SetInMotion | Again$ True | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True


### PR DESCRIPTION
Follow-up to #11818 and #11820.

## Summary

PR #11820 fixed the original `NullPointerException` by restoring the `activeScheme` assignment in `Player.setSchemeInMotion(...)`.

While validating that fix, I found three remaining issues with `My Laughter Echoes` that can still cause incorrect behavior.

### 1. My Laughter Echoes can trigger on itself

The card script currently uses:

`ValidCard$ Card.!OnGoing`

`Ongoing` is a card type/supertype restriction, but in this form it is being treated as a card property restriction. As a result, the filter can incorrectly match My Laughter Echoes itself when it is first set in motion.

That causes the ongoing scheme to create an abandon trigger for its own `SetInMotion` event and can lead to a self-trigger/repeat loop.

The script now uses:

`ValidCard$ !Ongoing`

which correctly excludes ongoing schemes.

### 2. `Again$ True` should replay the exact triggering scheme

`SetInMotionEffect` currently handles `Again$ True` by replaying:

`controller.getActiveScheme()`

However, the `SetInMotion` trigger already stores the exact scheme that caused the trigger in `AbilityKey.Scheme`.

Using the triggering object is more precise than depending solely on the mutable `activeScheme` field, especially if game state changes before the trigger resolves.

The effect now:

- reads the triggering scheme from `AbilityKey.Scheme`,
- resolves it to the current card state,
- falls back to `activeScheme` for compatibility,
- and safely does nothing if neither can be resolved.

### 3. Abandoning an ongoing scheme bypasses normal trigger refresh

`AbandonEffect` moves a scheme directly from the Command zone back to the Scheme Deck with direct zone remove/add calls.

Because this does not go through the normal zone-change path, the card's active trigger registration is not immediately refreshed.

This matters for My Laughter Echoes because its `SetInMotionAgain` subability runs immediately after it is abandoned. Without refreshing the active triggers first, the abandoned scheme can still be registered while the replayed scheme is being set in motion.

`AbandonEffect` now clears and re-registers the abandoned card's triggers immediately after the move. Since My Laughter Echoes is no longer in its `TriggerZones$ Command` zone, its SetInMotion trigger is no longer active during the replay.

## Changes

- Change My Laughter Echoes from `ValidCard$ Card.!OnGoing` to `ValidCard$ !Ongoing`.
- Resolve `Again$ True` using the trigger's `AbilityKey.Scheme`, with `activeScheme` as a compatibility fallback.
- Refresh active triggers immediately after `AbandonEffect` moves a scheme back to the Scheme Deck.

## Result

With the #11820 fix plus these follow-up changes, My Laughter Echoes now:

- enters the Command zone without triggering on itself,
- remains ongoing normally,
- triggers when a later non-ongoing scheme is set in motion,
- abandons itself correctly,
- replays the exact triggering scheme once,
- and does not retrigger itself during that replay.

## Testing

Manually tested with an AI Archenemy:

- My Laughter Echoes was set in motion first and remained in the Command zone.
- It did not trigger on itself.
- On the following turn, the AI set a non-ongoing scheme in motion.
- My Laughter Echoes triggered and was abandoned.
- The triggering non-ongoing scheme was set in motion again exactly once.
- No crash or repeat loop occurred.

Full Windows/Linux build was also previously verified with:

`mvn -U -B clean -P windows-linux install`

Result:

- Full reactor: PASS
- Desktop tests: 450 run, 0 failures, 0 errors, 6 skipped
- Forge Installer: SUCCESS

## AI assistance

This contribution was developed with assistance from ChatGPT (OpenAI) for code analysis, debugging, and implementation guidance. The changes were manually reviewed and functionally tested before submission.