### PR TITLE
Stop routine network shutdown from logging errors

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -53,6 +53,7 @@ import org.jupnp.model.meta.Device;
 import org.jupnp.registry.Registry;
 import org.jupnp.support.igd.PortMappingListener;
 import org.jupnp.support.model.PortMapping;
+import org.jupnp.util.SpecificationViolationReporter;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -147,7 +148,7 @@ public final class FServerManager implements IHasForgeLog {
         }, deadline, TimeUnit.SECONDS);
     }
 
-    private boolean isHosting = false;
+    private volatile boolean isHosting = false;
     private EventLoopGroup bossGroup = new NioEventLoopGroup(1);
     private EventLoopGroup workerGroup = new NioEventLoopGroup();
     private UpnpService upnpService = null;
@@ -306,7 +307,11 @@ public final class FServerManager implements IHasForgeLog {
         stopServer(true);
     }
 
-    private void stopServer(final boolean removeShutdownHook) {
+    private synchronized void stopServer(final boolean removeShutdownHook) {
+        // The shutdown hook and the channel-close thread both stop the server; only the first does the work
+        if (!isHosting) {
+            return;
+        }
         // Cancel all reconnect timers
         for (final Timer timer : reconnectTimers.values()) {
             timer.cancel();
@@ -323,7 +328,12 @@ public final class FServerManager implements IHasForgeLog {
             Thread.currentThread().interrupt();
         }
         if (upnpService != null) {
-            upnpService.shutdown();
+            try {
+                upnpService.shutdown();
+            } catch (Exception | AssertionError e) {
+                // The JDK wraps a failed multicast leave in AssertionError, which jupnp doesn't catch
+                netLog.debug("UPnP shutdown incomplete: {}", e.toString());
+            }
             upnpService = null;
         }
         if (removeShutdownHook) {
@@ -759,6 +769,9 @@ public final class FServerManager implements IHasForgeLog {
                 upnpService.shutdown();
             }
 
+            // Gateways routinely break the UPnP spec in ways jupnp tolerates; don't log each one
+            SpecificationViolationReporter.disableReporting();
+
             // Create a new UPnP service instance
             upnpService = new UpnpServiceImpl(GuiBase.getInterface().getUpnpPlatformService());
             upnpService.startup();
@@ -774,6 +787,7 @@ public final class FServerManager implements IHasForgeLog {
                 public void run() {
                     if (!listener.isCompleted()) {
                         listener.setCompleted();
+                        netLog.warn("UPnP: no gateway confirmed a mapping for port {} within 5 seconds", port);
                         onUPnPResult(false);
                     }
                 }


### PR DESCRIPTION
## Summary

Stopping a hosted game no longer writes exception traces to the log, and routine UPnP warnings are silenced, so logs attached to network bug reports show only real problems. A UPnP port-mapping timeout is now logged.

## Bug report

Closing Forge while hosting, or stopping after a network adapter change, logs stack traces even though nothing went wrong. Each hosting session also logs dozens of UPnP spec-violation warnings about the router.

    java.lang.IllegalStateException: Shutdown in progress
        at java.base/java.lang.Runtime.removeShutdownHook(Runtime.java:252)
        at forge.gamemodes.net.server.FServerManager.stopServer(FServerManager.java:330)

    java.lang.AssertionError: java.net.BindException: Cannot assign requested address: setsocketopt
        at org.jupnp.transport.impl.MulticastReceiverImpl.stop(MulticastReceiverImpl.java:101)
        at forge.gamemodes.net.server.FServerManager.stopServer(FServerManager.java:326)

## Root cause

- `stopServer` runs twice per stop: once from its caller, and once from the thread waiting on the server channel's close. On exit, the second call's `removeShutdownHook` throws because the JVM is already shutting down.
- When a network adapter loses its address, the JDK wraps the failed multicast leave in an `AssertionError`, which jupnp doesn't catch. It aborts `stopServer` partway, so hosting again in the same session fails.
- jupnp logs every spec violation it tolerates, and the UPnP timeout only goes to lobby chat.

## Fix

- `stopServer` is `synchronized` and returns early when not hosting; `isHosting` is `volatile`.
- Failures in `upnpService.shutdown()` are caught and logged at debug.
- `SpecificationViolationReporter.disableReporting()` is called inside `mapNatPort`'s existing `try`.
- The UPnP timeout logs a warning.

## Why this is safe

- Every caller of `stopServer` except mobile's `closeConn` already checks `isHosting()`. That one also closes the client, which cleans up its own logging, so only the duplicate stops become no-ops.
- Nothing else locks on the server and no Netty handler calls `stopServer`, so the lock cannot deadlock.
- Descriptor failures and rejected mappings still log. Only violations jupnp already ignores go quiet.
- No protocol, synchronised state or engine code changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)