### PR TITLE
AI: prevent hangs when choosing a damage source

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChooseSourceAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseSourceAi.java
@@ -1,6 +1,5 @@
 package forge.ai.ability;
 
-import com.google.common.collect.Iterables;
 import forge.ai.*;
 import forge.game.Game;
 import forge.game.GameObject;
@@ -126,11 +125,12 @@ public class ChooseSourceAi extends SpellAbilityAi {
                 return bestCreature;
             }
             // No optimal creature was found above, so try to broaden the choice.
-            if (!Iterables.isEmpty(options)) {
-                List<Card> oppCreatures = CardLists.filter(options, Predicate.not(
-                        CardPredicates.CREATURES.and(CardPredicates.isOwner(aiChoser))
-                ));
-                List<Card> aiNonCreatures = CardLists.filter(options,
+            // ChooseSourceEffect includes section headings which are not valid sources.
+            List<Card> fallbackSources = CardLists.filter(options, c -> !c.getName().startsWith("--"));
+            if (!fallbackSources.isEmpty()) {
+                List<Card> oppCreatures = CardLists.filter(fallbackSources,
+                        CardPredicates.CREATURES.and(Predicate.not(CardPredicates.isOwner(aiChoser))));
+                List<Card> aiNonCreatures = CardLists.filter(fallbackSources,
                         CardPredicates.NON_CREATURES
                                 .and(CardPredicates.PERMANENTS)
                                 .and(CardPredicates.isOwner(aiChoser))
@@ -142,7 +142,7 @@ public class ChooseSourceAi extends SpellAbilityAi {
                 if (!aiNonCreatures.isEmpty()) {
                     return Aggregates.random(aiNonCreatures);
                 }
-                return Aggregates.random(options);
+                return Aggregates.random(fallbackSources);
             } else if (!game.getStack().isEmpty()) {
                 // No permanent for the AI to choose. Should normally not happen unless using dev mode or something,
                 // but when it does happen, choose the top card on stack if possible (generally it'll be the SA

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ChooseSourceAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ChooseSourceAiTest.java
@@ -1,0 +1,196 @@
+package forge.ai.ability;
+
+import java.util.List;
+import java.util.Map;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.ability.AbilityFactory;
+import forge.game.ability.AbilityUtils;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+
+public class ChooseSourceAiTest extends AITest {
+    private SpellAbility preventionAbility(String name, Player ai) {
+        Card card = createCard(name, ai);
+        for (SpellAbility sa : card.getSpellAbilities()) {
+            if (sa.getApi() == ApiType.ChooseSource) {
+                sa.setActivatingPlayer(ai);
+                return sa;
+            }
+        }
+        throw new AssertionError("Missing source choice on " + name);
+    }
+
+    private Card separator(Game game) {
+        Card card = new Card(-1, game);
+        card.setName("--PERMANENTS:--");
+        return card;
+    }
+
+    private Card choose(SpellAbility sa, Card... options) {
+        return new ChooseSourceAi().chooseSingleCard(sa.getActivatingPlayer(), sa,
+                List.of(options), false, null, Map.of());
+    }
+
+    private SpellAbility damage(Card source, int amount) {
+        SpellAbility sa = AbilityFactory.getAbility("DB$ DealDamage | Defined$ Opponent | NumDmg$ " + amount, source);
+        sa.setActivatingPlayer(source.getController());
+        return sa;
+    }
+
+    @DataProvider(name = "fallbackSources")
+    public Object[][] fallbackSources() {
+        return new Object[][] {
+                {"Black Vise", false},
+                {"Forest", true},
+                {"Grizzly Bears", true}
+        };
+    }
+
+    @Test(dataProvider = "fallbackSources")
+    public void mandatoryChoiceReturnsARealSource(String name, boolean ownedByAi) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card source = addCard(name, game.getPlayers().get(ownedByAi ? 1 : 0));
+        SpellAbility sa = preventionAbility("Reverse Damage", ai);
+
+        // Call the chooser directly: a null or separator would make ChooseSourceEffect retry forever.
+        AssertJUnit.assertEquals(source, choose(sa, separator(game), source));
+    }
+
+    @Test
+    public void fallbackPrefersOpponentCreatureThenOwnNoncreature() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        Card forest = addCard("Forest", ai);
+        Card vise = addCard("Black Vise", opponent);
+        Card bear = addCard("Grizzly Bears", opponent);
+        SpellAbility sa = preventionAbility("Reverse Damage", ai);
+
+        AssertJUnit.assertEquals(bear, choose(sa, separator(game), forest, vise, bear));
+        AssertJUnit.assertEquals(forest, choose(sa, separator(game), forest, vise));
+    }
+
+    @Test
+    public void fallbackNeverChoosesASectionHeading() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        Card vise = addCard("Black Vise", opponent);
+        Card rack = addCard("The Rack", opponent);
+        SpellAbility sa = preventionAbility("Reverse Damage", ai);
+
+        for (int i = 0; i < 100; i++) {
+            Card chosen = choose(sa, separator(game), vise, rack);
+            AssertJUnit.assertTrue("Choose an offered source, not null or a section heading",
+                    chosen == vise || chosen == rack);
+        }
+    }
+
+    @Test
+    public void choosesUnblockedAttackerBeforeIdleCreature() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        Card attacker = addCard("Grizzly Bears", opponent);
+        Card idle = addCard("Craw Wurm", opponent);
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, opponent);
+        Combat combat = new Combat(opponent);
+        combat.addAttacker(attacker, ai);
+        combat.setBlocked(attacker, false);
+        game.getPhaseHandler().setCombat(combat);
+
+        AssertJUnit.assertEquals(attacker, choose(preventionAbility("Reverse Damage", ai),
+                separator(game), attacker, idle));
+    }
+
+    @Test
+    public void blackViseThreatCanDisappearWhenReverseDamageLeavesHand() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Card vise = addCard("Black Vise", game.getPlayers().get(0));
+        vise.setChosenPlayer(ai);
+        SpellAbility damage = AbilityFactory.getAbility(vise.getSVar("TrigDamage"), vise);
+        damage.setActivatingPlayer(vise.getController());
+        SpellAbility prevention = preventionAbility("Reverse Damage", ai);
+        Card reverseDamage = prevention.getHostCard();
+        ai.getZone(ZoneType.Hand).add(reverseDamage);
+        for (int i = 0; i < 4; i++) {
+            addCardToZone("Plains", ai, ZoneType.Hand);
+        }
+        AssertJUnit.assertEquals(1, AbilityUtils.calculateAmount(vise, damage.getParam("NumDmg"), damage));
+        ai.getZone(ZoneType.Hand).remove(reverseDamage);
+        AssertJUnit.assertEquals(0, AbilityUtils.calculateAmount(vise, damage.getParam("NumDmg"), damage));
+        game.getStack().add(damage);
+
+        // There is no longer predicted damage, but resolving Reverse Damage still requires a source.
+        AssertJUnit.assertEquals(vise, choose(prevention, separator(game), vise));
+        AbilityUtils.resolve(prevention);
+        AssertJUnit.assertEquals(List.of(vise), prevention.getHostCard().getChosenCards());
+        AbilityUtils.resolve(damage);
+        AssertJUnit.assertEquals(20, ai.getLife());
+    }
+
+    @DataProvider(name = "pendingDamage")
+    public Object[][] pendingDamage() {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @Test(dataProvider = "pendingDamage")
+    public void reverseDamagePreventsOnlyChosenSourcesNextDamage(boolean pendingDamage) {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        Card vise = addCard("Black Vise", opponent);
+        SpellAbility damage = damage(vise, 3);
+        if (pendingDamage) {
+            game.getStack().add(damage);
+        }
+        SpellAbility prevention = preventionAbility("Reverse Damage", ai);
+
+        // Fail before resolving if the chooser would hang; then exercise the real card's subability.
+        AssertJUnit.assertEquals(vise, choose(prevention, separator(game), vise));
+        AbilityUtils.resolve(prevention);
+        AssertJUnit.assertEquals(List.of(vise), prevention.getHostCard().getChosenCards());
+
+        Card otherSource = addCard("The Rack", opponent);
+        AbilityUtils.resolve(damage(otherSource, 2));
+        AssertJUnit.assertEquals("Other sources must still deal damage", 18, ai.getLife());
+        AbilityUtils.resolve(damage);
+        AssertJUnit.assertEquals("Prevent three damage and gain three life", 21, ai.getLife());
+        AbilityUtils.resolve(damage(vise, 3));
+        AssertJUnit.assertEquals("The prevention effect is consumed after one damage event", 18, ai.getLife());
+    }
+
+    @Test
+    public void circleOfProtectionFallbackRespectsColorRestriction() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        Card redSource = addCard("Manabarbs", opponent);
+        Card greenSource = addCard("Grizzly Bears", opponent);
+        SpellAbility greenDamage = damage(greenSource, 2);
+        game.getStack().add(greenDamage);
+        SpellAbility prevention = preventionAbility("Circle of Protection: Red", ai);
+
+        AssertJUnit.assertEquals(redSource, choose(prevention, separator(game), redSource));
+        AbilityUtils.resolve(prevention);
+        AbilityUtils.resolve(greenDamage);
+        AssertJUnit.assertEquals("The green source is not prevented", 18, ai.getLife());
+        AbilityUtils.resolve(damage(redSource, 2));
+        AssertJUnit.assertEquals("The red source is prevented without gaining life", 18, ai.getLife());
+        AbilityUtils.resolve(damage(redSource, 2));
+        AssertJUnit.assertEquals("Only the next damage event is prevented", 16, ai.getLife());
+    }
+}


### PR DESCRIPTION
An AI game can spin indefinitely while **Reverse Damage is resolving and choosing a damage source**. This fixes the fallback in `ChooseSourceAi` used by `AILogic$ NeedsPrevention`, which is also used by Circle of Protection and other prevention abilities.

We found this while investigating a small percentage (~15% among decks just using Unlimited set cards) of problematic games at mtgbattles.com, where we were running **100,000+ games/day** and trying to eliminate all sources of AI vs AI matches timing out.

## What goes wrong

A concrete trigger is **Reverse Damage responding to Black Vise**:

1. The defending AI has five cards in hand, including Reverse Damage. Black Vise's pending ability is predicted to deal one damage.
2. Casting Reverse Damage leaves four cards in hand. By the time it resolves, the predicted Black Vise damage is zero.
3. Reverse Damage still requires a source to be chosen. With no useful damage threat found, the AI enters its fallback.
4. That fallback can return `null` or a display section heading instead of a real source. `ChooseSourceEffect` rejects that result and asks again. Nothing changes between attempts, so the game can loop indefinitely.

The fallback's `oppCreatures` predicate was effectively `!(isCreature && isOwnedByAI)`. That admits noncreatures and the synthetic section-heading cards supplied by `ChooseSourceEffect`. A nonempty list containing no creatures can therefore produce `null` when passed to `getBestCreatureAI`, preventing the later fallbacks from running. With only the AI's own creatures available, a heading can also become the selected singleton and be rejected repeatedly.

## Solution

The implementation change is confined to the fallback in `ChooseSourceAi`:

- Exclude the display section headings from fallback candidates, using the same name convention that `ChooseSourceEffect` already rejects.
- Require the creature candidates to actually be creatures owned by someone other than the choosing AI.
- Use the remaining real sources for the existing noncreature and random fallbacks.

This lets a resolving prevention ability make its required source choice even when the originally anticipated damage is no longer present.

## Why we expect limited side effects

The existing selection of damaging stack sources and unblocked attackers is unchanged. The fallback retains its existing intended preferences: creatures owned by other players, then the AI's own noncreature permanents, then a random remaining source. This corrects invalid candidates rather than introducing a new scoring or search policy.

There are no changes to card scripts, damage/prevention rules, human-player choices, cost payment, caching, or timeouts. Comparing the complete Java 17 desktop JARs found exactly one changed compiled class, `ChooseSourceAi`, plus build metadata.

The tests check that abilities still work, not just that execution terminates: Reverse Damage prevents damage from the chosen source, grants the correct life gain, leaves other sources' damage alone, and is consumed after one damage event. Circle of Protection: Red retains its color restriction and prevents damage without granting life. Existing stack-threat and combat choices are also covered.

This is evidence for a small, localized fix, not a guarantee for every card interaction. It does not address every source of simulation timeouts. Maintainer review of the fallback behavior is welcome.

## Rationale and remaining AI limitations

Choosing an arbitrary source can feel unsatisfying: a legal choice may have little strategic value. The random fallback already exists in `ChooseSourceAi`. This patch repairs the candidate filtering so that existing policy can complete, while preserving the earlier choices of damaging stack sources and unblocked attackers. In this caller, `null` represents an uncompleted mandatory choice; it cannot express "there is no useful damage to prevent." Repeatedly returning it leaves the resolving effect asking the same question forever.

A more capable prevention AI could evaluate how casting changes the game state and rank sources by their potential to deal damage later in the turn. Those are worthwhile strategy improvements with a broader behavioral impact. The scope here is to make the existing fallback return a real source and allow the game to continue. The tests establish the reported hang fix and the covered prevention behavior; they do not establish optimal AI play.

## Modern rules: Reverse Damage and Black Vise

Reverse Damage creates a prevention effect before damage occurs, with life gained equal to the damage actually prevented. Its source is chosen as it resolves. Rule 609.7a explicitly says: "A source doesn't need to be capable of dealing damage to be a legal choice." Black Vise remains legal even when its predicted damage is zero; a basic land can also be a legal choice. [Comprehensive Rules, 609.7a and 615](https://media.wizards.com/2026/downloads/MagicCompRules%2020260819.txt).

In the five-card example above, casting Reverse Damage leaves four cards in hand. The player can choose Black Vise when Reverse Damage resolves. Vise checks hand size when its ability resolves, so it deals no damage and Reverse Damage grants no life. The unused prevention effect lasts for the rest of that turn. Casting can still be worthwhile because reducing hand size itself avoids one Vise damage; a smarter AI should weigh that benefit against the card and mana spent. [Rules 608.2h, 120.8 and 615.3](https://media.wizards.com/2026/downloads/MagicCompRules%2020260819.txt).

## Validation

All validation used **Java 17.0.20.1+1**, with the final commit based on `c863084516`.

- **10 regression cases** in `ChooseSourceAiTest`: the same tests give 8 failures and 2 passes before the fix, and all 10 pass afterward. The tests assert the chooser's result before resolving an effect, so the broken implementation fails immediately rather than hanging a test thread.
- Full clean build: **458 passed, 6 skipped, 0 failures/errors**; zero Checkstyle violations.
- **Four saved production matchups** reproduced the loop on the unmodified build at a 60-second diagnostic limit, with 93-98% of JFR execution samples in source selection. All four finished naturally with the patch in **8.0-11.9 seconds**, using a 180-second limit. These are diagnostic observations, not a controlled throughput benchmark; watchdog-forced results were excluded.
- **Seven completed-game controls**, replayed with identical decks, seeds, seats, resources, and JVM settings: six had identical normalized game-event logs. The seventh differed only in the order of two adjacent protection-effect log lines; an additional unpatched replay reproduced that ordering and matched the patched log exactly.
- **Two mtgbattles compatibility games** passed, including result-line and detailed-event formats, using the exact packaged JAR tested above.

The regression tests are included in this PR. Standard Maven commands with Java 17 selected:

```sh
mvn -B -pl forge-gui-desktop -am -Dtest=ChooseSourceAiTest -Dsurefire.failIfNoSpecifiedTests=false test
mvn -B clean -P windows-linux install
```

## Coding-agent disclosure

We used **OpenAI Astra with xhigh reasoning** to investigate, implement, and test this fix. We are software developers, but we are not experts in the Forge codebase. We have kept the change small and provided behavioral tests so its assumptions and effects can be reviewed directly.
