### PR TITLE
fix(cards): let Dead Ringers' target-count condition take effect

### DIFF
--- a/forge-gui/res/cardsfolder/d/dead_ringers.txt
+++ b/forge-gui/res/cardsfolder/d/dead_ringers.txt
@@ -1,6 +1,6 @@
 Name:Dead Ringers
 ManaCost:4 B
 Types:Sorcery
-A:SP$ Destroy | TargetMin$ 2 | TargetMax$ 2 | NoRegen$ True | ValidTgts$ Creature.nonBlack | TgtPrompt$ Select target nonblack creatures | ConditionNoDifferentColors$ Targeted | ConditionDefined$ Targeted | ConditionPresent$ Card | ConditionPresentCompare$ EQ2 | SpellDescription$ Destroy two target nonblack creatures unless either one is a color the other isn't. They can't be regenerated.
+A:SP$ Destroy | TargetMin$ 2 | TargetMax$ 2 | NoRegen$ True | ValidTgts$ Creature.nonBlack | TgtPrompt$ Select target nonblack creatures | ConditionNoDifferentColors$ Targeted | ConditionDefined$ Targeted | ConditionPresent$ Card | ConditionCompare$ EQ2 | SpellDescription$ Destroy two target nonblack creatures unless either one is a color the other isn't. They can't be regenerated.
 AI:RemoveDeck:All
 Oracle:Destroy two target nonblack creatures unless either one is a color the other isn't. They can't be regenerated.


### PR DESCRIPTION
The line writes ConditionPresentCompare$ EQ2. The condition vocabulary is ConditionDefined / ConditionPresent / ConditionCompare (SpellAbilityCondition.java:164-173), so the key is read by nothing and presentCompare keeps its default "GE1"
(SpellAbilityVariables.java:102).

The condition was added deliberately in ca362664b7c, which removed the Condition$ AllTargetsLegal vocabulary item and rewrote both cards that used it. Goblin Welder got an equivalent count-of-legal-targets branch; Dead Ringers got this, and the typo meant it never applied. Targets are pinned at two by TargetMin$/TargetMax$, so the check only matters when an opponent removes one target in response -- which is the case the whole commit was about.

That case is settled by CR 608.2:

  Illegal targets, if any, won't be affected by parts of a resolving
  spell's effect for which they're illegal. ... If part of the effect
  requires information about an illegal target, it fails to determine
  any such information. Any part of the effect that requires that
  information won't happen.

"Destroy two target nonblack creatures unless either one is a color the other isn't" gates the destruction on a colour comparison between both targets. With one target illegal, that information cannot be determined, so the destruction does not happen and the surviving creature is not destroyed. EQ2 produces exactly that; GE1 destroys the survivor.

This also rules out the pre-2024 script, which kept the original targets with RememberOriginalTargets$ and compared their colours: that determines information about an illegal target, which 608.2 forbids.

The two Gatherer rulings, both 2004-10-04, cover only the case where both targets are legal and are already implemented by ConditionNoDifferentColors$ Targeted. Neither is affected by this change.

Powered by Claude Opus 5