### PR TITLE
Custom ThreadPoolExecutor

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -941,6 +941,8 @@ public class AiAttackController {
                 ThreadUtil.AIExecutor.invokeAll(tasks, ai.getGame().getAITimeout(), TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            } finally {
+                ThreadUtil.cleanAIThread();
             }
 
             if (attackersLeft.isEmpty()) {

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -942,7 +942,7 @@ public class AiAttackController {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } finally {
-                ThreadUtil.cleanAIThread();
+                ThreadUtil.killAIThreads();
             }
 
             if (attackersLeft.isEmpty()) {

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -77,6 +77,21 @@ public class AiAttackController {
 
     private int aiAggression = 0; // how aggressive the ai is attack will be depending on circumstances
     private final boolean nextTurn; // include creature that can only attack/block next turn
+    private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+        0, Runtime.getRuntime().availableProcessors(),
+        1L, TimeUnit.MILLISECONDS,
+        new SynchronousQueue<>(),
+        r -> {
+            Thread t = new Thread(r, "AI DeclareAttack");
+            t.setDaemon(true);
+            return t;
+        },
+        new ThreadPoolExecutor.CallerRunsPolicy()
+    );
+    static {
+        // Allow core threads to die when they have no work
+        executor.allowCoreThreadTimeOut(true);
+    }
 
     /**
      * <p>
@@ -873,15 +888,7 @@ public class AiAttackController {
         // nextTurn is now only used by effect from Oracle en-Vec, which can skip check must attack,
         // because creatures not chosen can't attack.
         if (!nextTurn) {
-            ExecutorService executor = Executors.newFixedThreadPool(
-                Runtime.getRuntime().availableProcessors(), r -> {
-                    Thread t = Executors.defaultThreadFactory().newThread(r);
-                    t.setDaemon(true);
-                    return t;
-                }
-            );
             List<Callable<Integer>> tasks = new ArrayList<>();
-
             for (final Card attacker : this.attackers) {
                 final GameEntity finalDefender = defender;
                 tasks.add(() -> {
@@ -949,8 +956,6 @@ public class AiAttackController {
                 executor.invokeAll(tasks, ai.getGame().getAITimeout(), TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-            } finally {
-                executor.shutdownNow();
             }
 
             if (attackersLeft.isEmpty()) {

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -77,21 +77,6 @@ public class AiAttackController {
 
     private int aiAggression = 0; // how aggressive the ai is attack will be depending on circumstances
     private final boolean nextTurn; // include creature that can only attack/block next turn
-    private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-        0, Runtime.getRuntime().availableProcessors(),
-        1L, TimeUnit.MILLISECONDS,
-        new SynchronousQueue<>(),
-        r -> {
-            Thread t = new Thread(r, "AI DeclareAttack");
-            t.setDaemon(true);
-            return t;
-        },
-        new ThreadPoolExecutor.CallerRunsPolicy()
-    );
-    static {
-        // Allow core threads to die when they have no work
-        executor.allowCoreThreadTimeOut(true);
-    }
 
     /**
      * <p>
@@ -953,7 +938,7 @@ public class AiAttackController {
             }
 
             try {
-                executor.invokeAll(tasks, ai.getGame().getAITimeout(), TimeUnit.SECONDS);
+                ThreadUtil.AIExecutor.invokeAll(tasks, ai.getGame().getAITimeout(), TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1601,7 +1601,7 @@ public class AiController {
             boolean isLifeInDanger = useLivingEnd && ComputerUtil.aiLifeInDanger(player, true, 0);
             for (final SpellAbility sa : ComputerUtilAbility.getOriginalAndAltCostAbilities(all, player)) {
                 if (Thread.currentThread().isInterrupted()) {
-                    break;
+                    throw new InterruptedException("AI evaluation interrupted");
                 }
 
                 // Don't add Counterspells to the "normal" playcard lookups
@@ -1682,46 +1682,34 @@ public class AiController {
 
         try {
             return future.get(game.getAITimeout(), TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (TimeoutException e) {
             e.printStackTrace();
-            // ask the eval thread to exit at the next SpellAbility check first: a brutal
-            // Thread.stop() mid-evaluation can leave partially mutated shared state behind
             future.cancel(true);
-            ThreadUtil.activeAIThreads.keySet().forEach(t -> {
-                if (e instanceof TimeoutException) {
-                    // log where the eval thread currently is - each timeout doubles as a
-                    // profiler sample for diagnosing remaining AI slowdowns from user logs
-                    StringBuilder sb = new StringBuilder("AI eval thread at timeout:");
-                    int sbInitLength = sb.length();
-                    StackTraceElement[] evalStack = t.getStackTrace();
-                    for (int i = 0; i < Math.min(30, evalStack.length); i++) {
-                        sb.append("\n\tat ").append(evalStack[i]);
-                    }
-                    // prints non empty stack trace since the thread may be already discarded by the executor policy
-                    if (sb.length() > sbInitLength)
-                        System.out.println(sb);
-                }
 
-                try {
-                    t.join(500);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
+            // Log stack traces for profiling
+            ThreadUtil.activeAIThreads.keySet().forEach(t -> {
+                StringBuilder sb = new StringBuilder("AI eval thread at timeout:");
+                int sbInitLength = sb.length();
+                StackTraceElement[] evalStack = t.getStackTrace();
+                for (int i = 0; i < Math.min(30, evalStack.length); i++) {
+                    sb.append("\n\tat ").append(evalStack[i]);
                 }
-                if (t.isAlive()) {
-                    // last resort, see #8302: the eval thread may be stuck inside a single
-                    // evaluation or an infinite loop and never reach the cooperative exit
-                    try {
-                        t.stop();
-                    } catch (UnsupportedOperationException | NoSuchMethodError ex) {
-                        // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
-                    } catch (ThreadDeath td) {
-                        throw td; // ThreadDeath is thrown on thread.stop une
-                    }
+                if (sb.length() > sbInitLength) {
+                    System.out.println(sb);
                 }
             });
-            ThreadUtil.cleanAIThread();
-            // TODO mark some as skipped to increase chance to find something playable next priority
+
+            ThreadUtil.killAIThreads();
             return null;
+
+        } catch (ExecutionException | InterruptedException ie) {
+            // Preserve interrupt status
+            if (ie instanceof InterruptedException)
+                Thread.currentThread().interrupt();
+            future.cancel(true);
+            ThreadUtil.killAIThreads();
+            return null;
+
         }
     }
 

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1684,40 +1684,43 @@ public class AiController {
             return future.get(game.getAITimeout(), TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            if (e instanceof TimeoutException) {
-                // log where the eval thread currently is - each timeout doubles as a
-                // profiler sample for diagnosing remaining AI slowdowns from user logs
-                StringBuilder sb = new StringBuilder("AI eval thread at timeout:");
-                ThreadUtil.activeAIThreads.keySet().forEach(t -> {
+            // ask the eval thread to exit at the next SpellAbility check first: a brutal
+            // Thread.stop() mid-evaluation can leave partially mutated shared state behind
+            future.cancel(true);
+            ThreadUtil.activeAIThreads.keySet().forEach(t -> {
+                if (e instanceof TimeoutException) {
+                    // log where the eval thread currently is - each timeout doubles as a
+                    // profiler sample for diagnosing remaining AI slowdowns from user logs
+                    StringBuilder sb = new StringBuilder("AI eval thread at timeout:");
+                    int sbInitLength = sb.length();
                     StackTraceElement[] evalStack = t.getStackTrace();
                     for (int i = 0; i < Math.min(30, evalStack.length); i++) {
                         sb.append("\n\tat ").append(evalStack[i]);
                     }
-                    System.out.println(sb);
-                });
-            }
-            // ask the eval thread to exit at the next SpellAbility check first: a brutal
-            // Thread.stop() mid-evaluation can leave partially mutated shared state behind
-            future.cancel(true);
+                    // prints non empty stack trace since the thread may be already discarded by the executor policy
+                    if (sb.length() > sbInitLength)
+                        System.out.println(sb);
+                }
 
-            ThreadUtil.activeAIThreads.keySet().forEach(t -> {
                 if (t.isAlive()) {
-                    try {
-                        t.join(500);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                    }
                     if (t.isAlive()) {
-                        // last resort, see #8302: the eval thread may be stuck inside a single
-                        // evaluation or an infinite loop and never reach the cooperative exit
                         try {
-                            t.stop();
-                        } catch (UnsupportedOperationException | NoSuchMethodError ex) {
-                            // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                            t.join(500);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
                         }
+                        if (t.isAlive()) {
+                            // last resort, see #8302: the eval thread may be stuck inside a single
+                            // evaluation or an infinite loop and never reach the cooperative exit
+                            try {
+                                t.stop();
+                            } catch (UnsupportedOperationException | NoSuchMethodError ex) {
+                                // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                            }
+                        }
+                    } else {
+                        ThreadUtil.activeAIThreads.remove(t);
                     }
-                } else {
-                    ThreadUtil.activeAIThreads.remove(t);
                 }
             });
             // TODO mark some as skipped to increase chance to find something playable next priority

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1702,25 +1702,21 @@ public class AiController {
                         System.out.println(sb);
                 }
 
+                try {
+                    t.join(500);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
                 if (t.isAlive()) {
+                    // last resort, see #8302: the eval thread may be stuck inside a single
+                    // evaluation or an infinite loop and never reach the cooperative exit
                     try {
-                        t.join(500);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
+                        t.stop();
+                    } catch (UnsupportedOperationException | NoSuchMethodError ex) {
+                        // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                    } catch (ThreadDeath td) {
+                        throw td; // ThreadDeath is thrown on thread.stop une
                     }
-                    if (t.isAlive()) {
-                        // last resort, see #8302: the eval thread may be stuck inside a single
-                        // evaluation or an infinite loop and never reach the cooperative exit
-                        try {
-                            t.stop();
-                        } catch (UnsupportedOperationException | NoSuchMethodError ex) {
-                            // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
-                        } catch (ThreadDeath td) {
-                            throw td;
-                        }
-                    }
-                } else {
-                    ThreadUtil.activeAIThreads.remove(t);
                 }
             });
             ThreadUtil.cleanAIThread();

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1703,26 +1703,25 @@ public class AiController {
                 }
 
                 if (t.isAlive()) {
-                    if (t.isAlive()) {
-                        try {
-                            t.join(500);
-                        } catch (InterruptedException ie) {
-                            Thread.currentThread().interrupt();
-                        }
-                        if (t.isAlive()) {
-                            // last resort, see #8302: the eval thread may be stuck inside a single
-                            // evaluation or an infinite loop and never reach the cooperative exit
-                            try {
-                                t.stop();
-                            } catch (UnsupportedOperationException | NoSuchMethodError ex) {
-                                // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
-                            }
-                        }
-                    } else {
-                        ThreadUtil.activeAIThreads.remove(t);
+                    try {
+                        t.join(500);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
                     }
+                    if (t.isAlive()) {
+                        // last resort, see #8302: the eval thread may be stuck inside a single
+                        // evaluation or an infinite loop and never reach the cooperative exit
+                        try {
+                            t.stop();
+                        } catch (UnsupportedOperationException | NoSuchMethodError ex) {
+                            // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                        }
+                    }
+                } else {
+                    ThreadUtil.activeAIThreads.remove(t);
                 }
             });
+            ThreadUtil.cleanAIThread();
             // TODO mark some as skipped to increase chance to find something playable next priority
             return null;
         }

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1684,34 +1684,42 @@ public class AiController {
             return future.get(game.getAITimeout(), TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            Thread t = ThreadUtil.AIExecThread.get();
             if (e instanceof TimeoutException) {
                 // log where the eval thread currently is - each timeout doubles as a
                 // profiler sample for diagnosing remaining AI slowdowns from user logs
                 StringBuilder sb = new StringBuilder("AI eval thread at timeout:");
-                StackTraceElement[] evalStack = t.getStackTrace();
-                for (int i = 0; i < Math.min(30, evalStack.length); i++) {
-                    sb.append("\n\tat ").append(evalStack[i]);
-                }
-                System.out.println(sb);
+                ThreadUtil.activeAIThreads.keySet().forEach(t -> {
+                    StackTraceElement[] evalStack = t.getStackTrace();
+                    for (int i = 0; i < Math.min(30, evalStack.length); i++) {
+                        sb.append("\n\tat ").append(evalStack[i]);
+                    }
+                    System.out.println(sb);
+                });
             }
             // ask the eval thread to exit at the next SpellAbility check first: a brutal
             // Thread.stop() mid-evaluation can leave partially mutated shared state behind
             future.cancel(true);
-            try {
-                t.join(500);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            }
-            if (t.isAlive()) {
-                // last resort, see #8302: the eval thread may be stuck inside a single
-                // evaluation or an infinite loop and never reach the cooperative exit
-                try {
-                    t.stop();
-                } catch (UnsupportedOperationException | NoSuchMethodError ex) {
-                    // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+
+            ThreadUtil.activeAIThreads.keySet().forEach(t -> {
+                if (t.isAlive()) {
+                    try {
+                        t.join(500);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                    if (t.isAlive()) {
+                        // last resort, see #8302: the eval thread may be stuck inside a single
+                        // evaluation or an infinite loop and never reach the cooperative exit
+                        try {
+                            t.stop();
+                        } catch (UnsupportedOperationException | NoSuchMethodError ex) {
+                            // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                        }
+                    }
+                } else {
+                    ThreadUtil.activeAIThreads.remove(t);
                 }
-            }
+            });
             // TODO mark some as skipped to increase chance to find something playable next priority
             return null;
         }

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1715,6 +1715,8 @@ public class AiController {
                             t.stop();
                         } catch (UnsupportedOperationException | NoSuchMethodError ex) {
                             // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                        } catch (ThreadDeath td) {
+                            throw td;
                         }
                     }
                 } else {

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -70,7 +70,6 @@ import io.sentry.Sentry;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -97,24 +96,7 @@ public class AiController {
     private int lastAttackAggression;
     private boolean useLivingEnd;
     private List<SpellAbility> skipped;
-    private static final AtomicReference<Thread> execRef = new AtomicReference<>();
-    private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-            0,                           // Core pool: 0 threads when idle (saves Android memory)
-            1,                           // Max pool: Only 1 thread max running at a time
-            1L, TimeUnit.MILLISECONDS, // Kill the underlying thread 1ms after it becomes idle
-            new SynchronousQueue<>(),    // Hand off tasks directly to the thread with zero queue latency
-            r -> {
-                Thread t = new Thread(r, "AI ChooseSpell");
-                t.setDaemon(true);
-                execRef.set(t);
-                return t;
-            },
-            new ThreadPoolExecutor.CallerRunsPolicy() // Runs on main thread if the pool is somehow saturated
-    );
-    static {
-        // Allow core threads to die when they have no work
-        executor.allowCoreThreadTimeOut(true);
-    }
+
     public AiController(final Player computerPlayer, final Game game0) {
         player = computerPlayer;
         game = game0;
@@ -1614,7 +1596,7 @@ public class AiController {
             Sentry.captureMessage(ex.getMessage() + "\nAssertionError [verifyTransitivity]: " + assertex);
         }
 
-        Future<SpellAbility> future = executor.submit(() -> {
+        Future<SpellAbility> future = ThreadUtil.AIExecutor.submit(() -> {
             //avoid ComputerUtil.aiLifeInDanger in loops as it slows down a lot.. call this outside loops will generally be fast...
             boolean isLifeInDanger = useLivingEnd && ComputerUtil.aiLifeInDanger(player, true, 0);
             for (final SpellAbility sa : ComputerUtilAbility.getOriginalAndAltCostAbilities(all, player)) {
@@ -1702,7 +1684,7 @@ public class AiController {
             return future.get(game.getAITimeout(), TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
-            Thread t = execRef.get();
+            Thread t = ThreadUtil.AIExecThread.get();
             if (e instanceof TimeoutException) {
                 // log where the eval thread currently is - each timeout doubles as a
                 // profiler sample for diagnosing remaining AI slowdowns from user logs

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -70,6 +70,7 @@ import io.sentry.Sentry;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -96,7 +97,24 @@ public class AiController {
     private int lastAttackAggression;
     private boolean useLivingEnd;
     private List<SpellAbility> skipped;
-
+    private static final AtomicReference<Thread> execRef = new AtomicReference<>();
+    private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            0,                           // Core pool: 0 threads when idle (saves Android memory)
+            1,                           // Max pool: Only 1 thread max running at a time
+            1L, TimeUnit.MILLISECONDS, // Kill the underlying thread 1ms after it becomes idle
+            new SynchronousQueue<>(),    // Hand off tasks directly to the thread with zero queue latency
+            r -> {
+                Thread t = new Thread(r, "AI ChooseSpell");
+                t.setDaemon(true);
+                execRef.set(t);
+                return t;
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy() // Runs on main thread if the pool is somehow saturated
+    );
+    static {
+        // Allow core threads to die when they have no work
+        executor.allowCoreThreadTimeOut(true);
+    }
     public AiController(final Player computerPlayer, final Game game0) {
         player = computerPlayer;
         game = game0;
@@ -1596,7 +1614,7 @@ public class AiController {
             Sentry.captureMessage(ex.getMessage() + "\nAssertionError [verifyTransitivity]: " + assertex);
         }
 
-        FutureTask<SpellAbility> future = new FutureTask<>(() -> {
+        Future<SpellAbility> future = executor.submit(() -> {
             //avoid ComputerUtil.aiLifeInDanger in loops as it slows down a lot.. call this outside loops will generally be fast...
             boolean isLifeInDanger = useLivingEnd && ComputerUtil.aiLifeInDanger(player, true, 0);
             for (final SpellAbility sa : ComputerUtilAbility.getOriginalAndAltCostAbilities(all, player)) {
@@ -1679,13 +1697,12 @@ public class AiController {
 
             return null;
         });
-        Thread t = new Thread(future, "Game AI Eval");
-        t.setDaemon(true);
-        t.start();
+
         try {
             return future.get(game.getAITimeout(), TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
+            Thread t = execRef.get();
             if (e instanceof TimeoutException) {
                 // log where the eval thread currently is - each timeout doubles as a
                 // profiler sample for diagnosing remaining AI slowdowns from user logs
@@ -1700,7 +1717,7 @@ public class AiController {
             // Thread.stop() mid-evaluation can leave partially mutated shared state behind
             future.cancel(true);
             try {
-                t.join(2000); //2 seconds wait
+                t.join(500);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
             }

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -6,7 +6,7 @@ public class ThreadUtil {
     public static final ConcurrentHashMap<Thread, Boolean> activeAIThreads = new ConcurrentHashMap<>();
     public static final ThreadPoolExecutor AIExecutor = new ThreadPoolExecutor(
             0, Runtime.getRuntime().availableProcessors(),
-            1L, TimeUnit.MILLISECONDS, // Kill the underlying thread 1ms after it becomes idle
+            1L, TimeUnit.SECONDS, // Kill the underlying thread 1s after it becomes idle
             new SynchronousQueue<>(),  // Hand off tasks directly to the thread with zero queue latency
             r -> {
                 Thread t = new Thread(r, "AI ThreadPool");
@@ -17,6 +17,11 @@ public class ThreadUtil {
             // Dropped tasks disappear safely
             new ThreadPoolExecutor.DiscardPolicy()
     );
+
+    public static void cleanAIThread() {
+        activeAIThreads.keySet().removeIf(thread -> !thread.isAlive());
+    }
+
     static {
         System.out.printf("(ThreadUtil first call): Running with priority %d%n", Thread.currentThread().getPriority());
         // Allow core threads to die when they have no work

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -1,10 +1,25 @@
 package forge.util;
 
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class ThreadUtil {
+public class ThreadUtil {public static final AtomicReference<Thread> AIExecThread = new AtomicReference<>();
+    public static final ThreadPoolExecutor AIExecutor = new ThreadPoolExecutor(
+            0, Runtime.getRuntime().availableProcessors(),
+            1L, TimeUnit.MILLISECONDS, // Kill the underlying thread 1ms after it becomes idle
+            new SynchronousQueue<>(),  // Hand off tasks directly to the thread with zero queue latency
+            r -> {
+                Thread t = new Thread(r, "AI ThreadPool");
+                t.setDaemon(true);
+                AIExecThread.set(t);
+                return t;
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy() // Runs on main thread if the pool is somehow saturated
+    );
     static {
         System.out.printf("(ThreadUtil first call): Running with priority %d%n", Thread.currentThread().getPriority());
+        // Allow core threads to die when they have no work
+        AIExecutor.allowCoreThreadTimeOut(true);
     }
 
     private static class WorkerThreadFactory implements ThreadFactory {

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -18,6 +18,21 @@ public class ThreadUtil {
             new ThreadPoolExecutor.DiscardPolicy()
     );
 
+    public static void killAIThreads() {
+        activeAIThreads.keySet().forEach(t -> {
+            if (t.isAlive()) {
+                // Ask it to stop cooperatively
+                t.interrupt();
+                try {
+                    t.join(1000); // give it up to 1s to exit
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+        cleanAIThread(); // remove dead ones from the map
+    }
+
     public static void cleanAIThread() {
         activeAIThreads.keySet().removeIf(thread -> !thread.isAlive());
     }

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -3,7 +3,8 @@ package forge.util;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class ThreadUtil {public static final AtomicReference<Thread> AIExecThread = new AtomicReference<>();
+public class ThreadUtil {
+    public static final AtomicReference<Thread> AIExecThread = new AtomicReference<>();
     public static final ThreadPoolExecutor AIExecutor = new ThreadPoolExecutor(
             0, Runtime.getRuntime().availableProcessors(),
             1L, TimeUnit.MILLISECONDS, // Kill the underlying thread 1ms after it becomes idle

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -1,10 +1,9 @@
 package forge.util;
 
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class ThreadUtil {
-    public static final AtomicReference<Thread> AIExecThread = new AtomicReference<>();
+    public static final ConcurrentHashMap<Thread, Boolean> activeAIThreads = new ConcurrentHashMap<>();
     public static final ThreadPoolExecutor AIExecutor = new ThreadPoolExecutor(
             0, Runtime.getRuntime().availableProcessors(),
             1L, TimeUnit.MILLISECONDS, // Kill the underlying thread 1ms after it becomes idle
@@ -12,7 +11,7 @@ public class ThreadUtil {
             r -> {
                 Thread t = new Thread(r, "AI ThreadPool");
                 t.setDaemon(true);
-                AIExecThread.set(t);
+                activeAIThreads.put(t, Boolean.TRUE);
                 return t;
             },
             // Dropped tasks disappear safely

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -13,8 +13,7 @@ public class ThreadUtil {public static final AtomicReference<Thread> AIExecThrea
                 t.setDaemon(true);
                 AIExecThread.set(t);
                 return t;
-            },
-            new ThreadPoolExecutor.CallerRunsPolicy() // Runs on main thread if the pool is somehow saturated
+            }
     );
     static {
         System.out.printf("(ThreadUtil first call): Running with priority %d%n", Thread.currentThread().getPriority());

--- a/forge-core/src/main/java/forge/util/ThreadUtil.java
+++ b/forge-core/src/main/java/forge/util/ThreadUtil.java
@@ -13,7 +13,9 @@ public class ThreadUtil {public static final AtomicReference<Thread> AIExecThrea
                 t.setDaemon(true);
                 AIExecThread.set(t);
                 return t;
-            }
+            },
+            // Dropped tasks disappear safely
+            new ThreadPoolExecutor.DiscardPolicy()
     );
     static {
         System.out.printf("(ThreadUtil first call): Running with priority %d%n", Thread.currentThread().getPriority());


### PR DESCRIPTION
ThreadPoolExecutor configuration - short-lived tasks for AI Timeout.  Reusable  and It doesn't need to shutdown manually. Threads will die on idle. Really Bad for sequential operations where every single task must finish without being dropped. So don't use it for those. Optimize a bit for declare attackers by using a reusable runnable object and comparator so heap is reduced.