### PR TITLE
Remove Alchemy current metagame zip

### DIFF
--- a/forge-gui/res/lists/net-decks.txt
+++ b/forge-gui/res/lists/net-decks.txt
@@ -9,7 +9,6 @@ Budget Modern Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/hea
 Building on a Budget | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/buildingonabudget.zip
 Card Preview | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/cardpreview.zip
 Community Cup | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/communitycup.zip
-Current Alchemy Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentalchemymetagame.zip
 Current Historic Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currenthistoricmetagame.zip
 Current Legacy Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentlegacymetagame.zip
 Current Modern Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentmodernmetagame.zip


### PR DESCRIPTION
Alchemy is being retired so no need for this zip. Source: https://magic.wizards.com/en/news/mtg-arena/state-of-the-formats-2026