### PR TITLE
fix(cards): remove five dangling SubAbility references (powered by Claude Opus 5)

### DIFF
--- a/forge-gui/res/cardsfolder/c/casey_raph_hotheads.txt
+++ b/forge-gui/res/cardsfolder/c/casey_raph_hotheads.txt
@@ -6,6 +6,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigCharm:DB$ Charm | MinCharmNum$ 1 | CharmNum$ 2 | Choices$ DBExile,DBToken | AdditionalDescription$ . Each mode must target a different player.
 SVar:DBExile:DB$ Dig | ValidTgts$ Player | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Target player exiles the top card of their library. Until that player's next end step, they may play that card without paying its mana cost.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ CRPlay | EffectOwner$ RememberedOwner | Duration$ UntilYourNextEndStep | ExileOnMoved$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:CRPlay:Mode$ Continuous | Affected$ Card.IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | AffectedZone$ Exile | Description$ Until that player's next end step, they may play that card without paying its mana cost.
 SVar:DBToken:DB$ Token | ValidTgts$ Player | TargetUnique$ True | TokenOwner$ ThisTargetedPlayer | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac | SpellDescription$ Target player creates two Treasure tokens.
 Oracle:When Casey & Raph enter, choose one or both. Each mode must target a different player.\n• Target player exiles the top card of their library. Until that player's next end step, they may play that card without paying its mana cost.\n• Target player creates two Treasure tokens.

--- a/forge-gui/res/cardsfolder/c/circadian_struggle.txt
+++ b/forge-gui/res/cardsfolder/c/circadian_struggle.txt
@@ -8,6 +8,6 @@ SVar:DBAnimateB:DB$ AnimateAll | Zone$ Hand | Duration$ Perpetual | ValidCards$ 
 SVar:DBAnimateR:DB$ AnimateAll | Zone$ Hand | Duration$ Perpetual | ValidCards$ Card.IsRemembered | staticAbilities$ ReduceCost | ConditionPresent$ Permanent.YouCtrl+Red | LockInText$ True | SubAbility$ DBAnimateG
 SVar:DBAnimateG:DB$ AnimateAll | Zone$ Hand | Duration$ Perpetual | ValidCards$ Card.IsRemembered | staticAbilities$ ReduceCost | ConditionPresent$ Permanent.YouCtrl+Green | LockInText$ True | SubAbility$ DBCleanup
 SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBEffect
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Valid Permanent.YouCtrl$Colors
 Oracle:Vivid — Seek X cards that each share a color with one or more permanents you control, where X is the number of colors among permanents you control. For each color among permanents you control, those cards perpetually gain "This spell costs {1} less to cast."

--- a/forge-gui/res/cardsfolder/t/typhoid_mary_fractured.txt
+++ b/forge-gui/res/cardsfolder/t/typhoid_mary_fractured.txt
@@ -3,7 +3,7 @@ ManaCost:1 B R
 Types:Legendary Creature Mutant Villain
 PT:3/3
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME attacks, ABILITY
-SVar:TrigCharm:DB$ Charm | CharmNum$ 1 | Choices$ DBToken,DBDraw,DBDrain | Random$ Compare | RandomCompareSVar$ Y | RandomCompare$ LT1 | SubAbility$ DBCharm | AdditionalDescription$ . If you discarded a card this turn, you choose one instead.
+SVar:TrigCharm:DB$ Charm | CharmNum$ 1 | Choices$ DBToken,DBDraw,DBDrain | Random$ Compare | RandomCompareSVar$ Y | RandomCompare$ LT1 | AdditionalDescription$ . If you discarded a card this turn, you choose one instead.
 SVar:Y:PlayerCountPropertyYou$CardsDiscardedThisTurn
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ You | SpellDescription$ Mary — Create a Treasure token.
 SVar:DBDraw:DB$ Draw | SpellDescription$ Typhoid Mary — Draw a card.

--- a/forge-gui/res/cardsfolder/w/withering_curse.txt
+++ b/forge-gui/res/cardsfolder/w/withering_curse.txt
@@ -2,7 +2,7 @@ Name:Withering Curse
 ManaCost:1 B B
 Types:Sorcery
 A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBDestroyAll | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SpellDescription$ All creatures get -2/-2 until end of turn.
-SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Creature | SubAbility$ DBPutCounter | ConditionCheckSVar$ X | SpellDescription$ Infusion — If you gained life this turn, destroy all creatures instead.
+SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Creature | ConditionCheckSVar$ X | SpellDescription$ Infusion — If you gained life this turn, destroy all creatures instead.
 SVar:X:Count$LifeYouGainedThisTurn
 DeckHints:Ability$LifeGain
 Oracle:All creatures get -2/-2 until end of turn.\nInfusion — If you gained life this turn, destroy all creatures instead.

--- a/forge-gui/res/cardsfolder/w/worzel_the_protector.txt
+++ b/forge-gui/res/cardsfolder/w/worzel_the_protector.txt
@@ -2,7 +2,7 @@ Name:Worzel, the Protector
 ManaCost:1 W W W
 Types:Legendary Planeswalker Worzel
 Loyalty:4
-A:AB$ Token | Cost$ SubCounter<0/LOYALTY> | Planeswalker$ True | TokenScript$ w_1_1_cat_loyalty | TokenOwner$ You | RememberTokens$ True | SubAbility$ DBAttach | SpellDescription$ Create a 1/1 white Cat creature token with "{T}: Put a loyalty counter on each planeswalker you control."
+A:AB$ Token | Cost$ SubCounter<0/LOYALTY> | Planeswalker$ True | TokenScript$ w_1_1_cat_loyalty | TokenOwner$ You | RememberTokens$ True | SpellDescription$ Create a 1/1 white Cat creature token with "{T}: Put a loyalty counter on each planeswalker you control."
 A:AB$ Dig | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | DigNum$ 6 | ChangeNum$ 1 | Optional$ True | ChangeValid$ Planeswalker,Plains.Basic | ForceRevealToController$ True | RememberChanged$ True | RestRandomOrder$ True | SpellDescription$ Look at the top six cards of your library. You may reveal a planeswalker or basic Plains card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 A:AB$ CopyPermanent | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | DefinedName$ Scryb Sprites | NumCopies$ 10 | SpellDescription$ Create ten Scryb Sprites tokens. (They're {G} 1/1 Faerie ceratures with flying.)
 Text:CARDNAME can be your commander.


### PR DESCRIPTION
  Five card scripts chain to an SVar they never define. `AbilityFactory.getSubAbility` looks the name up, doesn't find it, prints to stdout and returns `null`:

  ```java
  System.out.println("SubAbility '"+ sSub +"' not found for: " + state.getName());
  return null;
  ```

  The chain then ends early. Nothing fails at load, so the cards ship with the missing link simply absent.

  ### Casey & Raph, Hotheads — the one that changes behaviour

  `DBExile` exiles with `RememberChanged$ True`, `DBEffect` reads it back through `RememberObjects$ Remembered`, then chains to `DBCleanup`, **which was never written**. So the remembered list is never cleared. Casey & Raph is a permanent whose trigger can fire again into the same
  list, and the `Effect` copies whatever is in it.

  This is the case the scripting docs call out: *"Because cards keep their remembered parts when changing zones manual cleanup is usually required"* (`docs/Card-scripting-API/AbilityFactory.md:64`).

  Adds the missing SVar, spelled as `riku_of_many_paths` and `ral_monsoon_mage_ral_leyline_prodigy` spell it for the same `Effect` + `RememberObjects$` shape:

  ```
  SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
  ```

  ### Four references to abilities that never existed

  Each is removed; Forge was already discarding all of them, so behaviour is unchanged.

  | Card | Reference | Why it's dead |
  | --- | --- | --- |
  | Circadian Struggle | `DBCleanup` → `DBEffect` | The perpetual cost reduction is already done by the five `AnimateAll` steps, each carrying `Duration$ Perpetual` and `staticAbilities$ ReduceCost`. A cleanup is the end of a chain |
  | Withering Curse | `DBDestroyAll` → `DBPutCounter` | Neither the card's text nor its script involves counters. `foolish_fate` scripts the same Infusion clause with no such link |
  | Worzel, the Protector | token ability → `DBAttach` | Attaching is for Auras and Equipment; a 1/1 Cat token is neither, and nothing in the card attaches anything |
  | Typhoid Mary, Fractured | `TrigCharm` → `DBCharm` | "Choose one at random. If you discarded a card this turn, you choose one instead" is already expressed by `Random$ Compare \| RandomCompareSVar$ Y \| RandomCompare$ LT1` — `CharmEffect` computes `random =
  Expressions.compare(Y, "LT", 1)` and falls through to the ordinary choose-a-mode path when false (`CharmEffect.java:245-262`). A second `Charm` would give the card two modes |

  `RememberTokens$ True` is deliberately left on Worzel: whether it still earns its place is a separate question from the broken reference.

  ### How they were found

  A card-script parser that resolves every `SubAbility$` chain across the corpus and treats an unresolved name as an error rather than a line on stdout. 33,684 of 33,689 cards resolved cleanly; these five were the exceptions. Every fix was checked against the card's printed Oracle
  text.

Fiind by Claude Opus 5