### PR TITLE
Sync token set codes alongside card set codes (i18n)

### DIFF
--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadFilteredCardImages.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadFilteredCardImages.java
@@ -56,8 +56,13 @@ public class GuiDownloadFilteredCardImages extends GuiDownloadService {
 
             matches.add(c);
             CardEdition edition = StaticData.instance().getEditions().get(setCode3);
-            if (edition != null && !StringUtils.isBlank(edition.getScryfallCode())) {
-                scryfallSetCodes.add(edition.getScryfallCode());
+            if (edition != null) {
+                if (!StringUtils.isBlank(edition.getScryfallCode())) {
+                    scryfallSetCodes.add(edition.getScryfallCode());
+                }
+                if (!StringUtils.isBlank(edition.getTokensCode())) {
+                    scryfallSetCodes.add(edition.getTokensCode());
+                }
             }
         }
 


### PR DESCRIPTION
Tokens weren't included in the CDN language sync, so they never resolved to the preferred language. Same fix as cards, just for getTokensCode() too.