### PR TITLE
AI: skip unrelated regeneration abilities before checking costs

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -1000,6 +1000,16 @@ public class ComputerUtil {
                     continue; // Not a Regenerate ability
                 }
                 sa.setActivatingPlayer(controller);
+                // Combat prediction asks this for many creatures. Rule out
+                // unrelated regeneration abilities before evaluating their costs.
+                final TargetRestrictions tgt = sa.getTargetRestrictions();
+                if (tgt != null) {
+                    if (!CardLists.getValidCards(game.getCardsIn(ZoneType.Battlefield), tgt.getValidTgts(), controller, sa.getHostCard(), sa).contains(card)) {
+                        continue;
+                    }
+                } else if (!AbilityUtils.getDefinedCards(sa.getHostCard(), sa.getParam("Defined"), sa).contains(card)) {
+                    continue;
+                }
                 if (!(sa.canPlay() && ComputerUtilCost.canPayCost(sa, controller, false))) {
                     continue; // Can't play ability
                 }
@@ -1018,14 +1028,7 @@ public class ComputerUtil {
                     }
                 }
 
-                final TargetRestrictions tgt = sa.getTargetRestrictions();
-                if (tgt != null) {
-                    if (CardLists.getValidCards(game.getCardsIn(ZoneType.Battlefield), tgt.getValidTgts(), controller, sa.getHostCard(), sa).contains(card)) {
-                        return true;
-                    }
-                } else if (AbilityUtils.getDefinedCards(sa.getHostCard(), sa.getParam("Defined"), sa).contains(card)) {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/forge-gui-desktop/src/test/java/forge/ai/RegenerationPredictionTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/RegenerationPredictionTest.java
@@ -1,0 +1,170 @@
+package forge.ai;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import forge.game.Game;
+import forge.game.ability.AbilityApiBased;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
+import forge.game.cost.Cost;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class RegenerationPredictionTest extends AITest {
+
+    @DataProvider(name = "selfRegenerators")
+    public Object[][] selfRegenerators() {
+        return new Object[][] {
+            { "Wall of Bone", "Swamp", "Forest" },
+            { "Will-o'-the-Wisp", "Swamp", "Forest" },
+            { "Uthden Troll", "Mountain", "Forest" },
+            { "Living Wall", "Forest", null }
+        };
+    }
+
+    @Test(dataProvider = "selfRegenerators")
+    public void predictionRespectsManaAndAbilityRestrictions(String name, String manaName, String wrongManaName) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card creature = addCard(name, ai);
+        Card other = addCard("Dragon Whelp", ai);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, creature));
+        if (wrongManaName != null) {
+            addCard(wrongManaName, ai);
+            game.getAction().checkStateEffects(true);
+            AssertJUnit.assertFalse("Wrong-colored mana must not pay for regeneration", ComputerUtil.canRegenerate(ai, creature));
+        }
+
+        Card mana = addCard(manaName, ai);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, other));
+        AssertJUnit.assertTrue(ComputerUtil.canRegenerate(ai, creature));
+        AssertJUnit.assertTrue("Opponent predictions must also see available regeneration",
+                ComputerUtil.canRegenerate(game.getPlayers().get(0), creature));
+        AssertJUnit.assertFalse("Prediction must not spend mana", mana.isTapped());
+        AssertJUnit.assertEquals(0, creature.getShieldCount());
+
+        mana.setTapped(true);
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, creature));
+        mana.setTapped(false);
+        SpellAbility regeneration = creature.getSpellAbilities().stream()
+                .filter(sa -> sa.getApi() == ApiType.Regenerate).findFirst().orElseThrow();
+        regeneration.setSuppressed(true);
+        AssertJUnit.assertFalse("A disabled ability must not count", ComputerUtil.canRegenerate(ai, creature));
+        regeneration.setSuppressed(false);
+        AssertJUnit.assertTrue(ComputerUtil.canRegenerate(ai, creature));
+        creature.addStaticAbility("Mode$ CantRegenerate | ValidCard$ Card.Self");
+        AssertJUnit.assertFalse("Cannot-regenerate effects must still apply", ComputerUtil.canRegenerate(ai, creature));
+    }
+
+    @Test(dataProvider = "selfRegenerators")
+    public void aiActuallyRegeneratesAfterAnUnrelatedPrediction(String name, String manaName, String wrongManaName) {
+        for (boolean hasMana : new boolean[] { false, true }) {
+            Game game = initAndCreateGame();
+            Player attacker = game.getPlayers().get(1);
+            Player defender = game.getPlayers().get(0);
+            attacker.setTeam(0);
+            defender.setTeam(1);
+            Card threat = addCard("Craw Wurm", attacker);
+            threat.setSickness(false);
+            Card blocker = addCard(name, defender);
+            Card unrelated = addCard("Dragon Whelp", defender);
+            if (hasMana) {
+                addCard(manaName, defender);
+            }
+            game.getAction().checkStateEffects(true);
+            AssertJUnit.assertFalse(ComputerUtil.canRegenerate(defender, unrelated));
+
+            Combat combat = new Combat(attacker);
+            combat.addAttacker(threat, defender);
+            combat.addBlocker(threat, blocker);
+            game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, attacker);
+            game.getPhaseHandler().setCombat(combat);
+            combat.fireTriggersForUnblockedAttackers(game);
+            combat.orderBlockersForDamageAssignment();
+            combat.orderAttackersForDamageAssignment();
+            for (int i = 0; i < 100 && !game.getPhaseHandler().getPhase().isAfter(PhaseType.COMBAT_DAMAGE); i++) {
+                game.getPhaseHandler().mainLoopStep();
+            }
+            AssertJUnit.assertTrue("Combat must finish", game.getPhaseHandler().getPhase().isAfter(PhaseType.COMBAT_DAMAGE));
+            if (hasMana) {
+                AssertJUnit.assertTrue("AI must save the blocker", blocker.isInPlay());
+                AssertJUnit.assertEquals("The regeneration shield must actually replace lethal destruction", 1, blocker.getRegeneratedThisTurn());
+            } else {
+                AssertJUnit.assertEquals("Without mana the blocker must die", 1, countCardsWithName(game, name, ZoneType.Graveyard));
+            }
+        }
+    }
+
+    @Test
+    public void lifePaymentSafetyStillApplies() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card creature = addCard("Mischievous Poltergeist", ai);
+        ai.setLife(20, null);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertTrue(ComputerUtil.canRegenerate(ai, creature));
+        AssertJUnit.assertEquals("Prediction must not pay life", 20, ai.getLife());
+        ai.setLife(4, null);
+        AssertJUnit.assertFalse("AI must preserve its life-payment safety margin", ComputerUtil.canRegenerate(ai, creature));
+    }
+
+    @Test
+    public void sacrificeRegenerationRetainsItsTargetRestriction() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card jar = addCard("Welding Jar", ai);
+        Card artifact = addCard("Living Wall", ai);
+        Card creature = addCard("Dragon Whelp", ai);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, creature));
+        AssertJUnit.assertTrue(ComputerUtil.canRegenerate(ai, artifact));
+        AssertJUnit.assertTrue("Prediction must not sacrifice its source", jar.isInPlay());
+    }
+
+    @Test
+    public void targetedRegenerationStillProtectsAnotherCreature() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        addCard("Asceticism", ai);
+        Card creature = addCard("Dragon Whelp", ai);
+        Card land = addCard("Forest", ai);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, creature));
+
+        addCard("Mountain", ai);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertTrue(ComputerUtil.canRegenerate(ai, creature));
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, land));
+    }
+
+    @Test
+    public void combatPredictionSkipsUnrelatedAbilityEvaluation() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card wall = addCard("Living Wall", ai);
+        Card other = addCard("Dragon Whelp", ai);
+        AtomicInteger evaluations = new AtomicInteger();
+        wall.addSpellAbility(new AbilityApiBased(ApiType.Regenerate, wall, new Cost("1", true), null,
+                Map.of("Defined", "Self")) {
+            @Override
+            public boolean canPlay() {
+                evaluations.incrementAndGet();
+                return false;
+            }
+        });
+        game.getAction().checkStateEffects(true);
+
+        AssertJUnit.assertFalse(ComputerUtil.canRegenerate(ai, other));
+        AssertJUnit.assertEquals("Unrelated regeneration must not evaluate playability or payment", 0, evaluations.get());
+    }
+}


### PR DESCRIPTION
At mtgbattles.com we were running 100,000+ Forge games per day, and a small percentage repeatedly exceeded our three-minute game limit in AI vs AI matches. This bug was the leading cause of those when using only cards from the Unlimited set.

Local debugging found combat prediction evaluating Wall of Bone's regeneration playability and payment while asking whether Dragon Whelp could regenerate. The same unnecessary work appeared for animated Swamps in a Kormus Bell game.

Move the existing target/Defined applicability check in `ComputerUtil.canRegenerate` before `canPlay` and `canPayCost`. Relevant abilities still go through the existing playability, mana, life-payment, and sacrifice checks. This applies to both self-regeneration and targeted regeneration; the engine change is confined to this method.

Replaying the two frozen matchups with **Temurin Java 17.0.20.1+1** shows the impact:

| Seeded matchup | Before, Java 17 | After, Java 17 | Observed improvement |
| --- | ---: | ---: | --- |
| Wall of Bone / Dragon Whelp | 385.2 s | 89.2 s | 4.3× faster; 76.8% less time |
| Wall of Bone / Kormus Bell | >600 s (timed out) | 148.2 s | >4.0× faster (lower bound) |

Both patched games finished naturally. The Dragon Whelp comparison produced **2,184 identical gameplay log lines**, with the same winner and the same **25 regeneration resolutions and 25 destruction replacements** in the same sequence. The speedup did not come from skipping regeneration or changing that game's actions. A run that reaches the time limit is counted as a timeout even if Forge prints an apparent winner.

<details>
<summary>Comparison setup and limits</summary>

- **After:** the exact Java 17 package tested from submitted head `d1e207a56a1fb033463510e7d9c24a6c61d625d9`, which includes `master` through `4bee0abda5`.
- **Before:** that same package with only `ComputerUtil.class` replaced by the version compiled from `4bee0abda5` using the same JDK and compiler options. The source difference is this PR's fix. Every other JAR entry is byte-for-byte identical. Recompiling the patched class with those options also matched the submitted class byte-for-byte.
- Same frozen decks, seats, seeds, resource files, runner, 2 GB JVM heap, and 600-second game/AI-decision limits on both sides. Each replay used a fresh JVM; the four replays ran in sequence without a debugger or stack sampling. The order was before/after for Dragon Whelp and after/before for Kormus Bell.
- One replay per variant per matchup on a shared development workstation, with other development tasks active. These timings demonstrate the problem on these inputs; they are not a statistical estimate of fleet-wide speedup. Earlier Java 17 replays of the patched Kormus Bell game included a timeout at 180 seconds and a natural completion in 230.7 seconds with a longer limit, so this optimization does not guarantee every game finishes within three minutes.

</details>

Validation on the submitted head used **Java 17 for both compilation and execution**:

- Clean full Windows/Linux source build and Checkstyle passed.
- The full default Maven test suite passed: **460 passed, 0 failures/errors, 6 skipped** across the reactor. This includes all 12 new regeneration cases and seven existing automatic-payment/reserved-mana cases. All six skips are existing opt-in network stress tests requiring `-Drun.stress.tests=true`.
- Two real mtgbattles compatibility games passed against the packaged JAR from this commit, checking turn, cast, damage, outcome, and result-line formats.
- The 12 regeneration cases were rerun against both comparison packages on Java 17. All **11 behavior cases pass on both**. The performance regression test fails on the unpatched package as expected (one unrelated playability evaluation instead of zero) and passes on the submitted package.

The [test source is included in this PR](https://github.com/Shedletsky/forge/blob/d1e207a56a1fb033463510e7d9c24a6c61d625d9/forge-gui-desktop/src/test/java/forge/ai/RegenerationPredictionTest.java). It covers unrelated-ability evaluation, self and targeted regeneration, missing/wrong/tapped mana, suppressed abilities, cannot-regenerate effects, opponent prediction, life and sacrifice costs, and actual AI regeneration through lethal combat with Wall of Bone, Living Wall, Uthden Troll, and Will-o'-the-Wisp. Prediction itself must not spend resources or create shields.

Reproduce the build and tests from the repository root with `JAVA_HOME` and `PATH` selecting JDK 17:

```sh
mvn -version
mvn -B clean -P windows-linux -Dmaven.compiler.debug=true -Dmaven.compiler.debuglevel=lines,vars,source install
```

We used **Astra (xhigh) in Codex** to investigate, implement, and test this fix. We are software developers, but not experts in the Forge codebase.
