### PR TITLE
Fix ChangeTargetsEffect that affects Chira's random targeting

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
@@ -198,7 +198,11 @@ public class ChangeTargetsEffect extends SpellAbilityEffect {
                 Map<AbilityKey, Object> runParams = AbilityKey.newMap();
                 runParams.put(AbilityKey.SourceSA, tgtSA);
                 runParams.put(AbilityKey.Targets, distinctObjects);
-                // Cause must be a Card, like MagicStack's own BecomesTargetOnce firing, or ValidCause$ never matches
+                // cause is the permanent/card responsible for this retargeting (e.g. the Chef's
+                // Kiss-style redirect source), not necessarily whoever ends up choosing/rolling
+                // the new target - that's fine for "did You cause this" checks (ValidCause$
+                // Card.YouCtrl) as long as Chooser$ (a different player making the actual choice)
+                // is never combined with random retargeting; it isn't today.
                 runParams.put(AbilityKey.Cause, sa.getHostCard());
                 if (random) {
                     runParams.put(AbilityKey.Random, true);

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
@@ -198,12 +198,8 @@ public class ChangeTargetsEffect extends SpellAbilityEffect {
                 Map<AbilityKey, Object> runParams = AbilityKey.newMap();
                 runParams.put(AbilityKey.SourceSA, tgtSA);
                 runParams.put(AbilityKey.Targets, distinctObjects);
-                // cause is the permanent/card responsible for this retargeting (e.g. the Chef's
-                // Kiss-style redirect source), not necessarily whoever ends up choosing/rolling
-                // the new target - that's fine for "did You cause this" checks (ValidCause$
-                // Card.YouCtrl) as long as Chooser$ (a different player making the actual choice)
-                // is never combined with random retargeting; it isn't today.
-                runParams.put(AbilityKey.Cause, sa);
+                // Cause must be a Card, like MagicStack's own BecomesTargetOnce firing, or ValidCause$ never matches
+                runParams.put(AbilityKey.Cause, sa.getHostCard());
                 if (random) {
                     runParams.put(AbilityKey.Random, true);
                 }


### PR DESCRIPTION
## What
`ChangeTargetsEffect` set `AbilityKey.Cause` to the `SpellAbility` itself when firing `BecomesTargetOnce`, instead of `sa.getHostCard()`.

## Why it mattered
`SpellAbility.isValid()` only matches spell/ability-shaped restrictions (`Spell`, `Instant`, `Triggered`, etc.) against itself — `Card.*` restrictions always fail there, correctly, since a `SpellAbility` isn't a `Card`. So any `ValidCause$ Card...` check on the trigger silently failed. `MagicStack`'s own `BecomesTargetOnce` firing already passes `getHostCard()`; this call site just didn't match it.

## Fix
```java
runParams.put(AbilityKey.Cause, sa.getHostCard());
```
***Used Claude as assistance for the creation of the code***