### PR TITLE
Convert Shadow to CantBlockBy/CanBlockIfShadow static abilities

### DIFF
--- a/forge-ai/src/main/java/forge/ai/CreatureEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/CreatureEvaluator.java
@@ -8,8 +8,10 @@ import forge.game.card.CounterEnumType;
 import forge.game.cost.CostPayEnergy;
 import forge.game.keyword.Keyword;
 import forge.game.spellability.SpellAbility;
+import forge.game.staticability.StaticAbility;
 import forge.game.staticability.StaticAbilityAssignCombatDamageAsUnblocked;
 import forge.game.staticability.StaticAbilityCantAttackBlock;
+import forge.game.staticability.StaticAbilityMode;
 import forge.game.staticability.StaticAbilityMustAttack;
 import forge.game.trigger.Trigger;
 import forge.game.trigger.TriggerType;
@@ -137,8 +139,11 @@ public class CreatureEvaluator implements Function<Card, Integer> {
         if (c.hasKeyword(Keyword.REACH) && !c.hasKeyword(Keyword.FLYING)) {
             value += addValue(5, "reach");
         }
-        if (c.hasKeyword("CARDNAME can block creatures with shadow as though they didn't have shadow.")) {
-            value += addValue(3, "shadow-block");
+        for (final StaticAbility stAb : c.getStaticAbilities()) {
+            if (stAb.checkConditions(StaticAbilityMode.CanBlockIfShadow)) {
+                value += addValue(3, "shadow-block");
+                break;
+            }
         }
 
         // Protection

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3991,6 +3991,14 @@ public class CardFactoryUtil {
             String effect = "Mode$ DisableTriggers | ValidCard$ Card.Self+ThisTurnEntered | ValidTrigger$ Triggered.ChapterNotLore | Secondary$ True" +
                     " | Description$ Chapter abilities of this Saga can't trigger the turn it entered the battlefield unless it has exactly the number of lore counters on it specified in the chapter symbol of that ability.";
             inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
+        } else if (keyword.equals("Shadow")) {
+            String desc = "Shadow (" + inst.getReminderText() + ")";
+            String effect1 = "Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.withoutShadow | Secondary$ True" +
+                    " | Description$ " + desc;
+            String effect2 = "Mode$ CantBlockBy | ValidAttacker$ Creature.withoutShadow | ValidBlocker$ Creature.Self | Secondary$ True" +
+                    " | Description$ " + desc;
+            inst.addStaticAbility(StaticAbility.create(effect1, state.getCard(), state, intrinsic));
+            inst.addStaticAbility(StaticAbility.create(effect2, state.getCard(), state, intrinsic));
         } else if (keyword.equals("Shroud")) {
             String effect = "Mode$ CantTarget | ValidTarget$ Card.Self | Secondary$ True"
                     + " | Description$ Shroud (" + inst.getReminderText() + ")";

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -25,7 +25,6 @@ import forge.game.ability.AbilityKey;
 import forge.game.card.*;
 import forge.game.cost.Cost;
 import forge.game.cost.CostPart;
-import forge.game.keyword.Keyword;
 import forge.game.keyword.KeywordInterface;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -994,22 +993,7 @@ public class CombatUtil {
             return false;
         }
 
-        // rare case:
-        if (blocker.hasKeyword(Keyword.SHADOW)
-                && blocker.hasKeyword("CARDNAME can block creatures with shadow as though they didn't have shadow.")) {
-            return false;
-        }
-
-        if (attacker.hasKeyword(Keyword.SHADOW) && !blocker.hasKeyword(Keyword.SHADOW)
-                && !blocker.hasKeyword("CARDNAME can block creatures with shadow as though they didn't have shadow.")) {
-            return false;
-        }
-
-        if (!attacker.hasKeyword(Keyword.SHADOW) && blocker.hasKeyword(Keyword.SHADOW)) {
-            return false;
-        }
-
-        // CantBlockBy static abilities
+        // CantBlockBy static abilities (includes Shadow's own two restrictions)
         if (StaticAbilityCantAttackBlock.cantBlockBy(attacker, blocker)) {
             return false;
         }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantAttackBlock.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantAttackBlock.java
@@ -246,6 +246,10 @@ public class StaticAbilityCantAttackBlock {
                     if (v.contains("withoutReach") && canBlockIfReach(attacker, blocker)) {
                         stillblock = true;
                     }
+                    // Heartwood Dryad / Wall of Diffusion / Aetherflame Wall / Aether Web check
+                    if (v.contains("withoutShadow") && canBlockIfShadow(attacker, blocker)) {
+                        stillblock = true;
+                    }
                     if (!stillblock) {
                         break;
                     }
@@ -288,6 +292,30 @@ public class StaticAbilityCantAttackBlock {
     }
 
     public static boolean applyCanBlockIfReachAbility(final StaticAbility stAb, final Card attacker, final Card blocker) {
+        if (!stAb.matchesValidParam("ValidAttacker", attacker)) {
+            return false;
+        }
+        if (!stAb.matchesValidParam("ValidBlocker", blocker)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean canBlockIfShadow(final Card attacker, final Card blocker) {
+        for (final Card ca : attacker.getGame().getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+            for (final StaticAbility stAb : ca.getStaticAbilities()) {
+                if (!stAb.checkConditions(StaticAbilityMode.CanBlockIfShadow)) {
+                    continue;
+                }
+                if (applyCanBlockIfShadowAbility(stAb, attacker, blocker)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean applyCanBlockIfShadowAbility(final StaticAbility stAb, final Card attacker, final Card blocker) {
         if (!stAb.matchesValidParam("ValidAttacker", attacker)) {
             return false;
         }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityMode.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityMode.java
@@ -37,6 +37,7 @@ public enum StaticAbilityMode {
     CantBlockBy,
     CanAttackIfHaste,
     CanBlockIfReach,
+    CanBlockIfShadow,
     MinMaxBlocker,
     BlockTapped,
     AttackVigilance,

--- a/forge-gui/res/cardsfolder/a/aether_web.txt
+++ b/forge-gui/res/cardsfolder/a/aether_web.txt
@@ -4,5 +4,7 @@ Types:Enchantment Aura
 K:Flash
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Reach & CARDNAME can block creatures with shadow as though they didn't have shadow. | Description$ Enchanted creature gets +1/+1, has reach, and can block creatures with shadow as though they didn't have shadow.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Reach | AddStaticAbility$ AWCanBlockShadow & AWCantBlockWithShadow | Description$ Enchanted creature gets +1/+1, has reach, and can block creatures with shadow as though they didn't have shadow.
+SVar:AWCanBlockShadow:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though they didn't have shadow.
+SVar:AWCantBlockWithShadow:Mode$ CantBlock | ValidCard$ Card.Self+withShadow | Secondary$ True
 Oracle:Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +1/+1, has reach, and can block creatures with shadow as though they didn't have shadow. (Creatures with reach can block creatures with flying.)

--- a/forge-gui/res/cardsfolder/a/aether_web.txt
+++ b/forge-gui/res/cardsfolder/a/aether_web.txt
@@ -4,7 +4,7 @@ Types:Enchantment Aura
 K:Flash
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Reach | AddStaticAbility$ AWCanBlockShadow & AWCantBlockWithShadow | Description$ Enchanted creature gets +1/+1, has reach, and can block creatures with shadow as though they didn't have shadow.
-SVar:AWCanBlockShadow:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though they didn't have shadow.
-SVar:AWCantBlockWithShadow:Mode$ CantBlock | ValidCard$ Card.Self+withShadow | Secondary$ True
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Reach | Description$ Enchanted creature gets +1/+1 and has reach.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Creature.EnchantedBy | Description$ Enchanted creature can block creatures with shadow as though they didn't have shadow.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy+withShadow | Secondary$ True
 Oracle:Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +1/+1, has reach, and can block creatures with shadow as though they didn't have shadow. (Creatures with reach can block creatures with flying.)

--- a/forge-gui/res/cardsfolder/a/aetherflame_wall.txt
+++ b/forge-gui/res/cardsfolder/a/aetherflame_wall.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Wall
 PT:0/4
 K:Defender
-A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
-S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though they didn't have shadow.
+A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ This creature gets +1/+0 until end of turn.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ This creature can block creatures with shadow as though they didn't have shadow.
 S:Mode$ CantBlock | ValidCard$ Card.Self+withShadow | Secondary$ True
-Oracle:Defender\nAetherflame Wall can block creatures with shadow as though they didn't have shadow.\n{R}: Aetherflame Wall gets +1/+0 until end of turn.
+Oracle:Defender\nThis creature can block creatures with shadow as though they didn't have shadow.\n{R}: This creature gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aetherflame_wall.txt
+++ b/forge-gui/res/cardsfolder/a/aetherflame_wall.txt
@@ -4,5 +4,6 @@ Types:Creature Wall
 PT:0/4
 K:Defender
 A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
-K:CARDNAME can block creatures with shadow as though they didn't have shadow.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though they didn't have shadow.
+S:Mode$ CantBlock | ValidCard$ Card.Self+withShadow | Secondary$ True
 Oracle:Defender\nAetherflame Wall can block creatures with shadow as though they didn't have shadow.\n{R}: Aetherflame Wall gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/h/heartwood_dryad.txt
+++ b/forge-gui/res/cardsfolder/h/heartwood_dryad.txt
@@ -2,5 +2,5 @@ Name:Heartwood Dryad
 ManaCost:1 G
 Types:Creature Dryad
 PT:2/1
-K:CARDNAME can block creatures with shadow as though they didn't have shadow.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though it had shadow.
 Oracle:Heartwood Dryad can block creatures with shadow as though Heartwood Dryad had shadow.

--- a/forge-gui/res/cardsfolder/h/heartwood_dryad.txt
+++ b/forge-gui/res/cardsfolder/h/heartwood_dryad.txt
@@ -2,5 +2,5 @@ Name:Heartwood Dryad
 ManaCost:1 G
 Types:Creature Dryad
 PT:2/1
-S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though it had shadow.
-Oracle:Heartwood Dryad can block creatures with shadow as though Heartwood Dryad had shadow.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ This creature can block creatures with shadow as though it had shadow.
+Oracle:This creature can block creatures with shadow as though it had shadow.

--- a/forge-gui/res/cardsfolder/w/wall_of_diffusion.txt
+++ b/forge-gui/res/cardsfolder/w/wall_of_diffusion.txt
@@ -3,5 +3,5 @@ ManaCost:1 R
 Types:Creature Wall
 PT:0/5
 K:Defender
-S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though it had shadow.
-Oracle:Defender (This creature can't attack.)\nWall of Diffusion can block creatures with shadow as though Wall of Diffusion had shadow.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ This creature can block creatures with shadow as though it had shadow.
+Oracle:Defender (This creature can't attack.)\nThis creature can block creatures with shadow as though it had shadow.

--- a/forge-gui/res/cardsfolder/w/wall_of_diffusion.txt
+++ b/forge-gui/res/cardsfolder/w/wall_of_diffusion.txt
@@ -3,5 +3,5 @@ ManaCost:1 R
 Types:Creature Wall
 PT:0/5
 K:Defender
-K:CARDNAME can block creatures with shadow as though they didn't have shadow.
+S:Mode$ CanBlockIfShadow | ValidAttacker$ Creature.withShadow | ValidBlocker$ Card.Self | Description$ CARDNAME can block creatures with shadow as though it had shadow.
 Oracle:Defender (This creature can't attack.)\nWall of Diffusion can block creatures with shadow as though Wall of Diffusion had shadow.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 dir="ltr">Summary</h2>

<p dir="ltr">This implements issue #2550, one item off the #3307 "remove hidden keywords" checklist. Shadow's blocking restriction currently lives as three hand-written <code>hasKeyword(...)</code> checks inside <code>CombatUtil.canBlock()</code>, instead of as composable <code>StaticAbility</code> restrictions the way Flying, Landwalk, Fear, etc. are already implemented. This PR moves it onto that same infrastructure and discards the keyword-string hack entirely.</p>

<h2 dir="ltr">What was there before</h2>

<div role="group" aria-label="java code" tabindex="0"><div><div></div></div><div>java</div><div><pre style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code class="language-java" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre;"><span><span><span style="color: rgb(129, 136, 152);">// rare case:</span>
</span><span><span style="color: rgb(204, 123, 244);">if</span> <span style="color: rgb(211, 215, 222);">(</span>blocker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span>Keyword<span style="color: rgb(211, 215, 222);">.</span>SHADOW<span style="color: rgb(211, 215, 222);">)</span>
</span><span>        &amp;&amp; blocker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span><span style="color: rgb(155, 233, 99);">"CARDNAME can block creatures with shadow as though they didn't have shadow."</span><span style="color: rgb(211, 215, 222);">))</span> <span style="color: rgb(211, 215, 222);">{</span>
</span><span>    <span style="color: rgb(204, 123, 244);">return</span> <span style="color: rgb(94, 237, 237);">false</span><span style="color: rgb(211, 215, 222);">;</span>
</span><span><span style="color: rgb(211, 215, 222);">}</span>
</span><span>
</span><span><span style="color: rgb(204, 123, 244);">if</span> <span style="color: rgb(211, 215, 222);">(</span>attacker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span>Keyword<span style="color: rgb(211, 215, 222);">.</span>SHADOW<span style="color: rgb(211, 215, 222);">)</span> &amp;&amp; !blocker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span>Keyword<span style="color: rgb(211, 215, 222);">.</span>SHADOW<span style="color: rgb(211, 215, 222);">)</span>
</span><span>        &amp;&amp; !blocker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span><span style="color: rgb(155, 233, 99);">"CARDNAME can block creatures with shadow as though they didn't have shadow."</span><span style="color: rgb(211, 215, 222);">))</span> <span style="color: rgb(211, 215, 222);">{</span>
</span><span>    <span style="color: rgb(204, 123, 244);">return</span> <span style="color: rgb(94, 237, 237);">false</span><span style="color: rgb(211, 215, 222);">;</span>
</span><span><span style="color: rgb(211, 215, 222);">}</span>
</span><span>
</span><span><span style="color: rgb(204, 123, 244);">if</span> <span style="color: rgb(211, 215, 222);">(</span>!attacker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span>Keyword<span style="color: rgb(211, 215, 222);">.</span>SHADOW<span style="color: rgb(211, 215, 222);">)</span> &amp;&amp; blocker<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">hasKeyword</span><span style="color: rgb(211, 215, 222);">(</span>Keyword<span style="color: rgb(211, 215, 222);">.</span>SHADOW<span style="color: rgb(211, 215, 222);">))</span> <span style="color: rgb(211, 215, 222);">{</span>
</span><span>    <span style="color: rgb(204, 123, 244);">return</span> <span style="color: rgb(94, 237, 237);">false</span><span style="color: rgb(211, 215, 222);">;</span>
</span><span><span style="color: rgb(211, 215, 222);">}</span></span></span></code></pre></div></div>

<p dir="ltr">Two problems with this:</p>

<ul dir="ltr">
<li>It's a hardcoded special case in the combat engine rather than a reusable ability — exactly the pattern #3307 is trying to remove.</li>
<li>The literal sentence <code>"CARDNAME can block creatures with shadow as though they didn't have shadow."</code> was reused, unmodified, as the "keyword" for <strong>four different cards</strong> — including two (Wall of Diffusion, Heartwood Dryad) whose real Oracle text says "as though <strong>it had</strong> shadow," not "as though <strong>they didn't have</strong> shadow." Those two phrasings are not mechanically interchangeable (see below), so those two cards were silently behaving like Aetherflame Wall instead of matching their own printed text.</li>
</ul>

<h2 dir="ltr">What changed</h2>

<p dir="ltr"><strong>1. Shadow itself → two generated <code>CantBlockBy</code> abilities</strong></p>

<p dir="ltr"><code>CardFactoryUtil</code> now generates Shadow's two-directional restriction the same way Flying already generates its own (one <code>CantBlockBy</code> ability for the attacker side, one for the blocker side), instead of <code>CombatUtil</code> special-casing it. The three hardcoded checks above are deleted outright.</p>

<p dir="ltr"><strong>2. New <code>StaticAbilityMode.CanBlockIfShadow</code></strong></p>

<p dir="ltr">Four printed cards let a creature block a shadow creature despite the blocker not having shadow itself. That's exactly what <code>CanBlockIfReach</code> already does for Dragon Hunter ("can block Dragons as though it had reach"), so this adds a direct sibling mode, <code>CanBlockIfShadow</code>, plus two small helper methods in <code>StaticAbilityCantAttackBlock</code>, hooked into the existing <code>ValidBlocker</code> override check right next to the Reach one.</p>

<p dir="ltr"><strong>3. The four cards rewritten as plain static abilities — no keyword involved</strong></p>

<ul dir="ltr">
<li><code>Heartwood Dryad</code>, <code>Wall of Diffusion</code> — one <code>CanBlockIfShadow</code> ability each, now using their correct Oracle wording.</li>
<li><code>Aetherflame Wall</code>, <code>Aether Web</code> — the same <code>CanBlockIfShadow</code>, plus one extra ability: <code>CantBlock | ValidCard$ Card.Self+withShadow</code>. This reproduces the documented ruling that if Aetherflame Wall ever gains shadow, it can't block <em>anything</em> — not even other shadow creatures — without needing any special-cased combat logic to get there.</li>
</ul>

<p dir="ltr"><strong>4. <code>CreatureEvaluator</code> AI heuristic</strong></p>

<p dir="ltr">Was checking for the now-deleted keyword string; updated to check for the <code>CanBlockIfShadow</code> static ability instead.</p>

<h2 dir="ltr">Why the extra <code>CantBlock</code> ability</h2>

<p dir="ltr">"Can block creatures with shadow as though they didn't have shadow" (Aetherflame Wall's wording) and "as though it had shadow" (Heartwood Dryad's wording) read as interchangeable but aren't: only the first creates an actual rules contradiction if the creature ever gains real shadow. Rather than model that interaction generically, it's declared directly as a second, always-on ability — if the card currently has shadow, it can't block, period. That one extra line reproduces the known ruling exactly.</p>

<h2 dir="ltr">Files changed</h2>

<ul dir="ltr">
<li><code>forge-game/.../card/CardFactoryUtil.java</code></li>
<li><code>forge-game/.../staticability/StaticAbilityMode.java</code></li>
<li><code>forge-game/.../staticability/StaticAbilityCantAttackBlock.java</code></li>
<li><code>forge-game/.../combat/CombatUtil.java</code></li>
<li><code>forge-ai/.../CreatureEvaluator.java</code></li>
<li><code>res/cardsfolder/a/aetherflame_wall.txt</code></li>
<li><code>res/cardsfolder/a/aether_web.txt</code></li>
<li><code>res/cardsfolder/h/heartwood_dryad.txt</code></li>
<li><code>res/cardsfolder/w/wall_of_diffusion.txt</code></li>
</ul>

<p dir="ltr">Closes #2550.</p><!--EndFragment-->
</body>
</html>

***Code changes made with heavy assistance from Claude***