### PR TITLE
Fix typo in AssetsDownloader comment (seperate -> separate)

### DIFF
--- a/forge-gui-mobile/src/forge/assets/AssetsDownloader.java
+++ b/forge-gui-mobile/src/forge/assets/AssetsDownloader.java
@@ -161,7 +161,7 @@ public class AssetsDownloader {
                 return;
             }
         }
-        // non android don't have seperate package to check
+        // non android don't have separate package to check
         if (!GuiBase.isAndroid()) {
             run(runnable);
             return;


### PR DESCRIPTION
Fixes the misspelling **seperate** in a comment inside `AssetsDownloader`.

No behaviour change - comment only.