### PR TITLE
fix(cards): correct two malformed script keys

### DIFF
--- a/forge-gui/res/cardsfolder/s/spirit_of_resilience.txt
+++ b/forge-gui/res/cardsfolder/s/spirit_of_resilience.txt
@@ -6,6 +6,6 @@ T:Mode$ ChangesZoneAll | ValidCards$ Card.YouOwn | Origin$ Graveyard | Destinati
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBChooseCard
 SVar:DBChooseCard:DB$ ChooseCard | DefinedCards$ TriggeredCards.Artifact,Creature | SubAbility$ DBClone | Optional$ True
 SVar:DBClone:DB$ Clone | Defined$ ChosenCard | Duration$ UntilEndOfTurn | SubAbility$ DBCleanup
-DBCleanup:DB$ Cleanup | ClearChosenCard$ True
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 DeckHas:Ability$Graveyard
 Oracle:Whenever one or more cards leave your graveyard, put a +1/+1 counter on this creature, then you may have this creature become a copy of an artifact or creature card from among those cards until end of turn.

--- a/forge-gui/res/cardsfolder/t/the_dawning_archaic.txt
+++ b/forge-gui/res/cardsfolder/t/the_dawning_archaic.txt
@@ -8,5 +8,5 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPlay | TriggerDescription$
 SVar:TrigPlay:DB$ Play | TgtZone$ Graveyard | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | ValidTgtsDesc$ instant or sorcery card in your graveyard | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True | ReplaceGraveyard$ Exile | AILogic$ ReplaySpell
 SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
 SVar:HasAttackEffect:TRUE
-ODeckHints:Ability$Graveyard
+DeckHints:Ability$Graveyard
 Oracle:This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nReach\nWhenever The Dawning Archaic attacks, you may cast target instant or sorcery card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.


### PR DESCRIPTION
Spirit of Resilience writes DBCleanup: where it means SVar:DBCleanup:

The Dawning Archaic writes ODeckHints: for DeckHints:

Fixed