### PR TITLE
fix(cards): restore Favor of Jukai's Channel ability

### DIFF
--- a/forge-gui/res/cardsfolder/f/favor_of_jukai.txt
+++ b/forge-gui/res/cardsfolder/f/favor_of_jukai.txt
@@ -5,7 +5,7 @@ K:Enchant:Creature,Artifact:artifact or creature
 SVar:AttachAITgts:Creature
 SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 3 | AddToughness$ 3 | AddKeyword$ Reach | Description$ As long as enchanted permanent is a creature, it gets +3/+3 and has reach.
-A:AB$ Pump | PrecostDesc$ Channel — | Cost$ 1 G Discard<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Creature NumAtt$ +3 | NumDef$ +3 | KW$ Reach | SpellDescription$ Target creature gets +3/+3 and gains reach until end of turn.
+A:AB$ Pump | PrecostDesc$ Channel — | Cost$ 1 G Discard<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ +3 | KW$ Reach | SpellDescription$ Target creature gets +3/+3 and gains reach until end of turn.
 DeckHas:Ability$Counters & Keyword$Reach
 DeckHints:Type$Artifact|Creature|Vehicle
 Oracle:Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +3/+3 and has reach.\nChannel — {1}{G}, Discard Favor of Jukai: Target creature gets +3/+3 and gains reach until end of turn.


### PR DESCRIPTION
A missing separator fuses two params: the line reads ValidTgts$ Creature NumAtt$ +3, so ValidTgts becomes the whole string "Creature NumAtt$ +3" and NumAtt is never set.

Card.isValid takes that as the base, finds it is not a card type, subtype or supertype, and returns false for every card, so the Channel ability has no legal target and cannot be activated. If it could resolve, PumpEffect would read a null NumAtt as 0 and grant +0/+3 rather than the +3/+3 the Oracle text promises.

The Aura's static ability is unaffected.