### PR TITLE
fix(cards): correct seven card-script parameter names that nothing reads

### DIFF
--- a/forge-gui/res/cardsfolder/b/beorns_hospitality.txt
+++ b/forge-gui/res/cardsfolder/b/beorns_hospitality.txt
@@ -2,7 +2,7 @@ Name:Beorn's Hospitality
 ManaCost:1 G
 Types:Enchantment
 T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.
-SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | ValidTgtDesc$ creature you control | CounterType$ P1P1 | CounterNum$ 1
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | ValidTgtsDesc$ creature you control | CounterType$ P1P1 | CounterNum$ 1
 A:AB$ Animate | Cost$ 5 G G | Defined$ Self | Types$ Creature,Bear | staticAbilities$ BeornStatic | Duration$ Permanent | SpellDescription$ This enchantment becomes a Bear creature in addition to its other types and gains "This creature's power and toughness are each equal to the number of lands you control." (This effect doesn't end.)
 SVar:BeornStatic:Mode$ Continuous | Affected$ Card.Self | SetPower$ X | SetToughness$ X | Description$ This creature's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl

--- a/forge-gui/res/cardsfolder/g/galion_elvenkings_butler.txt
+++ b/forge-gui/res/cardsfolder/g/galion_elvenkings_butler.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Legendary Creature Elf Advisor
 PT:4/4
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigAnimate | TriggerDescription$ Whenever NICKNAME attacks, choose up to one other target creature you control. Its base power and toughness become equal to NICKNAME's power and toughness until end of turn.
-SVar:TrigAnimate:DB$ Animate | ValidTgts$ Creature.Other+YouCtrl | ValidTgtsDes$ another creature you control | TargetMin$ 0 | TargetMax$ 1 | Power$ X | Toughness$ Y
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Creature.Other+YouCtrl | ValidTgtsDesc$ another creature you control | TargetMin$ 0 | TargetMax$ 1 | Power$ X | Toughness$ Y
 SVar:HasAttackEffect:TRUE
 SVar:X:Count$CardPower
 SVar:Y:Count$CardToughness

--- a/forge-gui/res/cardsfolder/l/leader_super_genius.txt
+++ b/forge-gui/res/cardsfolder/l/leader_super_genius.txt
@@ -2,7 +2,7 @@ Name:Leader, Super-Genius
 ManaCost:2 U U
 Types:Legendary Creature Gamma Scientist Villain
 PT:1/3
-R:Event$ Connive | ActiveZones$ Battlefield | ValidConniver$ Creature.YouCtrl | ReplaceWith$ DBDraw | Description$ If a creature you control would connive, instead you draw a card, then that creature connives.
+R:Event$ Connive | ActiveZones$ Battlefield | ValidCard$ Creature.YouCtrl | ReplaceWith$ DBDraw | Description$ If a creature you control would connive, instead you draw a card, then that creature connives.
 SVar:DBDraw:DB$ Draw | SubAbility$ DBConnive
 SVar:DBConnive:DB$ Connive | Defined$ ReplacedCard
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConnive | TriggerDescription$ At the beginning of combat on your turn, target creature you control connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)

--- a/forge-gui/res/cardsfolder/m/mindblaze.txt
+++ b/forge-gui/res/cardsfolder/m/mindblaze.txt
@@ -3,7 +3,7 @@ ManaCost:5 R
 Types:Sorcery
 A:SP$ NameCard | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBChooseNumber | SpellDescription$ Choose a nonland card name and a number greater than 0. Target player reveals their library. If that library contains exactly the chosen number of cards with the chosen name, CARDNAME deals 8 damage to that player. Then that player shuffles their library.
 SVar:DBChooseNumber:DB$ ChooseNumber | Min$ 1 | SubAbility$ DBReveal
-SVar:DBReveal:DB$ PeekAndReveal | PeekNum$ X | NoPeek$ True | ValidTgts$ Player | RememberRevealed$ True | SubAbility$ DBDamage
+SVar:DBReveal:DB$ PeekAndReveal | PeekAmount$ X | NoPeek$ True | ValidTgts$ Player | RememberRevealed$ True | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | NumDmg$ 8 | Defined$ Targeted | ConditionDefined$ Remembered | ConditionPresent$ Card.NamedCard | ConditionCompare$ EQY | SubAbility$ DBShuffle
 SVar:DBShuffle:DB$ Shuffle | Defined$ ParentTarget | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/m/mob_verdict.txt
+++ b/forge-gui/res/cardsfolder/m/mob_verdict.txt
@@ -1,7 +1,7 @@
 Name:Mob Verdict
 ManaCost:2 R R
 Types:Sorcery
-A:SP$ Vote | Defined$ Player | Secret$ True | VotePlayer$ Other | StoreVoteNum$ True | SubAbility$ DBRepeatOpp | StackDescription$ SpellDescription | SpellDescription$ Secret council — Each player secretly votes for another player, then those votes are revealed. For each vote an opponent received, CARDNAME deals 2 damage to that player and each creature that player controls. For each vote you received, draw a card.
+A:SP$ Vote | Defined$ Player | Secretly$ True | VotePlayer$ Other | StoreVoteNum$ True | SubAbility$ DBRepeatOpp | StackDescription$ SpellDescription | SpellDescription$ Secret council — Each player secretly votes for another player, then those votes are revealed. For each vote an opponent received, CARDNAME deals 2 damage to that player and each creature that player controls. For each vote you received, draw a card.
 SVar:DBRepeatOpp:DB$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBDamage | AmountFromVotes$ True | SubAbility$ DBRepeatYou
 SVar:DBDamage:DB$ DamageAll | NumDmg$ SVar$Votes/Times.2 | ValidCards$ Creature.RememberedPlayerCtrl | ValidPlayers$ Remembered
 SVar:DBRepeatYou:DB$ RepeatEach | RepeatPlayers$ You | RepeatSubAbility$ DBDraw | AmountFromVotes$ True

--- a/forge-gui/res/cardsfolder/upcoming/generous_revival.txt
+++ b/forge-gui/res/cardsfolder/upcoming/generous_revival.txt
@@ -1,7 +1,7 @@
 Name:Generous Revival
 ManaCost:2 W
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn+cmcLE3 | ValidTgtDesc$ creature card with mana value 3 or less in your graveyard | WithCountersType$ P1P1 | SpellDescription$ Return target creature card with mana value 3 or less from your graveyard to the battlefield with an additional +1/+1 counter on it.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn+cmcLE3 | ValidTgtsDesc$ creature card with mana value 3 or less in your graveyard | WithCountersType$ P1P1 | SpellDescription$ Return target creature card with mana value 3 or less from your graveyard to the battlefield with an additional +1/+1 counter on it.
 K:Flashback:4 W
 DeckHas:Ability$Graveyard|Counters
 Oracle:Return target creature card with mana value 3 or less from your graveyard to the battlefield with an additional +1/+1 counter on it.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/upcoming/shuttle_crew.txt
+++ b/forge-gui/res/cardsfolder/upcoming/shuttle_crew.txt
@@ -4,6 +4,6 @@ Types:Creature Human Officer
 PT:1/1
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When this creature enters, it deals 4 damage to target tapped creature an opponent controls.
-SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature.tapped+OppCtrl | ValidTgtsDes$ tapped creature an opponent controls | NumDmg$ 4
+SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature.tapped+OppCtrl | ValidTgtsDesc$ tapped creature an opponent controls | NumDmg$ 4
 SVar:PlayMain1:TRUE
 Oracle:Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen this creature enters, it deals 4 damage to target tapped creature an opponent controls.


### PR DESCRIPTION
Each of these keys is written by a card script and read by no Java code anywhere in the repository. Forge does not warn about an unread key: it sits in the param map, the effect resolves without it, and the card silently does less than its own line says.

Found by scanning every param name Forge reads (getParam, hasParam, getParamOrDefault, raw map access, helpers that take a key as an argument, matchesValidParam, and additionalAbilityKeys) and checking every param use in cardsfolder against that set.

Leader, Super-Genius: ValidConniver$ -> ValidCard$

  ReplaceConnive.canReplace reads only "ValidCard". When the param is
  absent, CardTraitBase.matchesValidParam returns true, so the
  restriction is not merely loosened but gone: the replacement applies
  to every connive in the game, including an opponent's, and Leader's
  controller draws a card each time. The card reads "If a creature you
  control would connive".

Mindblaze: PeekNum$ -> PeekAmount$

  PeekAndRevealEffect defaults PeekAmount to "1", so the card reveals
  the top card instead of the whole library, and can only ever deal
  damage when the chosen number is 1 and the top card matches. The card
  reads "Target player reveals their library". SVar:X is
  TargetedPlayer$CardsInLibrary and is currently computed and
  discarded.

  The name came from DigEffect's DigNum during the 2022 conversion to
  PeekAndReveal; the other 17 cards in that commit all use PeekAmount.

Mob Verdict: Secret$ -> Secretly$

  VoteEffect reads "Secretly". Without it the votes are cast openly, so
  every player after the first votes with full knowledge. The card is a
  Secret council card and reads "Each player secretly votes". The four
  other Secret council cards all write Secretly$ True.

Beorn's Hospitality, Generous Revival: ValidTgtDesc$ -> ValidTgtsDesc$
Galion, Elvenking's Butler; Shuttle Crew: ValidTgtsDes$ -> ValidTgtsDesc$

  One missing "s", one missing "c". TargetRestrictions falls back to
  Lang.buildValidDesc, which lowercases only bare card types, so a
  valid string carrying properties reaches the player unchanged and the
  prompt reads "Select target Creature.tapped+OppCtrl". No rules
  effect: each card's TriggerDescription or SpellDescription already
  carries the printed sentence.

No other card in cardsfolder writes any of these five keys.

Found by Claude Opus 5