### PR TITLE
fix(cards): drop seven card-script parameters that nothing reads

### DIFF
--- a/forge-gui/res/cardsfolder/d/dance_of_the_dead.txt
+++ b/forge-gui/res/cardsfolder/d/dance_of_the_dead.txt
@@ -6,7 +6,7 @@ SVar:AttachAILogic:Reanimate
 SVar:AttachAITgts:Creature.!namedWorldgorger Dragon
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Card.StrictlySelf | Execute$ TrigReanimate | TriggerDescription$ When CARDNAME enters, if it's on the battlefield, it loses "enchant creature card in a graveyard" and gains "enchant creature put onto the battlefield with CARDNAME." Put enchanted creature card onto the battlefield tapped under your control and attach CARDNAME to it. When CARDNAME leaves the battlefield, that creature's controller sacrifices it.
 SVar:TrigReanimate:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ Enchanted | RememberChanged$ True | GainControl$ True | Tapped$ True | SubAbility$ DBAnimate
-SVar:DBAnimate:DB$ Animate | Defined$ Self | OverwriteSpells$ True | Keywords$ Enchant:Creature.IsRemembered:creature put onto the battlefield with CARDNAME | RemoveKeywords$ Enchant:Creature.inZoneGraveyard:creature card in a graveyard | Duration$ Permanent | SubAbility$ DBAttach
+SVar:DBAnimate:DB$ Animate | Defined$ Self | Keywords$ Enchant:Creature.IsRemembered:creature put onto the battlefield with CARDNAME | RemoveKeywords$ Enchant:Creature.inZoneGraveyard:creature card in a graveyard | Duration$ Permanent | SubAbility$ DBAttach
 SVar:DBAttach:DB$ Attach | Defined$ Remembered | SubAbility$ DBDelay
 SVar:DBDelay:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Execute$ TrigSacrifice | RememberObjects$ RememberedLKI | TriggerDescription$ When CARDNAME leaves the battlefield, that creature's controller sacrifices it.
 SVar:TrigSacrifice:DB$ SacrificeAll | Defined$ DirectRemembered

--- a/forge-gui/res/cardsfolder/e/explosive_getaway.txt
+++ b/forge-gui/res/cardsfolder/e/explosive_getaway.txt
@@ -1,7 +1,7 @@
 Name:Explosive Getaway
 ManaCost:3 R W
 Types:Sorcery
-A:SP$ ChangeZone | ValidTgts$ Artifact,Creature | TgtPrompt$ Choose target artifact or creature | Origin$ Battlefield | Destination$ Exile | TargetMin$ 0 | TargetMax$ 1 | SpeTgtPrompt$ Select target creature you control | SubAbility$ DelTrig | RememberChanged$ True | SpellDescription$ Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step. CARDNAME deals 4 damage to each creature.
+A:SP$ ChangeZone | ValidTgts$ Artifact,Creature | TgtPrompt$ Choose target artifact or creature | Origin$ Battlefield | Destination$ Exile | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DelTrig | RememberChanged$ True | SpellDescription$ Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step. CARDNAME deals 4 damage to each creature.
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return exiled permanent to the battlefield. | SubAbility$ DBDamageAll
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI
 SVar:DBDamageAll:DB$ DamageAll | NumDmg$ 4 | ValidCards$ Creature | ValidDescription$ each creature. | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/f/faerie_dragon.txt
+++ b/forge-gui/res/cardsfolder/f/faerie_dragon.txt
@@ -22,7 +22,7 @@ SVar:White:DB$ ChooseCard | Choices$ Permanent | IncludeSpellsOnStack$ True | At
 SVar:DBAnimateW:DB$ Animate | Defined$ ChosenCard | Colors$ White | OverwriteColors$ True | Duration$ Permanent | LockInText$ True | SubAbility$ DBCleanup
 SVar:Red:DB$ ChooseCard | Choices$ Permanent | IncludeSpellsOnStack$ True | AtRandom$ True | LockInText$ True | SubAbility$ DBAnimateR | SpellDescription$ A spell or permanent chosen at random becomes red. (Mana symbols on that permanent remain unchanged.)
 SVar:DBAnimateR:DB$ Animate | Defined$ ChosenCard | Colors$ Red | OverwriteColors$ True | Duration$ Permanent | LockInText$ True | SubAbility$ DBCleanup
-SVar:Damage3:DB$ DealDamage | NumDmg$ 3 | Random$ True | CardChoices$ Creature | PlayerChoices$ Player | RememberRandomChoice$ True | SubAbility$ DBCleanup | SpellDescription$ CARDNAME deals 3 damage to a creature or player chosen at random.
+SVar:Damage3:DB$ DealDamage | NumDmg$ 3 | Random$ True | CardChoices$ Creature | PlayerChoices$ Player | SubAbility$ DBCleanup | SpellDescription$ CARDNAME deals 3 damage to a creature or player chosen at random.
 SVar:Flying:DB$ ChooseCard | Choices$ Creature | AtRandom$ True | SubAbility$ DBPump8 | SpellDescription$ A creature chosen at random gains flying until end of turn.
 SVar:DBPump8:DB$ Pump | Defined$ ChosenCard | KW$ Flying | SubAbility$ DBCleanup
 SVar:P3P3:DB$ ChooseCard | Choices$ Creature | AtRandom$ True | SubAbility$ DBPump9 | SpellDescription$ A creature chosen at random gets +3/+3 until end of turn.
@@ -43,7 +43,7 @@ SVar:M2M0:DB$ ChooseCard | Choices$ Creature | AtRandom$ True | SubAbility$ DBPu
 SVar:DBPump15:DB$ Pump | Defined$ ChosenCard | NumAtt$ -2 | SubAbility$ DBCleanup
 SVar:ToHand:DB$ ChooseCard | Choices$ Creature | AtRandom$ True | SubAbility$ DBChangeZone16 | SpellDescription$ Return a creature chosen at random to its owner's hand.
 SVar:DBChangeZone16:DB$ ChangeZone | Defined$ ChosenCard | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBCleanup
-SVar:Damage1:DB$ DealDamage | NumDmg$ 1 | Random$ True | CardChoices$ Creature | PlayerChoices$ Player | RememberRandomChoice$ True | SubAbility$ DBCleanup | SpellDescription$ CARDNAME deals 1 damage to a creature or player chosen at random.
+SVar:Damage1:DB$ DealDamage | NumDmg$ 1 | Random$ True | CardChoices$ Creature | PlayerChoices$ Player | SubAbility$ DBCleanup | SpellDescription$ CARDNAME deals 1 damage to a creature or player chosen at random.
 SVar:Nerf:DB$ ChooseCard | Choices$ Creature.Other | AtRandom$ True | SubAbility$ DBAnimate18 | SpellDescription$ A creature other than CARDNAME chosen at random becomes 0/2 until end of turn.
 SVar:DBAnimate18:DB$ Animate | Defined$ ChosenCard | Power$ 0 | Toughness$ 2 | SubAbility$ DBCleanup
 SVar:Exile:DB$ ChooseCard | Choices$ Creature | AtRandom$ True | SubAbility$ DBChangeZone19 | SpellDescription$ Exile a creature chosen at random. Its controller gains life equal to its power.

--- a/forge-gui/res/cardsfolder/i/invasion_of_arcavios_invocation_of_the_founders.txt
+++ b/forge-gui/res/cardsfolder/i/invasion_of_arcavios_invocation_of_the_founders.txt
@@ -3,7 +3,7 @@ ManaCost:3 U U
 Types:Battle Siege
 Defense:7
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters, search your library, graveyard, and/or outside the game for an instant or sorcery card you own, reveal it, and put it into your hand. If you search your library this way, shuffle.
-SVar:TrigSearch:DB$ ChangeZone | Hidden$ True | Origin$ Library | Destination$ Hand | ShuffleNonMandatory$ True | OriginAlternative$ Graveyard,Sideboard | AlternativeMessage$ Would you like to search your library with this ability? If you do, your library will be shuffled | ChangeType$ Sorcery.YouOwn,Instant.YouOwn
+SVar:TrigSearch:DB$ ChangeZone | Hidden$ True | Origin$ Library | Destination$ Hand | ShuffleNonMandatory$ True | OriginAlternative$ Graveyard,Sideboard | ChangeType$ Sorcery.YouOwn,Instant.YouOwn
 DeckHas:Ability$Graveyard
 DeckNeeds:Type$Instant|Sorcery
 AlternateMode:DoubleFaced

--- a/forge-gui/res/cardsfolder/n/natural_order.txt
+++ b/forge-gui/res/cardsfolder/n/natural_order.txt
@@ -1,7 +1,7 @@
 Name:Natural Order
 ManaCost:2 G G
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 2 G G Sac<1/Creature.Green/green creature> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Green | ChangeNum$ 1 | AILogic$ SacAndUpgrade+SacWorst | AISearchGoal$ Creature.Green | SpellDescription$ Search your library for a green creature card, put it onto the battlefield, then shuffle.
+A:SP$ ChangeZone | Cost$ 2 G G Sac<1/Creature.Green/green creature> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Green | ChangeNum$ 1 | AILogic$ SacAndUpgrade+SacWorst | SpellDescription$ Search your library for a green creature card, put it onto the battlefield, then shuffle.
 # AI Preference is needed to make the AI consider the ability. Further constraints are defined by AILogic SacAndUpgrade.
 SVar:AIPreference:SacCost$Creature.Green
 Oracle:As an additional cost to cast this spell, sacrifice a green creature.\nSearch your library for a green creature card, put it onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/n/nihiloor.txt
+++ b/forge-gui/res/cardsfolder/n/nihiloor.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:DBRepeat:DB$ RepeatEach | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ DBChoose | SubAbility$ DBCleanup
 SVar:DBChoose:DB$ ChooseCard | Defined$ You | MinAmount$ 0 | Amount$ 1 | Choices$ Creature.untapped+YouCtrl | ChoiceTitle$ Choose up to one untapped creature you control to tap | ChoiceTitleAppend$ Defined Player.IsRemembered | ChoiceZone$ Battlefield | SubAbility$ DBTap
 SVar:DBTap:DB$ Tap | Defined$ ChosenCard | SubAbility$ DBImmediateTrigger
-SVar:DBImmediateTrigger:DB$ ImmediateTrigger | RememberObjects$ ChosenCard & Player.IsRemembered | ConditionDefined$ ChosenCard | ConditionPresent$ Card | ConditionCompare$ GE1 | Execute$ TrigGainControl | TrigDescReminderDefined$ Player.IsRemembered | TriggerDescription$ When you do, gain control of target creature that player controls with power less than or equal to the tapped creature's power for as long as you control CARDNAME.
+SVar:DBImmediateTrigger:DB$ ImmediateTrigger | RememberObjects$ ChosenCard & Player.IsRemembered | ConditionDefined$ ChosenCard | ConditionPresent$ Card | ConditionCompare$ GE1 | Execute$ TrigGainControl | TriggerDescription$ When you do, gain control of target creature that player controls with power less than or equal to the tapped creature's power for as long as you control CARDNAME.
 SVar:TrigGainControl:DB$ GainControl | ValidTgts$ Creature.powerLEX+ControlledBy DelayTriggerRemembered | LoseControl$ LeavesPlay,LoseControl | TgtPrompt$ Select target creature that opponent controls
 SVar:X:TriggerRemembered$CardPower
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True

--- a/forge-gui/res/cardsfolder/o/orochi_hatchery.txt
+++ b/forge-gui/res/cardsfolder/o/orochi_hatchery.txt
@@ -2,7 +2,7 @@ Name:Orochi Hatchery
 ManaCost:X X
 Types:Artifact
 K:etbCounter:CHARGE:X
-A:AB$ Token | Cost$ 5 T | TokenAmount$ Y | TokenController$ You | TokenScript$ g_1_1_snake | SpellDescription$ Create a 1/1 green Snake creature token for each charge counter on CARDNAME.
+A:AB$ Token | Cost$ 5 T | TokenAmount$ Y | TokenScript$ g_1_1_snake | SpellDescription$ Create a 1/1 green Snake creature token for each charge counter on CARDNAME.
 SVar:X:Count$xPaid
 SVar:Y:Count$CardCounters.CHARGE
 SVar:NeedsToPlayVar:Z GE4

--- a/forge-gui/res/cardsfolder/s/spawning_pit.txt
+++ b/forge-gui/res/cardsfolder/s/spawning_pit.txt
@@ -2,6 +2,6 @@ Name:Spawning Pit
 ManaCost:2
 Types:Artifact
 A:AB$ PutCounter | Cost$ Sac<1/Creature> | Defined$ Self | CounterType$ CHARGE | CounterNum$ 1 | SpellDescription$ Put a charge counter on CARDNAME.
-A:AB$ Token | Cost$ 1 SubCounter<2/CHARGE> | TokenController$ You | TokenScript$ c_2_2_a_spawn | SpellDescription$ Create a 2/2 colorless Spawn artifact creature token.
+A:AB$ Token | Cost$ 1 SubCounter<2/CHARGE> | TokenScript$ c_2_2_a_spawn | SpellDescription$ Create a 2/2 colorless Spawn artifact creature token.
 AI:RemoveDeck:All
 Oracle:Sacrifice a creature: Put a charge counter on Spawning Pit.\n{1}, Remove two charge counters from Spawning Pit: Create a 2/2 colorless Spawn artifact creature token.

--- a/forge-gui/res/cardsfolder/t/tomb_of_urami.txt
+++ b/forge-gui/res/cardsfolder/t/tomb_of_urami.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Types:Legendary Land
 A:AB$ Mana | Cost$ T | Produced$ B | SubAbility$ DBPain | SpellDescription$ Add {B}. CARDNAME deals 1 damage to you if you don't control an Ogre.
 SVar:DBPain:DB$ DealDamage | NumDmg$ 1 | Defined$ You | ConditionPresent$ Ogre.YouCtrl | ConditionCompare$ EQ0
-A:AB$ Token | Cost$ 2 B B T Sac<All/Land> | TokenController$ You | TokenScript$ urami | CostDesc$ {2}{B}{B}, {T}, Sacrifice all lands you control: | SpellDescription$ Create Urami, a legendary 5/5 black Demon Spirit creature token with flying.
+A:AB$ Token | Cost$ 2 B B T Sac<All/Land> | TokenScript$ urami | CostDesc$ {2}{B}{B}, {T}, Sacrifice all lands you control: | SpellDescription$ Create Urami, a legendary 5/5 black Demon Spirit creature token with flying.
 AI:RemoveDeck:All
 Oracle:{T}: Add {B}. Tomb of Urami deals 1 damage to you if you don't control an Ogre.\n{2}{B}{B}, {T}, Sacrifice all lands you control: Create Urami, a legendary 5/5 black Demon Spirit creature token with flying.


### PR DESCRIPTION
Companion to the rename PR. These seven keys are also read by no Java code anywhere in the repository, but unlike the renames they change nothing observable, so each is deleted rather than corrected.

TokenController$ You  --  Orochi Hatchery, Spawning Pit, Tomb of Urami

  TokenEffect takes the creating player from
  getDefinedPlayersOrTargeted(sa, "TokenOwner"), which falls back to
  getParamOrDefault("TokenOwner", "You"). None of the three abilities
  targets, so the default branch is taken and the result is already
  You. The key was never read in any revision; it predates the 2013
  module re-org. 2,198 lines in cardsfolder write TokenOwner$ You.

RememberRandomChoice$ True  --  Faerie Dragon, twice

  DamageDealEffect already calls hostCard.addRemembered(random)
  unconditionally inside the Random branch, which is why both chains
  end in a Cleanup that clears Remembered.

OverwriteSpells$ True  --  Dance of the Dead

  Read by AnimateEffectBase until 25900ee, which removed the mechanism
  when Aura spells gained an internal Attach spell.

AISearchGoal$  --  Natural Order

  Read by ChangeZoneAi until 0ba88f3, which generalised SacAndUpgrade
  so the goal is derived rather than declared. That commit touched the
  only two cards using the key; Eldritch Evolution has since had it
  removed.

AlternativeMessage$  --  Invasion of Arcavios

  Read by ChangeZoneEffect until da0db22, which replaced it with
  lblSearchLibrary and lblCardMatchSearchingTypeInAlternateZones and
  stripped the param from roughly 60 cards in the same diff. 62 cards
  use OriginAlternative; this is the one the sweep missed.

SpeTgtPrompt$  --  Explosive Getaway

  Never existed in Java in any revision. The line already carries a
  correct TgtPrompt$, the spell has a single target (TargetMax$ 1), and
  the dead text names objects the card cannot target.

TrigDescReminderDefined$  --  Nihiloor

  Never existed in Java in any revision. ImmediateTriggerEffect reads
  TriggerDescription, SpellDescription, TriggerAmount, RememberObjects,
  RememberEach and RememberSVarAmount. Nihiloor's TriggerDescription
  already carries the printed sentence.

Each deletion removes the key, its value and one separator; no other part of any line changes. None of the seven appears anywhere else in the repository, including docs/Card-scripting-API.

Found by Claude Opus 6.