### PR TITLE
Restore Android 10 support / fix external storage initialization

### DIFF
--- a/forge-gui-android/src/main/AndroidManifest.xml
+++ b/forge-gui-android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-sdk
         android:minSdkVersion="26"
-        android:targetSdkVersion="35" />
+        android:targetSdkVersion="29" />
     <!-- When your app targets Android 11 or higher and it declares the MANAGE_EXTERNAL_STORAGE permission,
          Android Studio shows the lint warning. This warning reminds you that the Google Play store has a policy
          that limits usage of the permission. -->
@@ -30,6 +30,7 @@
 
     <application
         android:allowBackup="true"
+        android:requestLegacyExternalStorage="true"
         android:isGame="true"
         android:appCategory="game"
         android:configChanges="density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"


### PR DESCRIPTION
**Summary**

This PR restores Forge compatibility with Android 10 (API 29).

On Android 10, Forge currently fails during initialization because it cannot access external storage. This appears to be the same issue reported in #7691.

**Changes**
Set targetSdkVersion to API 29.
Added android:requestLegacyExternalStorage="true" to the application manifest.

This restores the legacy external storage behavior required by the current Forge storage implementation on Android 10.

**Testing**

Tested on a physical device:

- Device: HONOR Pad 6
- Android: Android 10
- Result: Forge installs and initializes successfully.
- Initial asset download works.
- Forge launches and runs normally.

Before this change, Forge failed to initialize because it could not access external storage.

**Related issue**

Fixes / relates to #7691.

**Notes**

The change is intentionally focused on restoring Android 10 compatibility with the existing Forge storage implementation.