### PR TITLE
fix(cards): register Ingris Stingerquill's SVar

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/ingris_stingerquill.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ingris_stingerquill.txt
@@ -6,6 +6,6 @@ K:Flying
 T:Mode$ Attacks | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever a creature you control attacks, that creature deals 1 damage to each opponent.
 SVar:TrigDamage:DB$ DealDamage | Defined$ Player.Opponent | DamageSource$ TriggeredAttackerLKICopy | NumDmg$ 1
 A:AB$ Token | Cost$ 4 | TokenScript$ cadet | TokenOwner$ You | SubAbility$ DBPumpAll | SpellDescription$ Create a 2/2 colorless Wizard Soldier creature token named Cadet. Then creatures you control gain haste until end of turn.
-Svar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Haste
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Haste
 SVar:HasAttackEffect:TRUE
 Oracle:Flying\nWhenever a creature you control attacks, that creature deals 1 damage to each opponent.\n{4}: Create a 2/2 colorless Wizard Soldier creature token named Cadet. Then creatures you control gain haste until end of turn.


### PR DESCRIPTION
Line 9 reads `Svar:DBPumpAll:` where every other SVar line, on this card and everywhere else, reads `SVar:`.

CardRules.Reader matches the key case-sensitively
(forge-core/src/main/java/forge/card/CardRules.java:841):

    } else if ("SVar".equals(key)) {

so `Svar` is not recognised and DBPumpAll is never registered. The activated ability on line 8 chains to it:

    A:AB$ Token | Cost$ 4 | TokenScript$ cadet | TokenOwner$ You |
      SubAbility$ DBPumpAll | SpellDescription$ Create a 2/2 colorless
      Wizard Soldier creature token named Cadet. Then creatures you
      control gain haste until end of turn.

AbilityFactory.getSubAbility prints "SubAbility 'DBPumpAll' not found" to stdout and returns null, so the token is created and the second sentence of the card does nothing: creatures you control never gain haste.

Printed text: "{4}: Create a 2/2 colorless Wizard Soldier creature token named Cadet. Then creatures you control gain haste until end of turn."

Powered by Claude Opus 5