### PR TITLE
Fix Archenemy lobby team synchronization

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
@@ -906,7 +906,9 @@ public class PlayerPanel extends FPanel {
     }
 
     public int getTeam() {
-        return teamComboBox.getSelectedIndex();
+        return lobby.hasVariant(GameType.Archenemy)
+                ? aeTeamComboBox.getSelectedIndex()
+                : teamComboBox.getSelectedIndex();
     }
     public void setTeam(final int team) {
         teamComboBox.suppressActionListeners();

--- a/forge-gui-mobile/src/forge/screens/constructed/PlayerPanel.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/PlayerPanel.java
@@ -1107,7 +1107,9 @@ public class PlayerPanel extends FContainer {
     }
 
     public int getTeam() {
-        return cbTeam.getSelectedIndex();
+        return screen.hasVariant(GameType.Archenemy)
+                ? cbArchenemyTeam.getSelectedIndex()
+                : cbTeam.getSelectedIndex();
     }
     public void setTeam(int team0) {
         applyingTeamFromNetwork = true;

--- a/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
@@ -138,6 +138,7 @@ public abstract class GameLobby implements IHasGameType {
                     lastArchenemy = otherIndex;
                 }
                 otherSlot.setIsArchenemy(becomesArchenemy);
+                otherSlot.setTeam(becomesArchenemy ? 0 : 1);
             }
         }
 
@@ -448,7 +449,9 @@ public abstract class GameLobby implements IHasGameType {
             final int avatar = slot.getAvatarIndex();
             final int sleeve = slot.getSleeveIndex();
             final boolean isArchenemy = slot.isArchenemy();
-            final int team = GameType.Archenemy.equals(currentGameType) && !isArchenemy ? 1 : slot.getTeam();
+            final int team = variantTypes.contains(GameType.Archenemy)
+                    ? (isArchenemy ? 0 : 1)
+                    : slot.getTeam();
             final Set<AIOption> aiOptions = slot.getAiOptions(); // TODO: could AiOptions carry the choice of which AI is selected to play against?
 
             final boolean isAI = slot.getType() == LobbySlotType.AI;

--- a/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
@@ -449,9 +449,7 @@ public abstract class GameLobby implements IHasGameType {
             final int avatar = slot.getAvatarIndex();
             final int sleeve = slot.getSleeveIndex();
             final boolean isArchenemy = slot.isArchenemy();
-            final int team = variantTypes.contains(GameType.Archenemy)
-                    ? (isArchenemy ? 0 : 1)
-                    : slot.getTeam();
+            final int team = slot.getTeam();
             final Set<AIOption> aiOptions = slot.getAiOptions(); // TODO: could AiOptions carry the choice of which AI is selected to play against?
 
             final boolean isAI = slot.getType() == LobbySlotType.AI;


### PR DESCRIPTION
Fixes #11812

## Summary

This fixes Archenemy lobby role selection becoming out of sync with the numeric team values stored in `LobbyData`.

The desktop lobby uses a dedicated Archenemy/Hero selector (`aeTeamComboBox`) when the Archenemy variant is active, but `VLobby.getSlot()` ultimately reads `PlayerPanel.getTeam()`.

Previously, `PlayerPanel.getTeam()` always returned the value from the normal team combo box, even while that combo was hidden and the Archenemy/Hero selector was being displayed.

That meant the UI could correctly display:

- Archenemy
- Heroes

while the underlying `LobbySlot.team` values still contained stale or unrelated numeric team assignments.

This caused multiple incorrect behaviors.

With Archenemy + Planechase, Heroes could end up on different internal teams and be treated as opponents, allowing an AI Hero to attack another Hero.

A second reproduction also showed that after switching which player was the Archenemy, both players could end up on the same numeric team. The game would then immediately end at Turn 0 because Forge believed all opposing teams had already lost.

The existing `startGame()` logic partially masked the problem by forcing non-Archenemy players onto team 1 only when `currentGameType` was exactly `GameType.Archenemy`.

That does not work reliably when Archenemy is active alongside another variant such as Planechase, because `currentGameType` may refer to the other active variant even though Archenemy is still present in the applied variant set.

## Changes

- `PlayerPanel.getTeam()` now returns the Archenemy/Hero selector value while the Archenemy variant is active.
- `GameLobby.applyToSlot()` now synchronizes the numeric team whenever it updates a player's Archenemy/Hero role.
- Archenemy is assigned team 0 and Heroes are assigned team 1 in the underlying lobby state.
- `GameLobby.startGame()` now derives Archenemy teams from the active variant set rather than requiring `currentGameType` to be exactly `GameType.Archenemy`.

## Result

While Archenemy is active, Forge now consistently maintains:

- Archenemy = team 0
- Heroes = team 1

This keeps the visible Archenemy/Hero selection, `LobbyData`, and the final `RegisteredPlayer` team assignment synchronized.

It also prevents:

- Heroes from being treated as opponents in Archenemy + Planechase,
- stale hidden team values from affecting gameplay,
- and the immediate Turn 0 game-over seen after switching which player is the Archenemy.

The `startGame()` normalization remains as a defensive check so malformed or stale lobby data cannot produce incorrect teams when the match begins.

## Testing

Manually tested:

- Human Hero vs AI Archenemy.
- Switching the Archenemy role between the human and AI.
- Starting a game after changing the Archenemy assignment.
- Archenemy + Planechase team behavior.
- AI Archenemy gameplay through multiple turns.

The previous Turn 0 game-over no longer occurred, and the AI Archenemy was able to play normally.

Ran:

`mvn -U -B clean -P windows-linux install`

Result:

- Full reactor: PASS
- Desktop tests: 450 run, 0 failures, 0 errors, 6 skipped
- Forge Installer: SUCCESS

## AI assistance

This contribution was developed with assistance from ChatGPT (OpenAI) for code analysis, debugging, and implementation guidance. The changes were manually reviewed and functionally tested before submission.