### PR TITLE
Adventure: let New Game+ offer the main quest again

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -1473,8 +1473,20 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         return (int) questFlags.getOrDefault(key, (byte) 0);
     }
 
+    /**
+     * Character flags that exist only to stop a quest from being offered twice. Data checks them
+     * with checkCharacterFlag, so they survive a quest wipe unless cleared here: "noQuest" is the
+     * New Game+ "skip the main quest" choice and hides the intro mage's main quest option, and
+     * "dungeonMasterQuestGiven" gates the lair-clearing quest offered in dungeons.
+     */
+    private static final String[] QUEST_GATE_CHARACTER_FLAGS = {"noQuest", "dungeonMasterQuestGiven"};
+
+    /** Forget all global quest progress so every quest can be offered again (New Game+, resetQuests) */
     public void resetQuestFlags() {
         questFlags.clear();
+        for (String flag : QUEST_GATE_CHARACTER_FLAGS) {
+            setCharacterFlag(flag, 0);
+        }
     }
 
     public void addQuest(String questID, boolean isNewGame) {


### PR DESCRIPTION
New Game+ clears the quest list and the quest flags, but the flags that gate whether a quest may be *offered* are **character** flags, and those were kept.

- `noQuest` is set by the New Game+ "Been here, done that. Show me to the enemies" choice in quest 28 (`quests.json`). The intro mage's "Why am I here?" option in `spawn.tmx` requires it to be unset — so a player who skipped the main quest once could never get it back on a later New Game+: the mage only said hello and the exit portal stayed shut. That's the soft-lock in #9286 (reproduced by four reporters across builds; #9295 was an unrelated POI revert and never touched it).
- `dungeonMasterQuestGiven` gates the lair-clearing quest that dungeon masters offer, with the same problem: the quest is wiped, the gate isn't.

`AdventurePlayer.resetQuestFlags()` now clears those two gate flags along with the quest flags. It backs both New Game+ (`SaveLoadScene`) and the `resetQuests` console command, so saves that are already stuck can be freed with `resetQuests` in the F9 console and then talking to the mage — no need to do another New Game+.

No test: the mobile module has no test scaffolding and the singletons need the full asset pipeline. The change is four lines against data that's all in the repo.

Fixes #9286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
