### PR TITLE
Desktop: explain a headless Java runtime instead of failing to open a window

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/Main.java
+++ b/forge-gui-desktop/src/main/java/forge/view/Main.java
@@ -25,6 +25,9 @@ import forge.gui.card.CardReaderExperiments;
 import forge.util.BuildInfo;
 import io.sentry.Sentry;
 
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+
 /**
  * Main class for Forge's swing application view.
  */
@@ -41,6 +44,15 @@ public final class Main {
             // -Djava.awt.headless=false on the command line, since it runs before GraphicsEnvironment
             // caches its answer.
             System.setProperty("java.awt.headless", "true");
+        }
+
+        // The GUI needs a display and a Java runtime that can drive one. Linux distributions ship a
+        // "headless" runtime package that lacks the AWT/Swing libraries, and it is often the default
+        // java, so check up front and say what is wrong: the alternative is a HeadlessException from
+        // the first Swing call (and, in releases before #11761, no output at all).
+        if (args.length == 0 && GraphicsEnvironment.isHeadless()) {
+            explainMissingDisplay();
+            System.exit(1);
         }
 
         // Sentry chains to whatever default handler is already installed, but if none is, an uncaught
@@ -118,6 +130,42 @@ public final class Main {
         }
 
         System.exit(0);
+    }
+
+    /**
+     * Tell the user why the GUI cannot start on this runtime. Written to stderr since there is no
+     * display to put a dialog on.
+     */
+    private static void explainMissingDisplay() {
+        System.err.print(describeMissingDisplay(System.getProperty("os.name", ""), System.getProperty("java.home"),
+                System.getProperty("java.vendor") + " " + System.getProperty("java.version"),
+                System.getProperty("java.awt.headless"), System.getenv("DISPLAY")));
+        System.err.flush();
+    }
+
+    /**
+     * Build the explanation for a runtime that reports itself headless, naming the likely cause.
+     * On Linux the runtime is headless when DISPLAY is unset or when the install is a "headless"
+     * package, which the JDK detects by the absence of lib/libawt_xawt.so.
+     */
+    public static String describeMissingDisplay(final String osName, final String javaHome, final String javaVersion,
+            final String headlessProperty, final String display) {
+        final boolean windowsOrMac = osName.matches("(?i).*(windows|mac).*");
+        final StringBuilder sb = new StringBuilder();
+        sb.append("Forge cannot start: this Java runtime has no display to open a window on.\n");
+        sb.append("  Java: ").append(javaHome).append(" (").append(javaVersion).append(")\n");
+        if ("true".equalsIgnoreCase(headlessProperty)) {
+            sb.append("  -Djava.awt.headless=true was passed on the command line; drop it to run the GUI.\n");
+        } else if (!windowsOrMac && (display == null || display.trim().isEmpty())) {
+            sb.append("  The DISPLAY environment variable is not set, so there is no X11/Wayland session to use.\n");
+        } else if (!windowsOrMac && !new File(javaHome, "lib/libawt_xawt.so").exists()) {
+            sb.append("  This is a \"headless\" Java package (no lib/libawt_xawt.so), which cannot show windows.\n");
+            sb.append("  Install the full runtime instead, e.g. \"sudo apt install openjdk-21-jre\" or\n");
+            sb.append("  \"sudo dnf install java-21-openjdk\", or point JAVA_HOME at a full JDK.\n");
+        } else {
+            sb.append("  Check that a graphical session is available and that the Java install is not a headless package.\n");
+        }
+        return sb.toString();
     }
 
     /**

--- a/forge-gui-desktop/src/test/java/forge/HeadlessStartupTest.java
+++ b/forge-gui-desktop/src/test/java/forge/HeadlessStartupTest.java
@@ -149,6 +149,58 @@ public class HeadlessStartupTest {
                 + explicit.output, explicit.output.contains("java.awt.headless=false"));
     }
 
+    /**
+     * A GUI launch (no arguments) on a headless runtime must fail fast with an explanation and a
+     * non-zero exit, rather than a HeadlessException from the first Swing call — which, before
+     * #11761, was swallowed and left the user with a silent exit (#11573). {@code java.awt.headless}
+     * is forced here since the machine running the suite may well have a display.
+     */
+    public void mainExplainsGuiLaunchOnHeadlessRuntime() throws Exception {
+        ProbeResult result = runInThrowawayHome(Main.class.getName(), List.of("-Djava.awt.headless=true"));
+        assertEquals("a headless GUI launch must exit non-zero, output was:\n" + result.output, 1, result.exitCode);
+        assertTrue("expected the explanation, got:\n" + result.output,
+                result.output.contains("Forge cannot start"));
+        assertTrue("expected the cause to name the property, got:\n" + result.output,
+                result.output.contains("-Djava.awt.headless=true was passed"));
+        assertFalse("must not fall through to a HeadlessException:\n" + result.output,
+                result.output.contains("HeadlessException"));
+    }
+
+    /**
+     * The explanation names the likely cause: the property when it was forced, a missing DISPLAY,
+     * or — the case both reporters of #11573 hit — a distro "headless" package, which the JDK
+     * recognises by the absence of lib/libawt_xawt.so.
+     */
+    public void missingDisplayMessageNamesTheCause() throws Exception {
+        String forced = Main.describeMissingDisplay("Linux", "/usr/lib/jvm/java-21", "OpenJDK 21", "true", ":0");
+        assertTrue(forced, forced.contains("-Djava.awt.headless=true was passed"));
+
+        String noDisplay = Main.describeMissingDisplay("Linux", "/usr/lib/jvm/java-21", "OpenJDK 21", null, null);
+        assertTrue(noDisplay, noDisplay.contains("DISPLAY environment variable is not set"));
+
+        // A fake java.home without lib/libawt_xawt.so, as a headless-only install looks.
+        File headlessHome = Files.createTempDirectory("headless-jre").toFile();
+        try {
+            assertTrue(new File(headlessHome, "lib").mkdir());
+            String headlessPackage = Main.describeMissingDisplay("Linux", headlessHome.getPath(), "OpenJDK 21", null, ":0");
+            assertTrue(headlessPackage, headlessPackage.contains("\"headless\" Java package"));
+            assertTrue(headlessPackage, headlessPackage.contains("openjdk-21-jre"));
+
+            // With the library present, the headless-package diagnosis must not be given.
+            assertTrue(new File(headlessHome, "lib/libawt_xawt.so").createNewFile());
+            String unknown = Main.describeMissingDisplay("Linux", headlessHome.getPath(), "OpenJDK 21", null, ":0");
+            assertFalse(unknown, unknown.contains("\"headless\" Java package"));
+            assertTrue(unknown, unknown.contains("graphical session"));
+        } finally {
+            deleteRecursively(headlessHome);
+        }
+
+        // The Linux-only diagnoses must not be offered on Windows or macOS.
+        String windows = Main.describeMissingDisplay("Windows 11", "C:\\jdk", "Temurin 21", null, null);
+        assertFalse(windows, windows.contains("DISPLAY"));
+        assertFalse(windows, windows.contains("libawt_xawt"));
+    }
+
     /** The console-mode list must stay in sync with the switch in {@code Main.main}. */
     public void commandLineModesAreRecognized() {
         assertTrue("sim must be a console mode", Main.isCommandLineMode("sim"));


### PR DESCRIPTION
Both reporters of #11573 were running a distro "headless" Java package (the second confirmed it: `dnf install java-25-openjdk` fixed it; the first has Ubuntu's `/usr/bin/java`, which resolves to `openjdk-21-jre-headless` when only that is installed). Those packages lack `lib/libawt_xawt.so`, and since JDK 9 `GraphicsEnvironment.isHeadless()` reports true when it's missing, even with `DISPLAY` set.

With the 2.0.14 release jar that meant a `HeadlessException` from `GuiDesktop`'s static initializer, swallowed by the Sentry handler: the jar exited with nothing printed, which is what both reports say. #11761 fixed the swallowing, so master now prints the trace — but it still doesn't tell the user what's wrong or what to do.

`Main` now checks `GraphicsEnvironment.isHeadless()` before a GUI launch (no arguments) and exits 1 with a message naming the likely cause:

```
Forge cannot start: this Java runtime has no display to open a window on.
  Java: /usr/lib/jvm/java-21-openjdk-amd64 (Ubuntu 21.0.11)
  This is a "headless" Java package (no lib/libawt_xawt.so), which cannot show windows.
  Install the full runtime instead, e.g. "sudo apt install openjdk-21-jre" or
  "sudo dnf install java-21-openjdk", or point JAVA_HOME at a full JDK.
```

The other diagnoses are an unset `DISPLAY`, and `-Djava.awt.headless=true` having been passed. Console modes (`sim`, `parse`, `server`) are unaffected — they force headless themselves.

Tests, added to `HeadlessStartupTest`: a forked GUI launch with `-Djava.awt.headless=true` must exit 1 with the explanation and no `HeadlessException`; and each diagnosis is checked against a fake `java.home` with and without `lib/libawt_xawt.so`, plus the Linux-only ones must not be offered on Windows/macOS. All 7 methods in the class pass locally on Windows 11 / Liberica 17. A normal GUI launch still starts.

Fixes #11573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
