### PR TITLE
fix(cards): let Oracle's ability find a target

### DIFF
--- a/forge-gui/res/cardsfolder/o/oracle.txt
+++ b/forge-gui/res/cardsfolder/o/oracle.txt
@@ -2,7 +2,7 @@ Name:Oracle
 ManaCost:no cost
 Types:Vanguard
 HandLifeModifier:+1/+9
-A:AB$ Untap | ActivationZone$ Command | Cost$ 0 | ValidTgts$ Creature.attacking+youCtrl | TgtPrompt$ Select target attacking creature you control | SubAbility$ Reconsider | SpellDescription$ Untap target attacking creature you control and remove it from combat.
+A:AB$ Untap | ActivationZone$ Command | Cost$ 0 | ValidTgts$ Creature.attacking+YouCtrl | TgtPrompt$ Select target attacking creature you control | SubAbility$ Reconsider | SpellDescription$ Untap target attacking creature you control and remove it from combat.
 SVar:Reconsider:DB$ RemoveFromCombat | Defined$ Targeted
 AI:RemoveDeck:All
 Oracle:Hand +1, life +9\n{0}: Untap target attacking creature you control and remove it from combat.


### PR DESCRIPTION
The Vanguard card reads "{0}: Untap target attacking creature you control and remove it from combat." The script writes:

    ValidTgts$ Creature.attacking+youCtrl

with a lowercase `y`. CardProperty tests property names case-sensitively -- `property.equals("YouCtrl")` -- so `youCtrl` matches no branch, and an unmatched property is not ignored: the chain ends at

    } else if (!card.getCurrentState().hasProperty(property, ...)) {
        return false;
    }
    return true;

(CardProperty.java:2116-2119), so the property is simply false for every card. The targeting restriction therefore matches nothing and the ability has no legal target in any game state.

Every other card writes `YouCtrl`; this is the only lowercase spelling in cardsfolder.

Powered by Claude Opus 5.